### PR TITLE
Add missing product handle API.

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClientTest_Storefront.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClientTest_Storefront.m
@@ -97,6 +97,25 @@
 	}];
 }
 
+- (void)testGetProductByHandle
+{
+	[OHHTTPStubs stubUsingResponseWithKey:@"testGetProduct_0" useMocks:[self shouldUseMocks]];
+	
+	NSString *handle = @"actinian-fur-hat";
+	
+	XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
+	[self.client getProductByHandle:handle completion:^(BUYProduct *product, NSError *error) {
+		
+		XCTAssertNil(error);
+		XCTAssertNotNil(product);
+		XCTAssertEqualObjects(product.handle, handle);
+		
+		[expectation fulfill];
+	}];
+	
+	[self waitForExpectationsWithTimeout:10 handler:nil];
+}
+
 - (void)testGetProductById
 {
 	[OHHTTPStubs stubUsingResponseWithKey:@"testGetProduct_0" useMocks:[self shouldUseMocks]];

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.h
@@ -141,6 +141,16 @@ typedef void (^BUYDataProductListBlock)(NSArray<BUYProduct *> * _Nullable produc
 - (BUYRequestOperation *)getProductsPage:(NSUInteger)page completion:(BUYDataProductListBlock)block;
 
 /**
+ *  Fetches a single product by the handle of the product.
+ *
+ *  @param handle  Product handle
+ *  @param block   (^BUYDataProductBlock)(BUYProduct *product, NSError *error);
+ *
+ *  @return The associated BUYRequestOperation
+ */
+- (BUYRequestOperation *)getProductByHandle:(NSString *)handle completion:(BUYDataProductBlock)block;
+
+/**
  *  Fetches a single product by the ID of the product.
  *
  *  @param productId Product ID


### PR DESCRIPTION
### What this does
- adds missing API that allows fetching a product by its unique `handle`
- adds integration test for product handle API

Fixes #194 
Relies on #204

@bgulanowski @davidmuzi 