### PR TITLE
Fix shipping rate issue for Apple Pay

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.m
@@ -53,7 +53,7 @@
 
 - (instancetype)initWithCart:(BUYCart *)cart
 {
-	self = [super initWithDictionary:@{}];
+	self = [super init];
 	if (self) {
 		_lineItems = [cart.lineItems copy];
 		[self markPropertyAsDirty:@"lineItems"];

--- a/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYAddress+Additions.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYAddress+Additions.m
@@ -57,5 +57,4 @@ NSString * const BUYPartialAddressPlaceholder = @"---";
 	return valid;
 }
 
-
 @end

--- a/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayHelpers.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayHelpers.m
@@ -264,8 +264,7 @@ const NSTimeInterval PollDelay = 0.5;
 					self.shippingRates = shippingRates;
 					
 					if ([self.shippingRates count] == 0) {
-						// Shipping address not supported
-						self.checkout.shippingRate = nil;
+						// Shipping address is not supported and no shipping rates were returned
 						if (completion) {
 							completion(PKPaymentAuthorizationStatusInvalidShippingPostalAddress, nil, [self.checkout buy_summaryItemsWithShopName:self.shop.name]);
 						}


### PR DESCRIPTION
Fix #36
Fix #37 

#### What this does

This fixes an issue with Apple Pay where, if the first address is not a valid shipping address for the shop and no shipping rates are returned, the rates are set to `nil` and it breaks validation on Shopify for all remaining calls to PATCH the `BUYCheckout` object, which would result in a continuous error callback on any subsequent - and valid - address selections.

@davidmuzi please review :eyes: 
