### PR TITLE
Remove province requirement from client-side address validation

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYAddress+Additions.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYAddress+Additions.m
@@ -46,7 +46,6 @@
 	
 	if (self.city.length > 0 &&
 		self.zip.length > 0 &&
-		self.province.length > 0 &&
 		(self.country.length > 0 || self.countryCode.length == 2)) {
 	
 		valid = YES;


### PR DESCRIPTION
Fix #82 

This removed the requirement in Apple Pay for a province to exist on a shipping address. This solves the issue of merchants that ship worldwide and support Apple Pay.

@davidmuzi please review :eyes: 