### PR TITLE
Add note to BUYCheckout

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.h
@@ -241,7 +241,7 @@
 /**
  *  An optional note attached to the order
  */
-@property (nonatomic, strong) NSString *note;
+@property (nonatomic, copy) NSString *note;
 
 /**
  *  The BUYOrder for a completed checkout

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.h
@@ -239,6 +239,11 @@
 @property (nonatomic, copy, readonly) NSString *customerId;
 
 /**
+ *  An optional note attached to the order
+ */
+@property (nonatomic, strong) NSString *note;
+
+/**
  *  The BUYOrder for a completed checkout
  */
 @property (nonatomic, strong, readonly) BUYOrder *order;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.m
@@ -160,7 +160,7 @@
 	self.updatedAtDate = [dateFormatter dateFromString:dictionary[@"updated_at"]];
 	self.creditCard = [BUYMaskedCreditCard convertObject:dictionary[@"credit_card"]];
 	self.customerId = [dictionary[@"customer_id"] copy];
-	self.note = dictionary[@"note"];
+	self.note = [dictionary[@"note"] copy];
 	
 	self.privacyPolicyURL = [NSURL buy_urlWithString:dictionary[@"privacy_policy_url"]];
 	self.refundPolicyURL = [NSURL buy_urlWithString:dictionary[@"refund_policy_url"]];

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.m
@@ -160,7 +160,7 @@
 	self.updatedAtDate = [dateFormatter dateFromString:dictionary[@"updated_at"]];
 	self.creditCard = [BUYMaskedCreditCard convertObject:dictionary[@"credit_card"]];
 	self.customerId = [dictionary[@"customer_id"] copy];
-	self.note = [dictionary[@"note"] copy];
+	self.note = dictionary[@"note"];
 	
 	self.privacyPolicyURL = [NSURL buy_urlWithString:dictionary[@"privacy_policy_url"]];
 	self.refundPolicyURL = [NSURL buy_urlWithString:dictionary[@"refund_policy_url"]];

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.m
@@ -160,6 +160,7 @@
 	self.updatedAtDate = [dateFormatter dateFromString:dictionary[@"updated_at"]];
 	self.creditCard = [BUYMaskedCreditCard convertObject:dictionary[@"credit_card"]];
 	self.customerId = [dictionary[@"customer_id"] copy];
+	self.note = dictionary[@"note"];
 	
 	self.privacyPolicyURL = [NSURL buy_urlWithString:dictionary[@"privacy_policy_url"]];
 	self.refundPolicyURL = [NSURL buy_urlWithString:dictionary[@"refund_policy_url"]];


### PR DESCRIPTION
### What this does

Fix #33

This adds a `note` to `BUYCheckout`, which will appear on the order in shop's admin.

It's not currently returned from the API, so not tests have been added.

@davidmuzi please review :eyes: 