### PR TITLE
Pod spec badge: point to new, public repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build status](https://badge.buildkite.com/d8fe8aa44d801c6238ab767867e4fb09abe516bb2933b577cc.svg?branch=develop)](https://buildkite.com/shopify/mobile-buy-sdk-ios)
 [![GitHub license](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://github.com/Shopify/mobile-buy-sdk-ios/blob/master/LICENSE)
 [![GitHub release](https://img.shields.io/github/release/shopify/mobile-buy-sdk-ios.svg)](https://github.com/Shopify/mobile-buy-sdk-ios/releases)
-[![Cocoapods](https://img.shields.io/cocoapods/v/mobile-buy-sdk-ios.svg)](https://cocoapods.org/pods/mobile-buy-sdk-ios)
+[![Cocoapods](https://img.shields.io/cocoapods/v/mobile-buy-sdk.svg)](https://cocoapods.org/pods/mobile-buy-sdk)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 # Mobile Buy SDK for iOS


### PR DESCRIPTION
#### What this does

Fix #9 

This points the Cocoapods shields.io badge to the new, public repo.

@davidmuzi please review :eyes: 