### PR TITLE
BUYProductViewController pushViewController: support

### DIFF
--- a/Mobile Buy SDK Sample Apps/Sample App Advanced/Mobile Buy SDK Advanced Sample/GetShopOperation.h
+++ b/Mobile Buy SDK Sample Apps/Sample App Advanced/Mobile Buy SDK Advanced Sample/GetShopOperation.h
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
 @import Buy;
 
 @class GetShopOperation;

--- a/Mobile Buy SDK Sample Apps/Sample App Advanced/Mobile Buy SDK Advanced Sample/Info.plist
+++ b/Mobile Buy SDK Sample Apps/Sample App Advanced/Mobile Buy SDK Advanced Sample/Info.plist
@@ -43,6 +43,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIRequiresFullScreen</key>
+	<true/>
 	<key>UIStatusBarTintParameters</key>
 	<dict>
 		<key>UINavigationBar</key>

--- a/Mobile Buy SDK Sample Apps/Sample App Advanced/Mobile Buy SDK Advanced Sample/ProductListViewController.m
+++ b/Mobile Buy SDK Sample Apps/Sample App Advanced/Mobile Buy SDK Advanced Sample/ProductListViewController.m
@@ -47,6 +47,7 @@
 @property (nonatomic, strong) NSArray *themeTintColors;
 @property (nonatomic, assign) NSInteger themeTintColorSelectedIndex;
 @property (nonatomic, assign) BOOL showsProductImageBackground;
+@property (nonatomic, assign) BOOL presentViewController;
 
 @end
 
@@ -73,10 +74,12 @@
     [self.tableView registerClass:[ProductViewControllerThemeStyleTableViewCell class] forCellReuseIdentifier:@"ThemeStyleCell"];
     [self.tableView registerClass:[ProductViewControllerThemeTintColorTableViewCell class] forCellReuseIdentifier:@"ThemeTintColorCell"];
     [self.tableView registerClass:[ProductViewControllerToggleTableViewCell class] forCellReuseIdentifier:@"ThemeShowsBackgroundToggleCell"];
+    [self.tableView registerClass:[ProductViewControllerToggleTableViewCell class] forCellReuseIdentifier:@"ProductViewControllerPresentViewControllerToggleCell"];
     
     self.themeTintColors = @[[UIColor colorWithRed:0.48f green:0.71f blue:0.36f alpha:1.0f], [UIColor colorWithRed:0.88 green:0.06 blue:0.05 alpha:1], [UIColor colorWithRed:0.02 green:0.54 blue:1 alpha:1]];
     self.themeTintColorSelectedIndex = 0;
     self.showsProductImageBackground = YES;
+    self.presentViewController = YES;
     
     if (self.collection) {
         // If we're presenting with a collection, add the ability to sort
@@ -175,7 +178,7 @@
     switch (section) {
         case 0:
             if (self.demoProductViewController) {
-                return 4;
+                return 5;
             } else {
                 return 1;
             }
@@ -223,6 +226,15 @@
                     [toggleCell.toggleSwitch setOn:self.showsProductImageBackground];
                     [toggleCell.toggleSwitch addTarget:self action:@selector(toggleShowsProductImageBackground:) forControlEvents:UIControlEventValueChanged];
                     cell = toggleCell;
+                }
+                    break;
+                case 4: {
+                    ProductViewControllerToggleTableViewCell *toggleCell = (ProductViewControllerToggleTableViewCell*)[tableView dequeueReusableCellWithIdentifier:@"ProductViewControllerPresentViewControllerToggleCell" forIndexPath:indexPath];
+                    toggleCell.textLabel.text = @"Modal Presentation";
+                    [toggleCell.toggleSwitch setOn:self.presentViewController];
+                    [toggleCell.toggleSwitch addTarget:self action:@selector(togglePresentViewController:) forControlEvents:UIControlEventValueChanged];
+                    cell = toggleCell;
+                    
                 }
                     break;
                 default:
@@ -295,7 +307,11 @@
     BUYProductViewController *productViewController = [self productViewController];
     [productViewController loadWithProduct:product completion:^(BOOL success, NSError *error) {
         if (error == nil) {
-            [productViewController presentPortraitInViewController:self];
+            if (self.presentViewController) {
+                [productViewController presentPortraitInViewController:self];
+            } else {
+                [self.navigationController pushViewController:productViewController animated:YES];
+            }
         }
     }];
 }
@@ -339,6 +355,11 @@
     self.showsProductImageBackground = toggleSwitch.on;
 }
 
+- (void)togglePresentViewController:(UISwitch*)toggleSwitch
+{
+    self.presentViewController = toggleSwitch.on;
+}
+
 - (BUYAddress *)address
 {
     BUYAddress *address = [[BUYAddress alloc] init];
@@ -376,7 +397,11 @@
 
 -(void)previewingContext:(id<UIViewControllerPreviewing>)previewingContext commitViewController:(UIViewController *)viewControllerToCommit
 {
-    [self presentViewController:viewControllerToCommit animated:YES completion:NULL];
+    if (self.presentViewController) {
+        [self presentViewController:viewControllerToCommit animated:YES completion:NULL];
+    } else {
+        [self.navigationController pushViewController:viewControllerToCommit animated:YES];
+    }
 }
 
 @end

--- a/Mobile Buy SDK.xcworkspace/xcshareddata/Mobile Buy SDK.xcscmblueprint
+++ b/Mobile Buy SDK.xcworkspace/xcshareddata/Mobile Buy SDK.xcscmblueprint
@@ -1,21 +1,28 @@
 {
-  "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey" : "B8AB7D59AD74F224C9D65CE20D7D3C30D5100598",
+  "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey" : "150992371D08DE0BC2C0F7D24AB62392DB6F1E4C",
   "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey" : {
 
   },
   "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey" : {
-    "27386CDE6C45B5519FB1AD62B45ACA8C18A2EFF0" : 0,
-    "B8AB7D59AD74F224C9D65CE20D7D3C30D5100598" : 0
+    "150992371D08DE0BC2C0F7D24AB62392DB6F1E4C" : 0,
+    "B8AB7D59AD74F224C9D65CE20D7D3C30D5100598" : 0,
+    "27386CDE6C45B5519FB1AD62B45ACA8C18A2EFF0" : 0
   },
   "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "F65CB188-9FFA-4AD7-8982-12C88FB79C9D",
   "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
-    "27386CDE6C45B5519FB1AD62B45ACA8C18A2EFF0" : "mobile-buy-sdk-private\/Submodules",
-    "B8AB7D59AD74F224C9D65CE20D7D3C30D5100598" : "mobile-buy-sdk-private"
+    "150992371D08DE0BC2C0F7D24AB62392DB6F1E4C" : "mobile-buy-sdk-ios\/",
+    "B8AB7D59AD74F224C9D65CE20D7D3C30D5100598" : "mobile-buy-sdk-private",
+    "27386CDE6C45B5519FB1AD62B45ACA8C18A2EFF0" : "mobile-buy-sdk-private\/Submodules"
   },
   "DVTSourceControlWorkspaceBlueprintNameKey" : "Mobile Buy SDK",
   "DVTSourceControlWorkspaceBlueprintVersion" : 204,
   "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "Mobile Buy SDK.xcworkspace",
   "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey" : [
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:Shopify\/mobile-buy-sdk-ios.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "150992371D08DE0BC2C0F7D24AB62392DB6F1E4C"
+    },
     {
       "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:Shopify\/BUYPaymentButton.git",
       "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",

--- a/Mobile Buy SDK/Mobile Buy SDK/Product View/BUYProductView.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Product View/BUYProductView.h
@@ -125,9 +125,17 @@
 /**
  *  The inset for the table view and scroll indicator, allowing for custom insets.
  *
- *  @param edgeInsets           The edge inset to set for the table view
+ *  @param edgeInsets           The edge inset to set for the table view.
  *  @param appendToCurrentInset A flag that allows for adding the edge insets to the current edgeinsets of the table view.
  */
 - (void)setInsets:(UIEdgeInsets)edgeInsets appendToCurrentInset:(BOOL)appendToCurrentInset;
+
+/**
+ *  Sets the top inset specifically for when the product view is pushed into a navigation controller stack
+ *  instead of presented modally.
+ *
+ *  @param topInset The inset to use for insetting the product view inside the container.
+ */
+- (void)setTopInset:(CGFloat)topInset;
 
 @end

--- a/Mobile Buy SDK/Mobile Buy SDK/Product View/BUYProductView.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Product View/BUYProductView.m
@@ -126,6 +126,7 @@
 																	 options:0
 																	 metrics:nil
 																	   views:NSDictionaryOfVariableBindings(_tableView)]];
+		
 		_topInsetConstraint = [NSLayoutConstraint constraintWithItem:self.tableView
 														   attribute:NSLayoutAttributeTop
 														   relatedBy:NSLayoutRelationEqual

--- a/Mobile Buy SDK/Mobile Buy SDK/Product View/BUYProductView.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Product View/BUYProductView.m
@@ -44,6 +44,7 @@
 @property (nonatomic, strong) UILabel *poweredByShopifyLabel;
 @property (nonatomic, strong) NSLayoutConstraint *poweredByShopifyLabelConstraint;
 @property (nonatomic, strong) BUYProductViewErrorView *errorView;
+@property (nonatomic, strong) NSLayoutConstraint *topInsetConstraint;
 
 @end
 
@@ -121,10 +122,18 @@
 																	 options:0
 																	 metrics:nil
 																	   views:NSDictionaryOfVariableBindings(_tableView)]];
-		[self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_tableView]|"
+		[self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[_tableView]|"
 																	 options:0
 																	 metrics:nil
 																	   views:NSDictionaryOfVariableBindings(_tableView)]];
+		_topInsetConstraint = [NSLayoutConstraint constraintWithItem:self.tableView
+														   attribute:NSLayoutAttributeTop
+														   relatedBy:NSLayoutRelationEqual
+															  toItem:self
+														   attribute:NSLayoutAttributeTop
+														  multiplier:1.0
+															constant:0];
+		[self addConstraint:_topInsetConstraint];
 		
 		CGFloat size = MIN(CGRectGetWidth(rect), CGRectGetHeight(rect));
 		if ([product.images count] > 0) {
@@ -233,6 +242,10 @@
 	if (footerViewHeight <= 0) {
 		footerViewHeight = 0;
 	}
+	
+	// Add the top inset for the navigation bar (when pushed in a navigation controller stack, not presented)
+	footerViewHeight += -self.topInsetConstraint.constant;
+	
 	self.footerHeightLayoutConstraint.constant = footerViewHeight;
 	self.footerOffsetLayoutConstraint.constant = -footerViewHeight;
 	
@@ -323,6 +336,11 @@
 	CGFloat bottom = appendToCurrentInset ? self.tableView.contentInset.bottom + edgeInsets.bottom : edgeInsets.bottom;
 	CGFloat right = appendToCurrentInset ? self.tableView.contentInset.right + edgeInsets.right : edgeInsets.right;
 	self.tableView.contentInset = self.tableView.scrollIndicatorInsets = UIEdgeInsetsMake(top, left, bottom, right);
+}
+
+- (void)setTopInset:(CGFloat)topInset
+{
+	self.topInsetConstraint.constant = topInset;
 }
 
 @end

--- a/Mobile Buy SDK/Mobile Buy SDK/Product View/BUYProductViewController.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Product View/BUYProductViewController.m
@@ -460,9 +460,11 @@ CGFloat const BUYMaxProductViewHeight = 640.0;
 			[(BUYNavigationController*)self.navigationController updateCloseButtonImageWithTintColor:YES duration:0];
 			self.navigationBar.alpha = 1;
 			self.navigationBarTitle.alpha = 1;
-			// When using 3D Touch, the initial height of the navigation bar (without UIStatusBar) doesn't match the final height (with UIStatusBar)
-			// so we're forced to set it manually in case it's not tall enough. Of course, this is only valid for products with no product images.
-			[self.productView setInsets:UIEdgeInsetsMake(MAX(CGRectGetHeight(self.navigationBar.bounds), 64), 0, 0, 0) appendToCurrentInset:YES];
+			CGFloat topInset = 0;
+			if (self.presentingViewController) {
+				topInset = CGRectGetHeight([[(UINavigationController*)self.presentingViewController navigationBar] bounds]) + self.presentingViewController.topLayoutGuide.length;
+			}
+			[self.productView setInsets:UIEdgeInsetsMake(topInset, 0, 0, 0) appendToCurrentInset:YES];
 		}
 	}
 }

--- a/Mobile Buy SDK/Mobile Buy SDK/Product View/BUYProductViewController.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Product View/BUYProductViewController.m
@@ -118,6 +118,8 @@ CGFloat const BUYMaxProductViewHeight = 640.0;
 															  attribute:NSLayoutAttributeCenterX
 															 multiplier:1.0
 															   constant:0.0]];
+		
+		
 	}
 	return self;
 }
@@ -195,7 +197,7 @@ CGFloat const BUYMaxProductViewHeight = 640.0;
 
 - (void)setupNavigationBarAppearance
 {
-	if (self.navigationBar == nil && _productView) {
+	if (self.navigationBar == nil && _productView && self.presentingViewController != nil) {
 		for (UIView *view in [self.navigationController.navigationBar subviews]) {
 			if (CGRectGetHeight(view.bounds) >= 44) {
 				// Get a reference to the UINavigationBar
@@ -211,6 +213,8 @@ CGFloat const BUYMaxProductViewHeight = 640.0;
 		}
 		// Hide the navigation bar
 		[self scrollViewDidScroll:self.productView.tableView];
+	} else if (self.navigationController && _productView && self.presentingViewController == nil) {
+		[self.productView setTopInset:CGRectGetHeight(self.navigationController.navigationBar.bounds) + self.navigationController.topLayoutGuide.length];
 	}
 }
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you would like to not include the Mobile Buy SDK Project within your existing
 
 1.  Open the `Mobile Buy SDK.xcodeproj` and build the `Universal Framework` Target
 2.  Drag the `Buy.framework` that was just created from `Mobile Buy SDK Sample Apps` onto the `Linked Frameworks and Libraries` section for the target you want to add the framework to. Check Copy items if needed so the framework is copied to your project
-3.  In the `Build Settings` tab, add `-all_load` to `Other Linker Flags`.
+3.  In the `Build Settings` tab, add `-all_load` to `Other Linker Flags`
 
 #### CocoaPods
 


### PR DESCRIPTION
#### What this does

Fix #5 

This adds functionality for the `BUYProductViewController` to be pushed onto an existing navigation controller stack. Previously, there were some UI bugs associated with this presentation style. This has now been fixed.

I also took the chance to add it as a demo to the Advanced Sample App and snuck in a few comment fixes.

@davidmuzi Please review :eyes: 