### PR TITLE
Remove shippingRateId on BUYCheckout

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYCheckoutTest.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYCheckoutTest.m
@@ -73,17 +73,6 @@
 	XCTAssertTrue([checkout isDirty]);
 }
 
-- (void)testSettingAShippingRateMarksShippingRateIdAsDirty
-{
-	BUYShippingRate *shippingRate = [[BUYShippingRate alloc] initWithDictionary:@{ @"id" : @"banana" }];
-	XCTAssertNil(_checkout.shippingRate);
-	XCTAssertNil(_checkout.shippingRateId);
-	_checkout.shippingRate = shippingRate;
-	XCTAssertEqualObjects(@"banana", _checkout.shippingRateId);
-	
-	XCTAssertTrue([[_checkout dirtyProperties] containsObject:@"shippingRateId"]);
-}
-
 - (void)testDirtyPropertiesAreReturnedInJSON
 {
 	BUYShippingRate *shippingRate = [[BUYShippingRate alloc] initWithDictionary:@{ @"id" : @"banana" }];
@@ -93,12 +82,10 @@
 	_checkout.currency = @"BANANA";
 	NSSet *dirtyProperties = [_checkout dirtyProperties];
 	XCTAssertTrue([dirtyProperties containsObject:@"currency"]);
-	XCTAssertTrue([dirtyProperties containsObject:@"shippingRateId"]);
 	XCTAssertTrue([dirtyProperties containsObject:@"shippingRate"]);
 	
 	NSDictionary *json = [_checkout jsonDictionaryForCheckout];
 	XCTAssertEqualObjects(json[@"checkout"][@"currency"], @"BANANA");
-	XCTAssertEqualObjects(json[@"checkout"][@"shipping_rate_id"], @"banana");
 }
 
 - (void)testRequiresShippingAndIncludesTaxesSerialization

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.h
@@ -149,11 +149,6 @@
 @property (nonatomic, strong) BUYShippingRate *shippingRate;
 
 /**
- *  Shipping rate identifier
- */
-@property (nonatomic, readonly) NSString *shippingRateId;
-
-/**
  *  A discount added to the checkout
  *  Only one discount can be added to a checkout. Call `updateCheckout:completion:`
  *  after adding a discount to apply the discount code to the checkout.

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.h
@@ -149,6 +149,11 @@
 @property (nonatomic, strong) BUYShippingRate *shippingRate;
 
 /**
+*  Shipping rate identifier
+*/
+@property (nonatomic, readonly) NSString *shippingRateId DEPRECATED_MSG_ATTRIBUTE("Use shippingRate.shippingRateIdentifier");
+
+/**
  *  A discount added to the checkout
  *  Only one discount can be added to a checkout. Call `updateCheckout:completion:`
  *  after adding a discount to apply the discount code to the checkout.

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.m
@@ -71,20 +71,11 @@
 	return self;
 }
 
-- (void)setShippingRateId:(NSString *)shippingRateIdentifier
-{
-	[self willChangeValueForKey:@"shippingRateId"];
-	_shippingRateId = shippingRateIdentifier;
-	[self didChangeValueForKey:@"shippingRateId"];
-}
-
 - (void)setShippingRate:(BUYShippingRate *)shippingRate
 {
 	[self willChangeValueForKey:@"shippingRate"];
 	_shippingRate = shippingRate;
 	[self didChangeValueForKey:@"shippingRate"];
-	
-	[self setShippingRateId:shippingRate.shippingRateIdentifier];
 }
 
 + (NSString *)jsonKeyForProperty:(NSString *)property

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.m
@@ -155,6 +155,11 @@
 	self.sourceIdentifier = dictionary[@"source_identifier"];
 }
 
+- (NSString *)shippingRateId
+{
+	return self.shippingRate.shippingRateIdentifier;
+}
+
 - (id)jsonValueForValue:(id)value
 {
 	id newValue = value;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.m
@@ -71,13 +71,6 @@
 	return self;
 }
 
-- (void)setShippingRate:(BUYShippingRate *)shippingRate
-{
-	[self willChangeValueForKey:@"shippingRate"];
-	_shippingRate = shippingRate;
-	[self didChangeValueForKey:@"shippingRate"];
-}
-
 + (NSString *)jsonKeyForProperty:(NSString *)property
 {
 	NSString *key = nil;


### PR DESCRIPTION
Fix #84 

`shipping_rate_id` is no longer required on Shopify. This is a `readonly` property, so there's no need to deprecate it. It can be removed without the need for any fallbacks.

@davidmuzi please review :eyes: 