### PR TITLE
BUYProductViewController: Support for bottom inset when presented with tab bar and/or toolbar

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Product View/BUYProductView.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Product View/BUYProductView.m
@@ -173,7 +173,7 @@
 																	 options:0
 																	 metrics:nil
 																	   views:NSDictionaryOfVariableBindings(_productViewFooter)]];
-		[self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[_productViewFooter]|"
+		[self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[_productViewFooter]-|"
 																	 options:0
 																	 metrics:nil
 																	   views:NSDictionaryOfVariableBindings(_productViewFooter)]];
@@ -203,7 +203,7 @@
 - (void)layoutSubviews
 {
 	[super layoutSubviews];
-	[self setInsets:UIEdgeInsetsMake(self.tableView.contentInset.top, self.tableView.contentInset.left, CGRectGetHeight(self.productViewFooter.frame), self.tableView.contentInset.right) appendToCurrentInset:NO];
+	[self setInsets:UIEdgeInsetsMake(self.tableView.contentInset.top, self.tableView.contentInset.left, CGRectGetHeight(self.bounds) - CGRectGetMinY(self.productViewFooter.frame), self.tableView.contentInset.right) appendToCurrentInset:NO];
 }
 
 - (void)setTheme:(BUYTheme *)theme

--- a/Mobile Buy SDK/Mobile Buy SDK/Product View/BUYProductViewController.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Product View/BUYProductViewController.m
@@ -90,6 +90,7 @@ CGFloat const BUYMaxProductViewHeight = 640.0;
 {
 	self = [super initWithClient:client];
 	if (self) {
+		
 		self.theme = theme? : [[BUYTheme alloc] init];
 		
 		self.modalPresentationStyle = UIModalPresentationCustom;
@@ -177,6 +178,10 @@ CGFloat const BUYMaxProductViewHeight = 640.0;
 	[super viewWillAppear:animated];
 	[self setupNavigationBarAppearance];
 	[self.navigationController setNavigationBarHidden:self.isLoading];
+	CGFloat bottomMargin = 0;
+	bottomMargin += self.tabBarController ? CGRectGetHeight(self.tabBarController.tabBar.bounds) : 0;
+	bottomMargin += self.navigationController.isToolbarHidden ? 0 : CGRectGetHeight(self.navigationController.toolbar.bounds);
+	_productView.layoutMargins = UIEdgeInsetsMake(self.productView.layoutMargins.top, self.productView.layoutMargins.left, bottomMargin, self.productView.layoutMargins.right);
 }
 
 - (void)viewDidLayoutSubviews


### PR DESCRIPTION
*reopen as I opened against `master`*

Fix #27 

#### What this does

This adds logic that insets the product view's checkout button footer view if it's presented in a stack that includes a tab bar or a toolbar.

###### Without any bars:
<img width="409" alt="screen shot 2015-10-09 at 9 50 49 am" src="https://cloud.githubusercontent.com/assets/708741/10395562/aaade998-6e6b-11e5-93f7-7ab5d2a3ad65.png">

###### With a tab bar:
<img width="415" alt="screen shot 2015-10-09 at 9 50 24 am" src="https://cloud.githubusercontent.com/assets/708741/10395561/aaa5229a-6e6b-11e5-9e5f-7a5a467c9c72.png">

###### With a toolbar:
<img width="409" alt="screen shot 2015-10-09 at 9 51 11 am" src="https://cloud.githubusercontent.com/assets/708741/10395563/aab417be-6e6b-11e5-909c-448bed4e95ec.png">

@davidmuzi please review :eyes: 
