### PR TITLE
Checkout v2.0 conversion

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClientTest.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClientTest.m
@@ -131,33 +131,6 @@
 	XCTAssertNotNil(task);
 }
 
-- (void)testCheckoutURLParsing
-{
-	NSURL *url = [NSURL URLWithString:@"sampleapp://?checkout%5Btoken%5D=377a6afb2c6651b6c42af5547e12bda1"];
-	
-	[self.client getCompletionStatusOfCheckoutURL:url completion:^(BUYStatus status, NSError *error) {
-		// We should not get a callback here
-		XCTFail();
-	}];
-}
-
-- (void)testCheckoutBadURLParsing
-{
-	XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
-	
-	NSURL *url = [NSURL URLWithString:@"sampleapp://"];
-	
-	[self.client getCompletionStatusOfCheckoutURL:url completion:^(BUYStatus status, NSError *error) {
-		XCTAssertEqual(status, BUYStatusUnknown);
-		XCTAssertEqual(error.code, BUYShopifyError_InvalidCheckoutObject);
-		[expectation fulfill];
-	}];
-	
-	[self waitForExpectationsWithTimeout:10 handler:^(NSError *error) {
-		XCTAssertNil(error);
-	}];
-}
-
 - (void)testMerchantId
 {
 	NSString *merchantId = @"com.merchant.id";
@@ -195,14 +168,14 @@
 {
 	__block int callbackCount = 0;
 	
-	[self.client completeCheckout:nil withApplePayToken:[PKPaymentToken new] completion:^(BUYCheckout *checkout, NSError *error) {
+	[self.client completeCheckout:nil withApplePayToken:[PKPaymentToken new] completion:^(BUYPayment *payment, NSError *error) {
 		callbackCount++;
 		XCTAssertEqual(error.code, BUYShopifyError_InvalidCheckoutObject);
 	}];
 	
 	BUYCheckout *checkout = [[BUYCheckout alloc] initWithDictionary:@{@"token": @"abcdef", @"payment_due": @0}];
 
-	[self.client completeCheckout:checkout withApplePayToken:nil completion:^(BUYCheckout *checkout, NSError *error) {
+	[self.client completeCheckout:checkout withApplePayToken:nil completion:^(BUYPayment *payment, NSError *error) {
 		callbackCount++;
 		XCTAssertEqual(error.code, BUYShopifyError_NoApplePayTokenSpecified);
 	}];

--- a/Mobile Buy SDK/Mobile Buy SDK.xcodeproj/project.pbxproj
+++ b/Mobile Buy SDK/Mobile Buy SDK.xcodeproj/project.pbxproj
@@ -244,8 +244,8 @@
 		90F593091B0D5F4C0026B382 /* BUYClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 90F592FD1B0D5F4C0026B382 /* BUYClientTest.m */; };
 		90F5930A1B0D5F4C0026B382 /* BUYLineItemTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 90F592FE1B0D5F4C0026B382 /* BUYLineItemTest.m */; };
 		90F5930B1B0D5F4C0026B382 /* BUYObjectTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 90F592FF1B0D5F4C0026B382 /* BUYObjectTests.m */; };
-		9A6715EE1CD0009C001348C7 /* BUYPayment.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A6715EC1CD0009C001348C7 /* BUYPayment.h */; };
-		9A6715EF1CD0009C001348C7 /* BUYPayment.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A6715EC1CD0009C001348C7 /* BUYPayment.h */; };
+		9A6715EE1CD0009C001348C7 /* BUYPayment.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A6715EC1CD0009C001348C7 /* BUYPayment.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9A6715EF1CD0009C001348C7 /* BUYPayment.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A6715EC1CD0009C001348C7 /* BUYPayment.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9A6715F01CD0009C001348C7 /* BUYPayment.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A6715ED1CD0009C001348C7 /* BUYPayment.m */; };
 		9A6715F11CD0009C001348C7 /* BUYPayment.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A6715ED1CD0009C001348C7 /* BUYPayment.m */; };
 		BE1007951B6038150031CEE7 /* BUYProductVariant+Options.h in Headers */ = {isa = PBXBuildFile; fileRef = BE1007931B6038150031CEE7 /* BUYProductVariant+Options.h */; };

--- a/Mobile Buy SDK/Mobile Buy SDK.xcodeproj/project.pbxproj
+++ b/Mobile Buy SDK/Mobile Buy SDK.xcodeproj/project.pbxproj
@@ -244,6 +244,10 @@
 		90F593091B0D5F4C0026B382 /* BUYClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 90F592FD1B0D5F4C0026B382 /* BUYClientTest.m */; };
 		90F5930A1B0D5F4C0026B382 /* BUYLineItemTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 90F592FE1B0D5F4C0026B382 /* BUYLineItemTest.m */; };
 		90F5930B1B0D5F4C0026B382 /* BUYObjectTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 90F592FF1B0D5F4C0026B382 /* BUYObjectTests.m */; };
+		9A6715EE1CD0009C001348C7 /* BUYPayment.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A6715EC1CD0009C001348C7 /* BUYPayment.h */; };
+		9A6715EF1CD0009C001348C7 /* BUYPayment.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A6715EC1CD0009C001348C7 /* BUYPayment.h */; };
+		9A6715F01CD0009C001348C7 /* BUYPayment.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A6715ED1CD0009C001348C7 /* BUYPayment.m */; };
+		9A6715F11CD0009C001348C7 /* BUYPayment.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A6715ED1CD0009C001348C7 /* BUYPayment.m */; };
 		BE1007951B6038150031CEE7 /* BUYProductVariant+Options.h in Headers */ = {isa = PBXBuildFile; fileRef = BE1007931B6038150031CEE7 /* BUYProductVariant+Options.h */; };
 		BE1007961B6038150031CEE7 /* BUYProductVariant+Options.m in Sources */ = {isa = PBXBuildFile; fileRef = BE1007941B6038150031CEE7 /* BUYProductVariant+Options.m */; };
 		BE10079B1B6165EC0031CEE7 /* BUYOptionValueCell.h in Headers */ = {isa = PBXBuildFile; fileRef = BE1007991B6165EC0031CEE7 /* BUYOptionValueCell.h */; };
@@ -498,6 +502,8 @@
 		90F593001B0D5F4C0026B382 /* BUYTestConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BUYTestConstants.h; sourceTree = "<group>"; };
 		90FC31A61B50371600AFAB51 /* BUYProductViewHeaderBackgroundImageView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; name = BUYProductViewHeaderBackgroundImageView.h; path = "Product View/BUYProductViewHeaderBackgroundImageView.h"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		90FC31A71B50371600AFAB51 /* BUYProductViewHeaderBackgroundImageView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BUYProductViewHeaderBackgroundImageView.m; path = "Product View/BUYProductViewHeaderBackgroundImageView.m"; sourceTree = "<group>"; };
+		9A6715EC1CD0009C001348C7 /* BUYPayment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BUYPayment.h; sourceTree = "<group>"; };
+		9A6715ED1CD0009C001348C7 /* BUYPayment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BUYPayment.m; sourceTree = "<group>"; };
 		BE1007931B6038150031CEE7 /* BUYProductVariant+Options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "BUYProductVariant+Options.h"; sourceTree = "<group>"; };
 		BE1007941B6038150031CEE7 /* BUYProductVariant+Options.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "BUYProductVariant+Options.m"; sourceTree = "<group>"; };
 		BE1007991B6165EC0031CEE7 /* BUYOptionValueCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BUYOptionValueCell.h; sourceTree = "<group>"; };
@@ -632,6 +638,8 @@
 			children = (
 				90AFAA601B01390F00F21C23 /* BUYAddress.h */,
 				90AFAA611B01390F00F21C23 /* BUYAddress.m */,
+				9A6715EC1CD0009C001348C7 /* BUYPayment.h */,
+				9A6715ED1CD0009C001348C7 /* BUYPayment.m */,
 				BEB74A1B1B5490140005A300 /* BUYCheckout_Private.h */,
 				F773749419C77C260039681C /* BUYCheckout.h */,
 				F773749519C77C260039681C /* BUYCheckout.m */,
@@ -1001,6 +1009,7 @@
 				9019314F1BC5B9BC00D1134E /* BUYOptionSelectionViewController.h in Headers */,
 				901931501BC5B9BC00D1134E /* BUYOrder.h in Headers */,
 				901931531BC5B9BC00D1134E /* BUYOptionSelectionNavigationController.h in Headers */,
+				9A6715EF1CD0009C001348C7 /* BUYPayment.h in Headers */,
 				901931541BC5B9BC00D1134E /* BUYPresentationControllerWithNavigationController.h in Headers */,
 				901931551BC5B9BC00D1134E /* BUYPresentationControllerForVariantSelection.h in Headers */,
 				901931571BC5B9BC00D1134E /* BUYObject.h in Headers */,
@@ -1080,6 +1089,7 @@
 				BEB74A791B5564790005A300 /* BUYOptionSelectionViewController.h in Headers */,
 				90E83BC41B9F550E00C95A1B /* BUYOrder.h in Headers */,
 				BEB74A281B554BFB0005A300 /* BUYOptionSelectionNavigationController.h in Headers */,
+				9A6715EE1CD0009C001348C7 /* BUYPayment.h in Headers */,
 				BEB74A691B5564160005A300 /* BUYPresentationControllerWithNavigationController.h in Headers */,
 				BEB74A221B554BF20005A300 /* BUYPresentationControllerForVariantSelection.h in Headers */,
 				BE9A645D1B503CE30033E558 /* BUYObject.h in Headers */,
@@ -1300,6 +1310,7 @@
 				901931021BC5B9BC00D1134E /* BUYStoreViewController.m in Sources */,
 				901931031BC5B9BC00D1134E /* BUYOptionValue.m in Sources */,
 				901931041BC5B9BC00D1134E /* BUYApplePayAdditions.m in Sources */,
+				9A6715F11CD0009C001348C7 /* BUYPayment.m in Sources */,
 				901931051BC5B9BC00D1134E /* BUYOptionSelectionNavigationController.m in Sources */,
 				901931061BC5B9BC00D1134E /* BUYDiscount.m in Sources */,
 				841ADE0A1CB6C942000004B0 /* NSDateFormatter+BUYAdditions.m in Sources */,
@@ -1405,6 +1416,7 @@
 				BE9A647F1B503D960033E558 /* BUYStoreViewController.m in Sources */,
 				BE9A64691B503D0C0033E558 /* BUYOptionValue.m in Sources */,
 				BE9A646D1B503D1C0033E558 /* BUYApplePayAdditions.m in Sources */,
+				9A6715F01CD0009C001348C7 /* BUYPayment.m in Sources */,
 				BEB74A2A1B554BFB0005A300 /* BUYOptionSelectionNavigationController.m in Sources */,
 				BE9A64501B503CAD0033E558 /* BUYDiscount.m in Sources */,
 				841ADE091CB6C942000004B0 /* NSDateFormatter+BUYAdditions.m in Sources */,

--- a/Mobile Buy SDK/Mobile Buy SDK/Buy.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Buy.h
@@ -47,6 +47,7 @@ FOUNDATION_EXPORT const unsigned char BuyVersionString[];
 #import <Buy/BUYOption.h>
 #import <Buy/BUYOptionValue.h>
 #import <Buy/BUYOrder.h>
+#import <Buy/BUYPayment.h>
 #import <Buy/BUYProduct.h>
 #import <Buy/BUYProductVariant.h>
 #import <Buy/BUYShippingRate.h>

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.h
@@ -463,27 +463,6 @@ typedef void (^BUYDataGiftCardBlock)(BUYGiftCard *giftCard, NSError *error);
  */
 - (NSURLSessionDataTask *)completeCheckout:(BUYCheckout *)checkout withApplePayToken:(PKPaymentToken *)token completion:(BUYDataCheckoutBlock)block;
 
-/**
- *  Retrieve the status of a BUYCheckout. This checks the status of the current payment processing job for the provided checkout.
- *  Once the job is complete (status == BUYStatusComplete), you can retrieve the completed order by calling `getCheckout:completion`
- *
- *  @param checkout The BUYCheckout to retrieve completion status for
- *  @param block    (^BUYDataCheckoutStatusBlock)(BUYCheckout *checkout, BUYStatus status, NSError *error);
- *
- *  @return The associated NSURLSessionDataTask
- */
-- (NSURLSessionDataTask *)getCompletionStatusOfCheckout:(BUYCheckout *)checkout completion:(BUYDataCheckoutStatusBlock)block;
-
-/**
- *  Retrieve the status of a checkout given a URL obtained in the UIApplicationDelegate method `application:sourceApplication:annotation`
- *
- *  @param url   The URL resource used to open the application
- *  @param block    (^BUYDataCheckoutStatusBlock)(BUYCheckout *checkout, BUYStatus status, NSError *error);
- *
- *  @return The associated NSURLSessionDataTask
- */
-- (NSURLSessionDataTask *)getCompletionStatusOfCheckoutURL:(NSURL *)url completion:(BUYDataCheckoutStatusBlock)block;
-
 #pragma mark - Shipping Rates
 
 /**

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.h
@@ -33,6 +33,7 @@
 @class BUYCheckout;
 @class BUYCreditCard;
 @class BUYGiftCard;
+@class BUYPayment;
 @class BUYProduct;
 @class BUYProductVariant;
 @class BUYShop;
@@ -125,6 +126,14 @@ typedef void (^BUYDataCreditCardBlock)(BUYCheckout *checkout, NSString *paymentS
  *  @param error    Optional NSError
  */
 typedef void (^BUYDataCheckoutBlock)(BUYCheckout *checkout, NSError *error);
+
+/**
+ *  Return block containing a BUYPayment and/or an NSError
+ *
+ *  @param payment  The returned BUYPayment
+ *  @param error    Optional NSError
+ */
+typedef void (^BUYDataPaymentBlock)(BUYPayment *payment, NSError *error);
 
 /**
  *  Return block containing a BUYCheckout, a BUYStatus and/or an NSError
@@ -443,7 +452,7 @@ typedef void (^BUYDataGiftCardBlock)(BUYGiftCard *giftCard, NSError *error);
  *
  *  @return The associated NSURLSessionDataTask
  */
-- (NSURLSessionDataTask *)completeCheckout:(BUYCheckout *)checkout completion:(BUYDataCheckoutBlock)block;
+- (NSURLSessionDataTask *)completeCheckout:(BUYCheckout *)checkout completion:(BUYDataPaymentBlock)block;
 
 /**
  */
@@ -461,7 +470,7 @@ typedef void (^BUYDataGiftCardBlock)(BUYGiftCard *giftCard, NSError *error);
  *
  *  @return The associated NSURLSessionDataTask
  */
-- (NSURLSessionDataTask *)completeCheckout:(BUYCheckout *)checkout withApplePayToken:(PKPaymentToken *)token completion:(BUYDataCheckoutBlock)block;
+- (NSURLSessionDataTask *)completeCheckout:(BUYCheckout *)checkout withApplePayToken:(PKPaymentToken *)token completion:(BUYDataPaymentBlock)block;
 
 #pragma mark - Shipping Rates
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.m
@@ -487,7 +487,13 @@ static NSString *const kBUYClientPathCollectionPublications = @"collection_listi
 	}
 	else {
 		NSString *tokenString = [[NSString alloc] initWithData:token.paymentData encoding:NSUTF8StringEncoding];
-		NSDictionary *paymentJson = @{ @"payment_token" : @{ @"payment_data" : tokenString, @"type" : @"apple_pay" }};
+		NSDictionary *paymentJson = @{
+									  @"payment" : @{
+											  @"source" : @{
+													  @"token" : tokenString,
+													  },
+											  },
+									  };
 		NSError *error = nil;
 		NSData *data = [NSJSONSerialization dataWithJSONObject:paymentJson options:0 error:&error];
 		if (data && error == nil) {

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.m
@@ -498,50 +498,6 @@ static NSString *const kBUYClientPathCollectionPublications = @"collection_listi
 	}];
 }
 
-- (NSURLSessionDataTask *)getCompletionStatusOfCheckout:(BUYCheckout *)checkout completion:(BUYDataCheckoutStatusBlock)block
-{
-	NSURLSessionDataTask *task = nil;
-	if ([checkout hasToken]) {
-		task = [self getCompletionStatusOfCheckoutToken:checkout.token completion:block];
-	}
-	else {
-		block(BUYStatusUnknown, [NSError errorWithDomain:kShopifyError code:BUYShopifyError_InvalidCheckoutObject userInfo:nil]);
-	}
-	return task;
-}
-
-- (NSURLSessionDataTask *)getCompletionStatusOfCheckoutURL:(NSURL *)url completion:(BUYDataCheckoutStatusBlock)block
-{
-	NSString *token = nil;
-	
-	NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
-	for (NSURLQueryItem *item in components.queryItems) {
-		
-		if ([item.name isEqualToString:@"checkout[token]"]) {
-			token = item.value;
-		}
-	}
-	
-	if (token) {
-		return [self getCompletionStatusOfCheckoutToken:token completion:block];
-	}
-	else {
-		block(BUYStatusUnknown, [NSError errorWithDomain:kShopifyError code:BUYShopifyError_InvalidCheckoutObject userInfo:nil]);
-		return nil;
-	}
-}
-
-- (NSURLSessionDataTask *)getCompletionStatusOfCheckoutToken:(NSString *)token completion:(BUYDataCheckoutStatusBlock)block
-{
-	NSURLComponents *components = [self URLComponentsForCheckoutsAppendingPath:@"processing"
-																 checkoutToken:token
-																	queryItems:nil];
-	return [self getRequestForURL:components.URL completionHandler:^(NSDictionary *json, NSURLResponse *response, NSError *error) {
-		NSInteger statusCode = [(NSHTTPURLResponse *)response statusCode];
-		block([BUYClient statusForStatusCode:statusCode error:error], error);
-	}];
-}
-
 #pragma mark - Shipping Rates
 
 - (NSURLSessionDataTask *)getShippingRatesForCheckout:(BUYCheckout *)checkout completion:(BUYDataShippingRatesBlock)block

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.m
@@ -552,7 +552,7 @@ static NSString *const kBUYClientPathCollectionPublications = @"collection_listi
 	else {
 		
 		NSError *error = nil;
-		NSData *data = [NSJSONSerialization dataWithJSONObject:[creditCard jsonDictionaryForCheckout] options:0 error:&error];
+		NSData *data = [NSJSONSerialization dataWithJSONObject:@{ @"credit_card" : [creditCard jsonDictionaryForCheckout] } options:0 error:&error];
 		if (data && error == nil) {
 			task = [self postPaymentRequestWithCheckout:checkout body:data completion:block];
 		}

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYPayment.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYPayment.h
@@ -1,0 +1,103 @@
+//
+//  BUYPayment.h
+//  Mobile Buy SDK
+//
+//  Created by Shopify.
+//  Copyright (c) 2015 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import "BUYObject.h"
+
+@class BUYCheckout;
+
+@interface BUYPayment : BUYObject
+
+/**
+ *  The total amount reported in the `BUYCheckout` object
+ */
+@property (nonatomic, strong, readonly) NSDecimalNumber *amount;
+
+/**
+ *  TODO:
+ */
+@property (nonatomic, strong, readonly) NSDecimalNumber *amountIn;
+
+/**
+ *  TODO:
+ */
+@property (nonatomic, strong, readonly) NSDecimalNumber *amountOut;
+
+/**
+ *  TODO:
+ */
+@property (nonatomic, strong, readonly) NSDecimalNumber *amountRounding;
+
+/**
+ *  TODO:
+ */
+@property (nonatomic, strong, readonly) NSString *authorization;
+
+/**
+ * Creation date of the payment
+ */
+@property (nonatomic, strong, readonly) NSDate *createdAt;
+
+/**
+ * Three-letter currency code used for this payment
+ */
+@property (nonatomic, strong, readonly) NSString *currency;
+
+/**
+ * The error code, if one occured, for this payment
+ */
+@property (nonatomic, strong, readonly) NSNumber *errorCode;
+
+/**
+ *  TODO:
+ */
+@property (nonatomic, strong, readonly) NSString *gateway;
+
+/**
+ *  TODO:
+ */
+@property (nonatomic, strong, readonly) NSString *kind;
+
+/**
+ * A short message describing the status of the operation
+ */
+@property (nonatomic, strong, readonly) NSString *message;
+
+/**
+ * A status for the operation
+ */
+@property (nonatomic, strong, readonly) NSString *status;
+
+/**
+ * Checkout objects tied to this payment
+ */
+@property (nonatomic, strong, readonly) BUYCheckout *checkout;
+
+/**
+ *  TODO:
+ */
+@property (nonatomic, assign, readonly) BOOL isTest;
+
+@end

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYPayment.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYPayment.h
@@ -31,62 +31,47 @@
 @interface BUYPayment : BUYObject
 
 /**
- *  The total amount reported in the `BUYCheckout` object
+ *  The amount charged or that will be charged to the customer.
  */
 @property (nonatomic, strong, readonly) NSDecimalNumber *amount;
 
 /**
- *  TODO:
- */
-@property (nonatomic, strong, readonly) NSDecimalNumber *amountIn;
-
-/**
- *  TODO:
- */
-@property (nonatomic, strong, readonly) NSDecimalNumber *amountOut;
-
-/**
- *  TODO:
- */
-@property (nonatomic, strong, readonly) NSDecimalNumber *amountRounding;
-
-/**
- *  TODO:
+ * The authorization number returned by the payment provider
  */
 @property (nonatomic, strong, readonly) NSString *authorization;
 
 /**
- * Creation date of the payment
+ * The date and time when the checkout was created. The API returns this value in ISO 8601 format.
  */
 @property (nonatomic, strong, readonly) NSDate *createdAt;
 
 /**
- * Three-letter currency code used for this payment
+ * The currency used to complete the transaction.
  */
 @property (nonatomic, strong, readonly) NSString *currency;
 
 /**
- * The error code, if one occured, for this payment
+ * The error code returned by the payment provider.
  */
 @property (nonatomic, strong, readonly) NSNumber *errorCode;
 
 /**
- *  TODO:
+ * The gateway used by shopify to complete the transaction.
  */
 @property (nonatomic, strong, readonly) NSString *gateway;
 
 /**
- *  TODO:
+ * The kind of authorization. Can be either an authorization or a sale.
  */
 @property (nonatomic, strong, readonly) NSString *kind;
 
 /**
- * A short message describing the status of the operation
+ * An informative message returned by the payment provider.
  */
 @property (nonatomic, strong, readonly) NSString *message;
 
 /**
- * A status for the operation
+ * The status of the transaction. Can be either a 'success' or a 'failure'.
  */
 @property (nonatomic, strong, readonly) NSString *status;
 
@@ -96,7 +81,7 @@
 @property (nonatomic, strong, readonly) BUYCheckout *checkout;
 
 /**
- *  TODO:
+ * Indicates if the transaction was a test or not.
  */
 @property (nonatomic, assign, readonly) BOOL isTest;
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYPayment.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYPayment.m
@@ -39,10 +39,6 @@
 	NSDateFormatter *formatter = [NSDateFormatter dateFormatterForPublications];
 	
 	_amount         = [NSDecimalNumber buy_decimalNumberFromJSON:dictionary[@"amount"]];
-	_amountIn       = [NSDecimalNumber buy_decimalNumberFromJSON:dictionary[@"amount_in"]];
-	_amountOut      = [NSDecimalNumber buy_decimalNumberFromJSON:dictionary[@"amount_out"]];
-	_amountRounding = [NSDecimalNumber buy_decimalNumberFromJSON:dictionary[@"amount_rounding"]];
-	
 	_createdAt      = [formatter dateFromString:[dictionary buy_objectForKey:@"created_at"]];
 	
 	_authorization  = [dictionary buy_objectForKey:@"authorization"];

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYPayment.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYPayment.m
@@ -1,0 +1,61 @@
+//
+//  BUYPayment.m
+//  Mobile Buy SDK
+//
+//  Created by Shopify.
+//  Copyright (c) 2015 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import "BUYPayment.h"
+#import "BUYCheckout.h"
+#import "NSDecimalNumber+BUYAdditions.h"
+#import "NSDateFormatter+BUYAdditions.h"
+#import "NSDictionary+BUYAdditions.h"
+
+@implementation BUYPayment
+
+- (void)updateWithDictionary:(NSDictionary *)dictionary
+{
+	[super updateWithDictionary:dictionary];
+	
+	NSDateFormatter *formatter = [NSDateFormatter dateFormatterForPublications];
+	
+	_amount         = [NSDecimalNumber buy_decimalNumberFromJSON:dictionary[@"amount"]];
+	_amountIn       = [NSDecimalNumber buy_decimalNumberFromJSON:dictionary[@"amount_in"]];
+	_amountOut      = [NSDecimalNumber buy_decimalNumberFromJSON:dictionary[@"amount_out"]];
+	_amountRounding = [NSDecimalNumber buy_decimalNumberFromJSON:dictionary[@"amount_rounding"]];
+	
+	_createdAt      = [formatter dateFromString:[dictionary buy_objectForKey:@"created_at"]];
+	
+	_authorization  = [dictionary buy_objectForKey:@"authorization"];
+	_currency       = [dictionary buy_objectForKey:@"currency"];
+	_errorCode      = [dictionary buy_objectForKey:@"error_code"];
+	_gateway        = [dictionary buy_objectForKey:@"gateway"];
+	_kind           = [dictionary buy_objectForKey:@"kind"];
+	_message        = [dictionary buy_objectForKey:@"message"];
+	_status         = [dictionary buy_objectForKey:@"status"];
+	
+	_checkout       = [BUYCheckout convertObject:dictionary[@"checkout"]];
+	
+	_isTest         = [[dictionary buy_objectForKey:@"test"] boolValue];
+}
+
+@end

--- a/Mobile Buy SDK/Mobile Buy SDK/Static Framework/Buy.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Static Framework/Buy.h
@@ -43,6 +43,7 @@
 #import "BUYOption.h"
 #import "BUYOptionValue.h"
 #import "BUYOrder.h"
+#import "BUYPayment.h"
 #import "BUYProduct.h"
 #import "BUYProductVariant.h"
 #import "BUYShippingRate.h"

--- a/Mobile Buy SDK/Mobile Buy SDK/View Controllers/BUYStoreViewController.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/View Controllers/BUYStoreViewController.m
@@ -238,22 +238,16 @@
 
 - (void)checkoutCompleted:(BUYCheckout *)checkout status:(BUYStatus)status
 {
-	if (status == BUYStatusComplete) {
-		[self.client getCheckout:checkout completion:^(BUYCheckout *updatedCheckout, NSError *error) {
-			dispatch_async(dispatch_get_main_queue(), ^{
-				if (updatedCheckout.order.statusURL) {
-					[_webView loadRequest:[NSURLRequest requestWithURL:updatedCheckout.order.statusURL]];
-				}
-				else {
-					NSLog(@"Couldn't redirect to thank you page: %@ (url: %@)", updatedCheckout, updatedCheckout.order.statusURL);
-				}
-			});
-		}];
-	}
-	else {
-		NSError *error = [NSError errorWithDomain:BUYShopifyError code:status userInfo:@{@"checkout": checkout}];
-		[self.delegate controller:self failedToCompleteCheckout:checkout withError:error];
-	}
+	[self.client getCheckout:checkout completion:^(BUYCheckout *updatedCheckout, NSError *error) {
+		dispatch_async(dispatch_get_main_queue(), ^{
+			if (updatedCheckout.order.statusURL) {
+				[_webView loadRequest:[NSURLRequest requestWithURL:updatedCheckout.order.statusURL]];
+			}
+			else {
+				NSLog(@"Couldn't redirect to thank you page: %@ (url: %@)", updatedCheckout, updatedCheckout.order.statusURL);
+			}
+		});
+	}];
 }
 
 #pragma mark - Web View Configuration

--- a/Mobile Buy SDK/Mobile Buy SDK/View Controllers/BUYViewController.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/View Controllers/BUYViewController.m
@@ -440,14 +440,8 @@ NSString * BUYURLKey = @"url";
 
 - (void)didReceiveCallbackURLNotification:(NSNotification *)notification
 {
-	NSURL *url = notification.userInfo[BUYURLKey];
-	
-	[self.client getCompletionStatusOfCheckoutURL:url completion:^(BUYStatus status, NSError *error) {
-		
-		[self checkoutCompleted:_checkout status:status];
-		
-		[[NSNotificationCenter defaultCenter] removeObserver:self name:BUYSafariCallbackURLNotification object:nil];
-	}];
+	[self checkoutCompleted:_checkout status:BUYStatusComplete];
+	[[NSNotificationCenter defaultCenter] removeObserver:self name:BUYSafariCallbackURLNotification object:nil];
 	
 	if (self.presentedViewController) {
 		[self dismissViewControllerAnimated:YES completion:nil];


### PR DESCRIPTION
#### What's happening
- Removing endpoints for polling checkout status
- Introduce new model `BUYPayment`, which wraps the checkout on completion and provide other possibly valuable information about the transaction
- Updating endpoints to new Checkout v2.0 endpoints
- Updating tests for new endpoints and lack of polling

#### Notes
-  Sample app is not fully updated with 2.0 changes

Fixes #125

@bgulanowski @davidmuzi 