### PR TITLE
Generics / Nullability Annotations

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCart.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCart.h
@@ -42,7 +42,7 @@
  *  Note: These are different from BUYLineItem objects in that
  *  the line item objects do include the BUYProductVariant.
  */
-@property (nonatomic, strong, readonly) NSArray *lineItems;
+@property (nonatomic, strong, readonly, nonnull) NSArray<BUYCartLineItem *> *lineItems;
 
 /**
  *  Returns true if the cart is acceptable to send to Shopify.
@@ -62,7 +62,7 @@
  *
  *  @param variant The BUYProductVariant to add to the BUYCart or increase by one quantity
  */
-- (void)addVariant:(BUYProductVariant *)variant;
+- (void)addVariant:(nonnull BUYProductVariant *)variant;
 
 /**
  *  Removes the BUYCartLineItem from the BUYCart associated with the given BUYProductVariant object.
@@ -70,7 +70,7 @@
  *
  *  @param variant The BUYProductVariant to remove from the BUYCart or decrease by one quantity
  */
-- (void)removeVariant:(BUYProductVariant *)variant;
+- (void)removeVariant:(nonnull BUYProductVariant *)variant;
 
 /**
  *  Adds a BUYCartLineItem with a set quantity to the BUYCart with the given BUYProductVariant object on it.
@@ -80,6 +80,6 @@
  *  @param variant  The BUYProductVariant to add to the BUYCart with a quantity
  *  @param quantity The quantity for the BUYCartLineItem associated with the BUYProductVariant
  */
-- (void)setVariant:(BUYProductVariant *)variant withTotalQuantity:(NSInteger)quantity;
+- (void)setVariant:(nonnull BUYProductVariant *)variant withTotalQuantity:(NSInteger)quantity;
 
 @end

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCart.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCart.m
@@ -30,7 +30,7 @@
 
 @interface BUYCart ()
 
-@property (nonatomic, strong) NSMutableSet *lineItemsSet;
+@property (nonatomic, strong, nonnull) NSMutableSet<BUYCartLineItem *> *lineItemsSet;
 
 @end
 
@@ -45,7 +45,7 @@
 	return self;
 }
 
-- (NSArray *)lineItems
+- (nonnull NSArray<BUYCartLineItem *> *)lineItems
 {
 	return [self.lineItemsSet allObjects];
 }
@@ -62,7 +62,7 @@
 
 #pragma mark - Simple Cart Editing
 
-- (void)addVariant:(BUYProductVariant *)variant
+- (void)addVariant:(nonnull BUYProductVariant *)variant
 {
 	BUYCartLineItem *lineItem = [[BUYCartLineItem alloc] initWithVariant:variant];
 	BUYCartLineItem *existingLineItem = [self.lineItemsSet member:lineItem];
@@ -73,7 +73,7 @@
 	}
 }
 
-- (void)removeVariant:(BUYProductVariant *)variant
+- (void)removeVariant:(nonnull BUYProductVariant *)variant
 {
 	BUYCartLineItem *lineItem = [[BUYCartLineItem alloc] initWithVariant:variant];
 	BUYCartLineItem *existingLineItem = [self.lineItemsSet member:lineItem];
@@ -85,7 +85,7 @@
 	}
 }
 
-- (void)setVariant:(BUYProductVariant *)variant withTotalQuantity:(NSInteger)quantity
+- (void)setVariant:(nonnull BUYProductVariant *)variant withTotalQuantity:(NSInteger)quantity
 {
 	BUYCartLineItem *lineItem = [[BUYCartLineItem alloc] initWithVariant:variant];
 	BUYCartLineItem *existingLineItem = [self.lineItemsSet member:lineItem];

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.h
@@ -35,6 +35,8 @@
 @class BUYOrder;
 @class BUYShippingRate;
 @class BUYTaxLine;
+@class BUYLineItem;
+@class BUYGiftCard;
 
 /**
  *  The checkout object. This is the main object that you will interact with when creating orders on Shopify.
@@ -125,13 +127,12 @@
  *  Note: These are different from BUYCartLineItems in that the line item
  *  objects do not include the BUYProductVariant
  */
-@property (nonatomic, readonly, copy) NSArray *lineItems;
+@property (nonatomic, readonly, copy) NSArray<__kindof BUYLineItem *> *lineItems;
 
 /**
  *  Array of tax line objects on the checkout
  */
-@property (nonatomic, readonly, copy) NSArray *taxLines;
-
+@property (nonatomic, readonly, copy) NSArray<BUYTaxLine *> *taxLines;
 /**
  *  The mailing address associated with the payment method
  */
@@ -162,7 +163,7 @@
 /**
  *  An array of BUYGiftCard objects applied to the checkout
  */
-@property (nonatomic, strong, readonly) NSArray *giftCards;
+@property (nonatomic, strong, readonly) NSArray<BUYGiftCard *> *giftCards;
 
 /**
  *  Channel ID where the checkout was created

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYImage.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYImage.h
@@ -39,7 +39,7 @@
 /**
  *  An array of variant ids associated with the image.
  */
-@property (nonatomic, readonly, copy) NSArray *variantIds;
+@property (nonatomic, readonly, copy) NSArray<NSNumber *> *variantIds;
 
 /**
  *  Creation date of the image

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYProduct.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYProduct.h
@@ -64,19 +64,19 @@
 /**
  *  A list of BUYProductVariant objects, each one representing a slightly different version of the product.
  */
-@property (nonatomic, readonly, copy) NSArray *variants;
+@property (nonatomic, readonly, copy) NSArray<BUYProductVariant *> *variants;
 
 /**
  *  A list of BUYImage objects, each one representing an image associated with the product.
  */
-@property (nonatomic, readonly, copy) NSArray *images;
+@property (nonatomic, readonly, copy) NSArray<BUYImage *> *images;
 
 /**
  *  Custom product property names like "Size", "Color", and "Material".
  *  Products are based on permutations of these options.
  *  A product may have a maximum of 3 options. 255 characters limit each.
  */
-@property (nonatomic, readonly, copy) NSArray *options;
+@property (nonatomic, readonly, copy) NSArray<BUYOption *> *options;
 
 /**
  *  The description of the product, complete with HTML formatting.
@@ -92,7 +92,7 @@
  *  A categorization that a product can be tagged with, commonly used for filtering and searching. 
  *  Each tag has a character limit of 255.
  */
-@property (nonatomic, readonly, copy) NSSet *tags;
+@property (nonatomic, readonly, copy) NSSet<NSString *> *tags;
 
 /**
  *  The product is published on the current sales channel

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYProductVariant.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYProductVariant.h
@@ -27,6 +27,7 @@
 #import "BUYObject.h"
 
 @class BUYProduct;
+@class BUYOptionValue;
 
 /**
  *  A BUYProductVariant is a different version of a product, such as differing sizes or differing colours.
@@ -46,7 +47,7 @@
 /**
  *  Custom properties that a shop owner can use to define BUYProductVariants.
  */
-@property (nonatomic, readonly, copy) NSArray *options;
+@property (nonatomic, readonly, copy) NSArray<BUYOptionValue *> *options;
 
 /**
  *  The price of the BUYProductVariant.

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYShop.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYShop.h
@@ -74,7 +74,7 @@
 /**
  *  A list of two-letter country codes identifying the countries that the shop ships to.
  */
-@property (nonatomic, readonly, copy) NSArray *shipsToCountries;
+@property (nonatomic, readonly, copy) NSArray<NSString *> *shipsToCountries;
 
 /**
  *  The URL for the web storefront

--- a/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayAdditions.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayAdditions.h
@@ -65,7 +65,7 @@
 
 @interface BUYAddress (ApplePay)
 
-+ (nullable NSString *)buy_emailFromRecord:(nonnull ABRecordRef)record;
++ (nullable NSString *)buy_emailFromRecord:(nullable ABRecordRef)record;
 
 /**
  *  Creates a BUYAddress from an ABRecordRef
@@ -74,7 +74,7 @@
  *
  *  @return The BUYAddress created from an ABRecordRef
  */
-+ (nonnull BUYAddress *)buy_addressFromRecord:(nonnull ABRecordRef)record NS_DEPRECATED_IOS(8_0, 9_0, "Use the CNContact backed `buy_addressFromContact:` instead");
++ (nonnull BUYAddress *)buy_addressFromRecord:(nullable ABRecordRef)record NS_DEPRECATED_IOS(8_0, 9_0, "Use the CNContact backed `buy_addressFromContact:` instead");
 
 /**
  *  Creates a BUYAddress from a PKContact
@@ -83,6 +83,6 @@
  *
  *  @return The BUYAddress created from a PKContact
  */
-+ (nonnull BUYAddress *)buy_addressFromContact:(nonnull PKContact*)contact NS_AVAILABLE_IOS(9_0);
++ (nonnull BUYAddress *)buy_addressFromContact:(nullable PKContact*)contact NS_AVAILABLE_IOS(9_0);
 
 @end

--- a/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayAdditions.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayAdditions.h
@@ -37,7 +37,7 @@
  *  Returns an array of summary items for all Apple Pay requests.  Will use 'PAY TOTAL' as the summary label.  Apple recommends
  *  including the business name in the summary label, so it is recommended to use `buy_summaryItemsWithShopName` instead.
  */
-- (NSArray *)buy_summaryItems;
+- (nonnull NSArray<PKPaymentSummaryItem *> *)buy_summaryItems;
 
 /**
  *  Returns an array of summary items for all Apple Pay requests using the shop name in the "PAY" section
@@ -46,7 +46,7 @@
  *
  *  @return An array of PKPaymentSummaryItems
  */
-- (NSArray *)buy_summaryItemsWithShopName:(NSString *)shopName;
+- (nonnull NSArray<PKPaymentSummaryItem *> *)buy_summaryItemsWithShopName:(nullable NSString *)shopName;
 
 @end
 
@@ -59,13 +59,13 @@
 *
 *  @return An array of PKShippingMethods
 */
-+ (NSArray *)buy_convertShippingRatesToShippingMethods:(NSArray *)rates;
++ (nonnull NSArray<PKShippingMethod *> *)buy_convertShippingRatesToShippingMethods:(nonnull NSArray<BUYShippingRate *> *)rates;
 
 @end
 
 @interface BUYAddress (ApplePay)
 
-+ (NSString *)buy_emailFromRecord:(ABRecordRef)record;
++ (nullable NSString *)buy_emailFromRecord:(nonnull ABRecordRef)record;
 
 /**
  *  Creates a BUYAddress from an ABRecordRef
@@ -74,7 +74,7 @@
  *
  *  @return The BUYAddress created from an ABRecordRef
  */
-+ (BUYAddress *)buy_addressFromRecord:(ABRecordRef)record NS_DEPRECATED_IOS(8_0, 9_0, "Use the CNContact backed `buy_addressFromContact:` instead");
++ (nonnull BUYAddress *)buy_addressFromRecord:(nonnull ABRecordRef)record NS_DEPRECATED_IOS(8_0, 9_0, "Use the CNContact backed `buy_addressFromContact:` instead");
 
 /**
  *  Creates a BUYAddress from a PKContact
@@ -83,6 +83,6 @@
  *
  *  @return The BUYAddress created from a PKContact
  */
-+ (BUYAddress *)buy_addressFromContact:(PKContact*)contact NS_AVAILABLE_IOS(9_0);
++ (nonnull BUYAddress *)buy_addressFromContact:(nonnull PKContact*)contact NS_AVAILABLE_IOS(9_0);
 
 @end

--- a/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayAdditions.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayAdditions.m
@@ -38,11 +38,11 @@
 
 @implementation BUYCheckout (ApplePay)
 
-- (NSArray *)buy_summaryItemsWithShopName:(NSString *)shopName {
+- (nonnull NSArray<PKPaymentSummaryItem *> *)buy_summaryItemsWithShopName:(nullable NSString *)shopName {
 	
 	BOOL hasDiscount = [self.discount.amount compare:[NSDecimalNumber zero]] == NSOrderedDescending;
 	
-	NSMutableArray *summaryItems = [[NSMutableArray alloc] init];
+	NSMutableArray<PKPaymentSummaryItem *> *summaryItems = [[NSMutableArray alloc] init];
 	
 	if (hasDiscount || [self.lineItems count] > 1) {
 		NSDecimalNumber *lineItemSubtotal = [NSDecimalNumber zero];
@@ -76,10 +76,11 @@
 	
 	NSString *itemLabel = shopName ?: @"TOTAL";
 	[summaryItems addObject:[PKPaymentSummaryItem summaryItemWithLabel:itemLabel amount:self.paymentDue ?: [NSDecimalNumber zero]]];
+
 	return summaryItems;
 }
 
-- (NSArray *)buy_summaryItems
+- (nonnull NSArray<PKPaymentSummaryItem *> *)buy_summaryItems
 {
 	return [self buy_summaryItemsWithShopName:nil];
 }
@@ -88,9 +89,9 @@
 
 @implementation BUYShippingRate (ApplePay)
 
-+ (NSArray *)buy_convertShippingRatesToShippingMethods:(NSArray *)rates
++ (nonnull NSArray<PKShippingMethod *> *)buy_convertShippingRatesToShippingMethods:(nonnull NSArray<BUYShippingRate *> *)rates
 {
-	NSMutableArray *shippingMethods = [[NSMutableArray alloc] init];
+	NSMutableArray<PKShippingMethod *> *shippingMethods = [[NSMutableArray alloc] init];
 	for (BUYShippingRate *shippingRate in rates) {
 		PKShippingMethod *shippingMethod = [[PKShippingMethod alloc] init];
 		shippingMethod.label = shippingRate.title;
@@ -121,7 +122,7 @@
 
 @implementation BUYAddress (ApplePay)
 
-+ (NSString *)buy_emailFromRecord:(ABRecordRef)record
++ (nullable NSString *)buy_emailFromRecord:(nonnull ABRecordRef)record
 {
 	ABMultiValueRef emailMultiValue = ABRecordCopyValue(record, kABPersonEmailProperty);
 	CFArrayRef allEmails = ABMultiValueCopyArrayOfAllValues(emailMultiValue);
@@ -136,7 +137,7 @@
 	return email;
 }
 
-+ (BUYAddress *)buy_addressFromRecord:(ABRecordRef)record
++ (nonnull BUYAddress *)buy_addressFromRecord:(nonnull ABRecordRef)record
 {
 	BUYAddress *address = [[BUYAddress alloc] init];
 	
@@ -193,7 +194,7 @@
 	return address;
 }
 
-+ (BUYAddress *)buy_addressFromContact:(PKContact*)contact
++ (nonnull BUYAddress *)buy_addressFromContact:(nonnull PKContact*)contact
 {
 	BUYAddress *address = [[BUYAddress alloc] init];
 	

--- a/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayAdditions.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayAdditions.m
@@ -122,7 +122,7 @@
 
 @implementation BUYAddress (ApplePay)
 
-+ (nullable NSString *)buy_emailFromRecord:(nonnull ABRecordRef)record
++ (nullable NSString *)buy_emailFromRecord:(nullable ABRecordRef)record
 {
 	ABMultiValueRef emailMultiValue = ABRecordCopyValue(record, kABPersonEmailProperty);
 	CFArrayRef allEmails = ABMultiValueCopyArrayOfAllValues(emailMultiValue);
@@ -137,7 +137,7 @@
 	return email;
 }
 
-+ (nonnull BUYAddress *)buy_addressFromRecord:(nonnull ABRecordRef)record
++ (nonnull BUYAddress *)buy_addressFromRecord:(nullable ABRecordRef)record
 {
 	BUYAddress *address = [[BUYAddress alloc] init];
 	
@@ -194,7 +194,7 @@
 	return address;
 }
 
-+ (nonnull BUYAddress *)buy_addressFromContact:(nonnull PKContact*)contact
++ (nonnull BUYAddress *)buy_addressFromContact:(nullable PKContact*)contact
 {
 	BUYAddress *address = [[BUYAddress alloc] init];
 	


### PR DESCRIPTION
This patch adds generics and nullability annotations to most obvious public APIs. (shopify/mobile-buy-sdk-ios#16)

There are several locations that it does not touch, such as model JSON deserialization and their respective properties. It would probably be best to make a design decision in terms of whether model properties should be considered optional or not and the deserialization system should take that into account.