### PR TITLE
Product tags

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYProduct.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYProduct.h
@@ -89,6 +89,12 @@
 @property (nonatomic, readonly, assign) BOOL available;
 
 /**
+ *  A categorization that a product can be tagged with, commonly used for filtering and searching. 
+ *  Each tag has a character limit of 255.
+ */
+@property (nonatomic, readonly, copy) NSSet *tags;
+
+/**
  *  The product is published on the current sales channel
  */
 @property (nonatomic, readonly, assign) BOOL published;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYProduct.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYProduct.m
@@ -53,7 +53,7 @@
 	_createdAtDate = [dateFormatter dateFromString:dictionary[@"created_at"]];
 	_updatedAtDate = [dateFormatter dateFromString:dictionary[@"updated_at"]];
 	_publishedAtDate = [dateFormatter dateFromString:dictionary[@"published_at"]];
-	NSArray *tagsArray = [[dictionary[@"tags"] stringByReplacingOccurrencesOfString:@", " withString:@","] componentsSeparatedByString:@","];
+	NSArray *tagsArray = [dictionary[@"tags"] componentsSeparatedByString:@", "];
 	NSSet *tagsSet = [NSSet setWithArray:tagsArray];
 	_tags = [tagsSet copy];
 }

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYProduct.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYProduct.m
@@ -53,6 +53,9 @@
 	_createdAtDate = [dateFormatter dateFromString:dictionary[@"created_at"]];
 	_updatedAtDate = [dateFormatter dateFromString:dictionary[@"updated_at"]];
 	_publishedAtDate = [dateFormatter dateFromString:dictionary[@"published_at"]];
+	NSArray *tagsArray = [[dictionary[@"tags"] stringByReplacingOccurrencesOfString:@", " withString:@","] componentsSeparatedByString:@","];
+	NSSet *tagsSet = [NSSet setWithArray:tagsArray];
+	_tags = [tagsSet copy];
 }
 
 @end


### PR DESCRIPTION
#### What this does

Fix #7 

This adds support for product tags. Tags are provided as a comma-separated string, but I have converted them to a NSSet so they're more useful for searching and filtering products locally.

@davidmuzi please review :eyes: 