### PR TITLE
Change customerID type from NSString to the correct type - NSNumber.

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout.h
@@ -237,7 +237,7 @@
 /**
  *  Customer ID associated with the checkout
  */
-@property (nonatomic, copy, readonly) NSString *customerId;
+@property (nonatomic, copy, readonly) NSNumber *customerId;
 
 /**
  *  An optional note attached to the order

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout_Private.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCheckout_Private.h
@@ -48,7 +48,7 @@
 @property (nonatomic, copy) NSDate *updatedAtDate;
 @property (nonatomic, strong) BUYMaskedCreditCard *creditCard;
 @property (nonatomic, strong) BUYOrder *order;
-@property (nonatomic, copy) NSString *customerId;
+@property (nonatomic, copy) NSNumber *customerId;
 @property (nonatomic, strong) NSURL *privacyPolicyURL;
 @property (nonatomic, strong) NSURL *refundPolicyURL;
 @property (nonatomic, strong) NSURL *termsOfServiceURL;


### PR DESCRIPTION
The `customerId` was being represented by an `NSString` when it is, in fact, returned from the API as an `NSNumber`.

Fixes #116 

@bgulanowski @davidmuzi 