### PR TITLE
Apple Pay bug fixes

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayAdditions.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayAdditions.m
@@ -47,7 +47,7 @@
 	if (hasDiscount || [self.lineItems count] > 1) {
 		NSDecimalNumber *lineItemSubtotal = [NSDecimalNumber zero];
 		for (BUYLineItem *lineItem in self.lineItems) {
-			lineItemSubtotal = [lineItemSubtotal decimalNumberByAdding:lineItem.price];
+			lineItemSubtotal = [lineItemSubtotal decimalNumberByAdding:lineItem.linePrice];
 		}
 		[summaryItems addObject:[PKPaymentSummaryItem summaryItemWithLabel:@"CART TOTAL" amount:lineItemSubtotal]];
 	}

--- a/Mobile Buy SDK/Mobile Buy SDK/View Controllers/BUYViewController.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/View Controllers/BUYViewController.m
@@ -117,6 +117,8 @@ NSString * BUYURLKey = @"url";
 
 - (void)startApplePayCheckout:(BUYCheckout *)checkout
 {
+	// Default to the failure state, since cancelling a payment would not update the state and thus appear as a success
+	self.paymentAuthorizationStatus = PKPaymentAuthorizationStatusFailure;
 	
 	if (self.shop == nil && self.isLoadingShop == NO) {
 		// since requests are sent serially, this will return before the checkout is created


### PR DESCRIPTION
### Fixes

- A discount with a cart that has multiple quantities of the same variant display the incorrect subtotal in the Apple Pay sheet. Note, this just displays the incorrect subtotal amount, the total and charged amount was correct.
- If an Apple Pay sheet is cancelled, the status appears as success, and we did not execute the code to release the reservations on the checkout