### PR TITLE
Fix Apple Pay "Setup" button logic

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Product View/BUYProductViewController.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Product View/BUYProductViewController.h
@@ -76,13 +76,6 @@
 @property (nonatomic, assign, readonly) BOOL isLoading;
 
 /**
- *  If the merchantId is set and the device support Apple Pay but no credit card is present this allows the user to add a payment pass to the Wallet.
- *  The user is given the option to add a payment pass or continue with web checkout. Default is set to true. The Set Up Apple Pay button will, however
- *  still only show if [PKAddPaymentPassViewController canAddPaymentPass] returns true, merchantId is set and the app is running iOS 9.0 and above.
- */
-@property (nonatomic, assign) BOOL allowApplePaySetup;
-
-/**
  *  This is a convenience method as an alternative to presentViewController: which will force portrait orientation.  This method is only 
  *  required when presenting from a landscape view controller.
  *

--- a/Mobile Buy SDK/Mobile Buy SDK/Product View/BUYProductViewController.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Product View/BUYProductViewController.m
@@ -128,7 +128,7 @@ CGFloat const BUYMaxProductViewHeight = 640.0;
 - (BUYProductView *)productView
 {
 	if (_productView == nil && self.product != nil && self.shop != nil) {
-		_productView = [[BUYProductView alloc] initWithFrame:CGRectMake(0, 0, self.preferredContentSize.width, self.preferredContentSize.height) product:self.product theme:self.theme shouldShowApplePaySetup:self.allowApplePaySetup];
+		_productView = [[BUYProductView alloc] initWithFrame:CGRectMake(0, 0, self.preferredContentSize.width, self.preferredContentSize.height) product:self.product theme:self.theme shouldShowApplePaySetup:self.shouldShowApplePaySetup];
 		_productView.translatesAutoresizingMaskIntoConstraints = NO;
 		_productView.hidden = YES;
 		[self.view addSubview:_productView];
@@ -147,26 +147,6 @@ CGFloat const BUYMaxProductViewHeight = 640.0;
 		_productView.layoutMargins = UIEdgeInsetsMake(self.productView.layoutMargins.top, self.productView.layoutMargins.left, self.bottomLayoutGuide.length, self.productView.layoutMargins.right);
 	}
 	return _productView;
-}
-
-- (BOOL)canShowApplePaySetup
-{
-	PKPassLibrary *passLibrary = [[PKPassLibrary alloc] init];
-	if (self.allowApplePaySetup == YES &&
-		// Check that it's running iOS 9.0 or above
-		[passLibrary respondsToSelector:@selector(canAddPaymentPassWithPrimaryAccountIdentifier:)] &&
-		// Check if the device can add a payment pass
-		[PKPaymentAuthorizationViewController canMakePayments] &&
-		// Check that Apple Pay is enabled for the merchant
-		[self.merchantId length]) {
-		return YES;
-	} else {
-		return NO;
-	}
-}
-
-- (BOOL)shouldShowApplePayButton {
-	return self.isApplePayAvailable ? self.isApplePayAvailable : [self canShowApplePaySetup];
 }
 
 - (CGSize)preferredContentSize

--- a/Mobile Buy SDK/Mobile Buy SDK/View Controllers/BUYViewController.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/View Controllers/BUYViewController.h
@@ -171,6 +171,36 @@
 @property (nonatomic, assign, readonly) BOOL isApplePayAvailable;
 
 /**
+ *  If the merchantId is set and the device support Apple Pay but no credit card is present this allows the user to add a payment pass to the Wallet.
+ *  The user is given the option to add a payment pass or continue with web checkout. Default is set to true. The Set Up Apple Pay button will, however
+ *  still only show if [PKAddPaymentPassViewController canAddPaymentPass] returns true, merchantId is set and the app is running iOS 9.0 and above.
+ */
+@property (nonatomic, assign) BOOL allowApplePaySetup;
+
+/**
+ *  Whether the device is setup to show the Apple Pay setup sheet.
+ *  `allowApplePaySetup` must be set to YES, and the `merchantId` must also be set in addition to the
+ *  device settings for this method to return YES.
+ *
+ *  @return YES if the Setup Apple Pay button should be shown
+ */
+- (BOOL)canShowApplePaySetup;
+
+/**
+ *  Returns whether the Apple Pay button should be shown
+ *
+ *  @return YES if `isApplePayAvailable` or `canShowApplePaySetup` returns YES
+ */
+- (BOOL)shouldShowApplePayButton;
+
+/**
+ *  Returns whether to show the Apple Pay setup button in place of the Apple Pay buy button
+ *
+ *  @return YES if `isApplePayAvailable` returns NO and `canShowApplePaySetup` returns YES
+ */
+- (BOOL)shouldShowApplePaySetup;
+
+/**
  *  The current checkout object
  */
 @property (nonatomic, strong, readonly) BUYCheckout *checkout;

--- a/Mobile Buy SDK/Mobile Buy SDK/View Controllers/BUYViewController.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/View Controllers/BUYViewController.m
@@ -102,6 +102,22 @@ NSString * BUYURLKey = @"url";
 	}];
 }
 
+- (BOOL)canShowApplePaySetup
+{
+	PKPassLibrary *passLibrary = [[PKPassLibrary alloc] init];
+	if (self.allowApplePaySetup == YES &&
+		// Check that it's running iOS 9.0 or above
+		[passLibrary respondsToSelector:@selector(canAddPaymentPassWithPrimaryAccountIdentifier:)] &&
+		// Check if the device can add a payment pass
+		[PKPaymentAuthorizationViewController canMakePayments] &&
+		// Check that Apple Pay is enabled for the merchant
+		[self.merchantId length]) {
+		return YES;
+	} else {
+		return NO;
+	}
+}
+
 - (BOOL)isApplePayAvailable
 {
 	// checks if the client is setup to use Apple Pay
@@ -110,6 +126,15 @@ NSString * BUYURLKey = @"url";
 	return (self.merchantId.length &&
 			[PKPaymentAuthorizationViewController canMakePayments] &&
 			[PKPaymentAuthorizationViewController canMakePaymentsUsingNetworks:self.supportedNetworks]);
+}
+
+- (BOOL)shouldShowApplePayButton {
+	return self.isApplePayAvailable || [self canShowApplePaySetup];
+}
+
+- (BOOL)shouldShowApplePaySetup
+{
+	return self.isApplePayAvailable == NO && [self canShowApplePaySetup];
 }
 
 #pragma mark - Checkout Flow Methods


### PR DESCRIPTION
### What this does

This moves and adds a few methods in `BUYViewController` from `BUYProductViewController` that handles the logic for whether to display the "Setup  Pay" button if Apple Pay is available on the shop and on the device, but not yet setup with a card.

This also fixes an issue where the "Setup  Pay" would display instead of "Buy with  Pay" in the `BUYProductViewController` due to using an incorrect getter method.

@davidmuzi please review :eyes: 