### PR TITLE
Update to appearanceWhenContainedInInstancesOfClasses:

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Product View/BUYNavigationController.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Product View/BUYNavigationController.m
@@ -44,7 +44,11 @@
 	closeButton.frame = CGRectMake(0, 0, 22, 22);
 	UIBarButtonItem *barButtonItem = [[UIBarButtonItem alloc] initWithCustomView:closeButton];
 	self.topViewController.navigationItem.leftBarButtonItem = barButtonItem;
-	[[UINavigationBar appearanceWhenContainedIn:[BUYNavigationController class], nil] setBackgroundImage:nil forBarMetrics:UIBarMetricsDefault];
+	if ([[UINavigationBar class] respondsToSelector:@selector(appearanceWhenContainedInInstancesOfClasses:)]) {
+		[[UINavigationBar appearanceWhenContainedInInstancesOfClasses:@[[BUYNavigationController class]]] setBackgroundImage:nil forBarMetrics:UIBarMetricsDefault];
+	} else {
+		[[UINavigationBar appearanceWhenContainedIn:[BUYNavigationController class], nil] setBackgroundImage:nil forBarMetrics:UIBarMetricsDefault];
+	}
 	
 	return self;
 }
@@ -87,7 +91,11 @@
 	_theme = theme;
 	self.navigationBar.barStyle = [theme navigationBarStyle];
 	[self updateCloseButtonImageWithTintColor:NO duration:0];
-	[[UINavigationBar appearanceWhenContainedIn:[BUYNavigationController class], nil] setTitleTextAttributes:@{ NSForegroundColorAttributeName: [theme navigationBarTitleColor] }];
+	if ([[UINavigationBar class] respondsToSelector:@selector(appearanceWhenContainedInInstancesOfClasses:)]) {
+		[[UINavigationBar appearanceWhenContainedInInstancesOfClasses:@[[BUYNavigationController class]]] setTitleTextAttributes:@{ NSForegroundColorAttributeName: [theme navigationBarTitleColor] }];
+	} else {
+		[[UINavigationBar appearanceWhenContainedIn:[BUYNavigationController class], nil] setTitleTextAttributes:@{ NSForegroundColorAttributeName: [theme navigationBarTitleColor] }];
+	}
 }
 
 -(UIViewController *)childViewControllerForStatusBarStyle

--- a/Mobile Buy SDK/Mobile Buy SDK/Product View/Variant Selection/BUYOptionSelectionNavigationController.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Product View/Variant Selection/BUYOptionSelectionNavigationController.m
@@ -47,7 +47,7 @@
 		
 		// Add custom back button
 		UIImage *buttonImage = [[BUYImageKit imageOfVariantBackImageWithFrame:CGRectMake(0, 0, 12, 18)] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-		if ([[UINavigationBar class] respondsToSelector:@selector(appearanceWhenContainedInInstancesOfClasses:)]) {
+		if ([[UIBarButtonItem class] respondsToSelector:@selector(appearanceWhenContainedInInstancesOfClasses:)]) {
 			[[UIBarButtonItem appearanceWhenContainedInInstancesOfClasses:@[[BUYNavigationController class]]] setBackButtonBackgroundImage:[buttonImage resizableImageWithCapInsets:UIEdgeInsetsMake(0, 12, 0, 0)]
 																																  forState:UIControlStateNormal
 																																barMetrics:UIBarMetricsDefault];

--- a/Mobile Buy SDK/Mobile Buy SDK/Product View/Variant Selection/BUYOptionSelectionNavigationController.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Product View/Variant Selection/BUYOptionSelectionNavigationController.m
@@ -47,9 +47,15 @@
 		
 		// Add custom back button
 		UIImage *buttonImage = [[BUYImageKit imageOfVariantBackImageWithFrame:CGRectMake(0, 0, 12, 18)] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-		[[UIBarButtonItem appearanceWhenContainedIn:[BUYNavigationController class], nil] setBackButtonBackgroundImage:[buttonImage resizableImageWithCapInsets:UIEdgeInsetsMake(0, 12, 0, 0)]
-																											  forState:UIControlStateNormal
-																											barMetrics:UIBarMetricsDefault];
+		if ([[UINavigationBar class] respondsToSelector:@selector(appearanceWhenContainedInInstancesOfClasses:)]) {
+			[[UIBarButtonItem appearanceWhenContainedInInstancesOfClasses:@[[BUYNavigationController class]]] setBackButtonBackgroundImage:[buttonImage resizableImageWithCapInsets:UIEdgeInsetsMake(0, 12, 0, 0)]
+																																  forState:UIControlStateNormal
+																																barMetrics:UIBarMetricsDefault];
+		} else {
+			[[UIBarButtonItem appearanceWhenContainedIn:[BUYNavigationController class], nil] setBackButtonBackgroundImage:[buttonImage resizableImageWithCapInsets:UIEdgeInsetsMake(0, 12, 0, 0)]
+																												  forState:UIControlStateNormal
+																												barMetrics:UIBarMetricsDefault];
+		}
 		
 		_breadsCrumbsView = [BUYVariantOptionBreadCrumbsView new];
 		_breadsCrumbsView.translatesAutoresizingMaskIntoConstraints = NO;


### PR DESCRIPTION
#### What this does

Fix #12 

This adds `appearanceWhenContainedInInstancesOfClasses:` and replaces calls on iOS 9 SDK for the deprecated `appearanceWhenContainedIn:`.

@davidmuzi please review :eyes: 