### PR TITLE
Pop to root after dismissing order status page

### DIFF
--- a/Mobile Buy SDK Sample Apps/Sample App Advanced/Mobile Buy SDK Advanced Sample/CheckoutViewController.m
+++ b/Mobile Buy SDK Sample Apps/Sample App Advanced/Mobile Buy SDK Advanced Sample/CheckoutViewController.m
@@ -184,10 +184,18 @@ NSString * const MerchantId = @"";
                                                         style:UIAlertActionStyleDefault
                                                       handler:^(UIAlertAction *action) {
                                                           SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:self.checkout.order.statusURL];
+                                                          safariViewController.delegate = self;
                                                           [self presentViewController:safariViewController animated:YES completion:NULL];
                                                       }]];
     
     [self presentViewController:alertController animated:YES completion:nil];
+}
+
+#pragma mark - SafariViewControllerDelegate
+
+- (void)safariViewControllerDidFinish:(SFSafariViewController *)controller
+{
+    [self.navigationController popToRootViewControllerAnimated:YES];
 }
 
 #pragma mark Native Checkout


### PR DESCRIPTION
When using the "Checkout with Credit Card" option, and reviewing the order in Safari view, the checkout view was not dismissed when returning.

This implements the necessary delegate method to detect when the user is finished and reset to the collections view.

- [x] test
- [x] review

@davidmuzi @runmad 