### PR TITLE
Advanced Sample App: Prefetch BUYShop for Apple Pay

### DIFF
--- a/Mobile Buy SDK Sample Apps/Sample App Advanced/Mobile Buy SDK Advanced Sample/CheckoutViewController.m
+++ b/Mobile Buy SDK Sample Apps/Sample App Advanced/Mobile Buy SDK Advanced Sample/CheckoutViewController.m
@@ -297,8 +297,13 @@ NSString * const MerchantId = @"";
     
     // Get the completed checkout
     [self.client getCheckout:self.applePayHelper.checkout completion:^(BUYCheckout *checkout, NSError *error) {
-        NSLog(@"%@", checkout);
-        NSLog(@"%@", error);
+        if (error) {
+            NSLog(@"Unable to get completed checkout");
+            NSLog(@"%@", error);
+        }
+        if (checkout) {
+            NSLog(@"%@", checkout);
+        }
     }];
 }
 


### PR DESCRIPTION
### What this does

This adds an example of pre-fetching the `BUYShop` object for use with Apple Pay. Also use the currency and country code, if available.

I also added an example of getting a completed `BUYCheckout` once an Apple Pay checkout is completed.
- [x] Prefetch `BUYShop`
- [x] Use the shop's currency and country code for the `PKPaymentRequest` object
- [x] Example of getting the completed `BUYCheckout` once an Apple Pay checkout is completed

Fix #3 
- [x] Review @davidmuzi
