### PR TITLE
Refactor payment provider

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYPaymentProviderTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYPaymentProviderTests.m
@@ -240,7 +240,7 @@
 {
 }
 
-- (void)paymentProvider:(id <BUYPaymentProvider>)provider didFailCheckoutWithError:(NSError *)error;
+- (void)paymentProvider:(id <BUYPaymentProvider>)provider didFailWithError:(NSError *)error;
 {
 	if (self.expectations[@"failedCheckout"]) {
 		[self.expectations[@"failedCheckout"] fulfill];

--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYApplePayPaymentProvider.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYApplePayPaymentProvider.m
@@ -100,8 +100,8 @@ NSString *const BUYApplePayPaymentProviderId = @"BUYApplePayPaymentProviderId";
 	[self.client getShop:^(BUYShop *theShop, NSError *error) {
 		
 		if (error) {
-			if ([self.delegate respondsToSelector:@selector(paymentProvider:didFailCheckoutWithError:)]) {
-				[self.delegate paymentProvider:self didFailCheckoutWithError:error];
+			if ([self.delegate respondsToSelector:@selector(paymentProvider:didFailWithError:)]) {
+				[self.delegate paymentProvider:self didFailWithError:error];
 			}
 			[[NSNotificationCenter defaultCenter] postNotificationName:BUYPaymentProviderDidFailCheckoutNotificationKey object:self];
 		}
@@ -115,8 +115,8 @@ NSString *const BUYApplePayPaymentProviderId = @"BUYApplePayPaymentProviderId";
 	dispatch_group_enter(group);
 	[self.client handleCheckout:checkout completion:^(BUYCheckout *checkout, NSError *error) {
 		if (error) {
-			if ([self.delegate respondsToSelector:@selector(paymentProvider:didFailCheckoutWithError:)]) {
-				[self.delegate paymentProvider:self didFailCheckoutWithError:error];
+			if ([self.delegate respondsToSelector:@selector(paymentProvider:didFailWithError:)]) {
+				[self.delegate paymentProvider:self didFailWithError:error];
 			}
 			[[NSNotificationCenter defaultCenter] postNotificationName:BUYPaymentProviderDidFailCheckoutNotificationKey object:self];
 		}
@@ -181,8 +181,8 @@ NSString *const BUYApplePayPaymentProviderId = @"BUYApplePayPaymentProviderId";
 		[self.delegate paymentProvider:self wantsControllerPresented:controller];
 	}
 	else {
-		if ([self.delegate respondsToSelector:@selector(paymentProvider:didFailCheckoutWithError:)]) {
-			[self.delegate paymentProvider:self didFailCheckoutWithError:nil];
+		if ([self.delegate respondsToSelector:@selector(paymentProvider:didFailWithError:)]) {
+			[self.delegate paymentProvider:self didFailWithError:nil];
 		}
 		[[NSNotificationCenter defaultCenter] postNotificationName:BUYPaymentProviderDidFailCheckoutNotificationKey object:self];
 	}
@@ -225,15 +225,15 @@ NSString *const BUYApplePayPaymentProviderId = @"BUYApplePayPaymentProviderId";
 		self.paymentAuthorizationStatus = status;
 		switch (status) {
 			case PKPaymentAuthorizationStatusFailure:
-				if ([self.delegate respondsToSelector:@selector(paymentProvider:didFailCheckoutWithError:)]) {
-					[self.delegate paymentProvider:self didFailCheckoutWithError:self.applePayHelper.lastError];
+				if ([self.delegate respondsToSelector:@selector(paymentProvider:didFailWithError:)]) {
+					[self.delegate paymentProvider:self didFailWithError:self.applePayHelper.lastError];
 				}
 				[[NSNotificationCenter defaultCenter] postNotificationName:BUYPaymentProviderDidFailCheckoutNotificationKey object:self];
 				break;
 				
 			case PKPaymentAuthorizationStatusInvalidShippingPostalAddress:
-				if ([self.delegate respondsToSelector:@selector(paymentProvider:didFailToUpdateCheckoutWithError:)]) {
-					[self.delegate paymentProvider:self didFailToUpdateCheckoutWithError:self.applePayHelper.lastError];
+				if ([self.delegate respondsToSelector:@selector(paymentProvider:didFailWithError:)]) {
+					[self.delegate paymentProvider:self didFailWithError:self.applePayHelper.lastError];
 				}
 				[[NSNotificationCenter defaultCenter] postNotificationName:BUYPaymentProviderDidFailToUpdateCheckoutNotificationKey object:self];
 				break;
@@ -263,8 +263,8 @@ NSString *const BUYApplePayPaymentProviderId = @"BUYApplePayPaymentProviderId";
 {
 	[self.applePayHelper paymentAuthorizationViewController:controller didSelectShippingMethod:shippingMethod completion:^(PKPaymentAuthorizationStatus status, NSArray<PKPaymentSummaryItem *> * _Nonnull summaryItems) {
 		if (status == PKPaymentAuthorizationStatusInvalidShippingPostalAddress) {
-			if ([self.delegate respondsToSelector:@selector(paymentProvider:didFailToUpdateCheckoutWithError:)]) {
-				[self.delegate paymentProvider:self didFailToUpdateCheckoutWithError:self.applePayHelper.lastError];
+			if ([self.delegate respondsToSelector:@selector(paymentProvider:didFailWithError:)]) {
+				[self.delegate paymentProvider:self didFailWithError:self.applePayHelper.lastError];
 			}
 			[[NSNotificationCenter defaultCenter] postNotificationName:BUYPaymentProviderDidFailToUpdateCheckoutNotificationKey object:self];
 		}
@@ -276,8 +276,8 @@ NSString *const BUYApplePayPaymentProviderId = @"BUYApplePayPaymentProviderId";
 {
 	[self.applePayHelper paymentAuthorizationViewController:controller didSelectShippingAddress:address completion:^(PKPaymentAuthorizationStatus status, NSArray<PKShippingMethod *> * _Nonnull shippingMethods, NSArray<PKPaymentSummaryItem *> * _Nonnull summaryItems) {
 		if (status == PKPaymentAuthorizationStatusInvalidShippingPostalAddress) {
-			if ([self.delegate respondsToSelector:@selector(paymentProvider:didFailToUpdateCheckoutWithError:)]) {
-				[self.delegate paymentProvider:self didFailToUpdateCheckoutWithError:self.applePayHelper.lastError];
+			if ([self.delegate respondsToSelector:@selector(paymentProvider:didFailWithError:)]) {
+				[self.delegate paymentProvider:self didFailWithError:self.applePayHelper.lastError];
 			}
 			[[NSNotificationCenter defaultCenter] postNotificationName:BUYPaymentProviderDidFailToUpdateCheckoutNotificationKey object:self];
 		}
@@ -289,8 +289,8 @@ NSString *const BUYApplePayPaymentProviderId = @"BUYApplePayPaymentProviderId";
 {
 	[self.applePayHelper paymentAuthorizationViewController:controller didSelectShippingContact:contact completion:^(PKPaymentAuthorizationStatus status, NSArray<PKShippingMethod *> * _Nonnull shippingMethods, NSArray<PKPaymentSummaryItem *> * _Nonnull summaryItems) {
 		if (status == PKPaymentAuthorizationStatusInvalidShippingPostalAddress) {
-			if ([self.delegate respondsToSelector:@selector(paymentProvider:didFailToUpdateCheckoutWithError:)]) {
-				[self.delegate paymentProvider:self didFailToUpdateCheckoutWithError:self.applePayHelper.lastError];
+			if ([self.delegate respondsToSelector:@selector(paymentProvider:didFailWithError:)]) {
+				[self.delegate paymentProvider:self didFailWithError:self.applePayHelper.lastError];
 			}
 			[[NSNotificationCenter defaultCenter] postNotificationName:BUYPaymentProviderDidFailToUpdateCheckoutNotificationKey object:self];
 		}

--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYPaymentProvider.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYPaymentProvider.h
@@ -80,7 +80,7 @@ extern NSString *const BUYPaymentProviderDidCompleteCheckoutNotificationKey;
  *  @param provider   the `BUYPaymentProvider`
  *  @param error    the optional `NSError`
  */
-- (void)paymentProvider:(id <BUYPaymentProvider>)provider didFailWithError:(NSError *)error;
+- (void)paymentProvider:(id <BUYPaymentProvider>)provider didFailWithError:(nullable NSError *)error;
 
 /**
  *  Called when the checkout has completed

--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYPaymentProvider.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYPaymentProvider.h
@@ -75,20 +75,12 @@ extern NSString *const BUYPaymentProviderDidCompleteCheckoutNotificationKey;
 - (void)paymentProviderDidDismissCheckout:(id <BUYPaymentProvider>)provider;
 
 /**
- *  Called when a checkout failed to update
+ *  Called when a checkout payment operation has failed
  *
  *  @param provider   the `BUYPaymentProvider`
  *  @param error    the optional `NSError`
  */
-- (void)paymentProvider:(id <BUYPaymentProvider>)provider didFailToUpdateCheckoutWithError:(NSError *)error;
-
-/**
- *  Called when the checkout failed
- *
- *  @param provider   the `BUYPaymentProvider`
- *  @param error    the optional `NSError`
- */
-- (void)paymentProvider:(id <BUYPaymentProvider>)provider didFailCheckoutWithError:(NSError * _Nullable)error;
+- (void)paymentProvider:(id <BUYPaymentProvider>)provider didFailWithError:(NSError *)error;
 
 /**
  *  Called when the checkout has completed

--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYWebCheckoutPaymentProvider.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYWebCheckoutPaymentProvider.m
@@ -128,8 +128,8 @@ static NSString *const WebCheckoutCustomerAccessToken = @"customer_access_token"
 		[self openWebCheckout:checkout];
 	}
 	else {
-		if ([self.delegate respondsToSelector:@selector(paymentProvider:didFailCheckoutWithError:)]) {
-			[self.delegate paymentProvider:self didFailCheckoutWithError:error];
+		if ([self.delegate respondsToSelector:@selector(paymentProvider:didFailWithError:)]) {
+			[self.delegate paymentProvider:self didFailWithError:error];
 		}
 		[[NSNotificationCenter defaultCenter] postNotificationName:BUYPaymentProviderDidFailCheckoutNotificationKey object:self];
 		


### PR DESCRIPTION
## What
- Small change to method naming in `<BUYPaymentProviderDelegate>`
- Breaks up checkout error parsing into smaller methods

@bgulanowski @dbart01 @davidmuzi 