### PR TITLE
Add separate network request queue to avoid deadlock. Minor refactor.

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.h
@@ -96,11 +96,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nonnull) BUYModelManager *modelManager;
 
 /**
- *  Queue on which all request operation are executed
- */
-@property (nonatomic, strong, readonly, nonnull) NSOperationQueue *requestQueue;
-
-/**
  *  Queue on which network completion callbacks will be executed
  */
 @property (nonatomic, strong, nonnull) NSOperationQueue *callbackQueue;

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.m
@@ -34,7 +34,7 @@ static NSString * const BUYClientJSONMimeType = @"application/json";
 @interface BUYClient () <NSURLSessionDelegate>
 
 @property (nonatomic, strong) NSURLSession *session;
-@property (nonatomic, strong) NSOperationQueue *networkQueue;
+@property (nonatomic, strong) NSOperationQueue *requestQueue;
 
 @end
 
@@ -62,7 +62,6 @@ static NSString * const BUYClientJSONMimeType = @"application/json";
 		
 		_callbackQueue = [NSOperationQueue mainQueue];
 		_requestQueue  = [NSOperationQueue new];
-		_networkQueue  = [NSOperationQueue new];
 		
 		_session       = [self urlSession];
 		_pageSize      = 25;
@@ -96,7 +95,7 @@ static NSString * const BUYClientJSONMimeType = @"application/json";
 	NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
 	config.HTTPAdditionalHeaders      = [self additionalHeaders];
 	
-	return [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:self.networkQueue];
+	return [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:nil];
 }
 
 - (void)setPageSize:(NSUInteger)pageSize

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.m
@@ -34,6 +34,7 @@ static NSString * const BUYClientJSONMimeType = @"application/json";
 @interface BUYClient () <NSURLSessionDelegate>
 
 @property (nonatomic, strong) NSURLSession *session;
+@property (nonatomic, strong) NSOperationQueue *networkQueue;
 
 @end
 
@@ -54,17 +55,38 @@ static NSString * const BUYClientJSONMimeType = @"application/json";
 	
 	self = [super init];
 	if (self) {
-		_modelManager = [BUYModelManager modelManager];
-		_shopDomain = shopDomain;
-		_apiKey = apiKey;
-		_appId = appId;
-		_applicationName = [[NSBundle mainBundle] infoDictionary][@"CFBundleName"] ?: @"";
+		_modelManager  = [BUYModelManager modelManager];
+		_shopDomain    = shopDomain;
+		_apiKey        = apiKey;
+		_appId         = appId;
+		
 		_callbackQueue = [NSOperationQueue mainQueue];
-		_requestQueue = [NSOperationQueue new];
-		_session = [self urlSession];
-		_pageSize = 25;
+		_requestQueue  = [NSOperationQueue new];
+		_networkQueue  = [NSOperationQueue new];
+		
+		_session       = [self urlSession];
+		_pageSize      = 25;
 	}
 	return self;
+}
+
+#pragma mark - Headers -
+
+- (NSString *)applicationName
+{
+	return [[NSBundle mainBundle] infoDictionary][@"CFBundleName"] ?: @"";
+}
+
+- (NSString *)bundleIdentifier
+{
+	return [[NSBundle mainBundle] bundleIdentifier];
+}
+
+- (NSDictionary *)additionalHeaders
+{
+	return @{
+			 @"User-Agent": [NSString stringWithFormat:@"Mobile Buy SDK iOS/%@/%@", BUYClientVersionString, [self bundleIdentifier]]
+			 };
 }
 
 #pragma mark - Accessors -
@@ -72,12 +94,9 @@ static NSString * const BUYClientJSONMimeType = @"application/json";
 - (NSURLSession *)urlSession
 {
 	NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
+	config.HTTPAdditionalHeaders      = [self additionalHeaders];
 	
-	NSString *bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
-	
-	config.HTTPAdditionalHeaders = @{@"User-Agent": [NSString stringWithFormat:@"Mobile Buy SDK iOS/%@/%@", BUYClientVersionString, bundleIdentifier]};
-	
-	return [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:self.requestQueue];
+	return [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:self.networkQueue];
 }
 
 - (void)setPageSize:(NSUInteger)pageSize
@@ -89,23 +108,20 @@ static NSString * const BUYClientJSONMimeType = @"application/json";
 
 - (BUYStatus)statusForStatusCode:(NSUInteger)statusCode error:(NSError *)error
 {
-	BUYStatus status = BUYStatusUnknown;
-	if (statusCode == BUYStatusPreconditionFailed) {
-		status = BUYStatusPreconditionFailed;
+	switch ((BUYStatus)statusCode) {
+		case BUYStatusPreconditionFailed: return BUYStatusPreconditionFailed;
+		case BUYStatusNotFound:           return BUYStatusNotFound;
+		case BUYStatusFailed:             return BUYStatusFailed;
+		case BUYStatusProcessing:	      return BUYStatusProcessing;
+		case BUYStatusComplete:           return BUYStatusComplete;
+		default: {
+			if (error) {
+				return BUYStatusFailed;
+			} else {
+				return BUYStatusUnknown;
+			}
+		}
 	}
-	else if (statusCode == BUYStatusNotFound) {
-		status = BUYStatusNotFound;
-	}
-	else if (error || statusCode == BUYStatusFailed) {
-		status = BUYStatusFailed;
-	}
-	else if (statusCode == BUYStatusProcessing) {
-		status = BUYStatusProcessing;
-	}
-	else if (statusCode == BUYStatusComplete) {
-		status = BUYStatusComplete;
-	}
-	return status;
 }
 
 - (NSError *)errorFromJSON:(NSDictionary *)json response:(NSURLResponse *)response


### PR DESCRIPTION
### What this does
- adds a separate, private network queue for `NSURLSessionDataTask` requests
- minor refactoring and cleanup

Fixes #190 

@bgulanowski @davidmuzi 