### PR TITLE
Fix shipping rate invalidation bug using Apple Pay in 1.2.2

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClientTest.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClientTest.m
@@ -101,6 +101,8 @@
 {
 	BUYCart *cart = [[BUYCart alloc] init];
 	BUYCheckout *checkout = [[BUYCheckout alloc] initWithCart:cart];
+	
+	XCTAssertThrows([checkout setPartialAddresses:NO]);
 
 	NSURLSessionDataTask *task = [self.client createCheckout:checkout completion:nil];
 	NSDictionary *json = [NSJSONSerialization JSONObjectWithData:task.originalRequest.HTTPBody options:0 error:nil];

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.h
@@ -250,6 +250,8 @@
 
 /**
  *  Flag used to inform server that the shipping address is partially filled, suitable to retrieve shipping rates
+ *  with partial shipping addresses provided by PKPaymentAuthorizationViewController.
+ *  Note: This should only ever be set to YES. Setting it to NO throws an exception.
  */
 @property (nonatomic, assign) BOOL partialAddresses;
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.m
@@ -202,6 +202,14 @@
 	return @{ @"checkout" : json };
 }
 
+-(void)setPartialAddresses:(BOOL)partialAddresses
+{
+	if (partialAddresses == NO) {
+		@throw [NSException exceptionWithName:@"partialAddress" reason:@"partialAddresses can only be set to true and should never be set to false on a complete address" userInfo:nil];
+	}
+	_partialAddresses = partialAddresses;
+}
+
 - (BOOL)hasToken
 {
 	return (_token && [_token length] > 0);

--- a/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayHelpers.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayHelpers.m
@@ -89,8 +89,7 @@ const NSTimeInterval PollDelay = 0.5;
 {
 	// Update the checkout with the rest of the information. Apple has now provided us with a FULL billing address and a FULL shipping address.
 	// We now update the checkout with our new found data so that you can ship the products to the right address, and we collect whatever else we need.
-	
-	self.checkout.partialAddresses = NO;
+
 	if ([payment respondsToSelector:@selector(shippingContact)]) {
 		self.checkout.email = payment.shippingContact.emailAddress;
 		self.checkout.shippingAddress = self.checkout.requiresShipping ? [BUYAddress buy_addressFromContact:payment.shippingContact] : nil;
@@ -165,8 +164,13 @@ const NSTimeInterval PollDelay = 0.5;
 #pragma mark -
 
 - (void)updateCheckoutWithAddressCompletion:(void (^)(PKPaymentAuthorizationStatus, NSArray *shippingMethods, NSArray *summaryItems))completion
-{	
-	self.checkout.partialAddresses = [self.checkout.shippingAddress isPartialAddress];
+{
+	// This method call is internal to selection of shipping address that are returned as partial from PKPaymentAuthorizationViewController
+	// However, to ensure we never set partialAddresses to NO, we want to guard the setter. Should PKPaymentAuthorizationViewController ever
+	// return a full address through it's delegate method, this will still function since a complete address can be used to calculate shipping rates
+	if ([self.checkout.shippingAddress isPartialAddress] == YES) {
+		self.checkout.partialAddresses = YES;
+	}
 	
 	if ([self.checkout.shippingAddress isValidAddressForShippingRates]) {
 		


### PR DESCRIPTION
### What is this?

Fix #68 

This fixes an issue where the `partialAddresses` flag was set to false, which would invalidate the already set (through a `updateCheckout:completion:` call) shippingRate on Shopify during a call to `completeCheckout:completion:`.

I have added more context to the usage of the `partialAddresses` property and we now override the setter to throw an `NSException` if this is ever set to `false`. This value should always ever be set to `true`.

I have removed the code that would have (and may have) set this property to `false` and added a test assertion that an exception is thrown if the value is set.

@davidmuzi please review :eyes: