### PR TITLE
Fix equality test in BUYOptionValue

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYOptionValue.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYOptionValue.m
@@ -30,7 +30,7 @@
 
 - (BOOL)isEqualToOptionValue:(BUYOptionValue *)other
 {
-	return [other isKindOfClass:[self class]] && [self.name isEqual:other.name] && [self.optionId isEqual:other.optionId];
+	return [other isKindOfClass:[self class]] && [self.name isEqual:other.name] && [self.value isEqual:other.value];
 }
 
 #if !defined CORE_DATA_PERSISTENCE
@@ -42,7 +42,7 @@
 - (NSUInteger)hash
 {
 	NSUInteger hash = self.name.hash;
-	return ((hash << 5) + hash) + self.optionId.hash;
+	return ((hash << 5) + hash) + self.value.hash;
 }
 #endif
 


### PR DESCRIPTION
# What

This changes the test for equality in BUYOptionValue.

# Why

Without it, different values for the same option look equal, meaning some options will not show up with added to a set. A consequence was that in the Advanced Sample, all products show only one option.

# How

Use the `value`, not the `optionId` (which is basically equivalent to using the `name`, since both refer to properties on the related `BUYOption`).

@dbart01 @davidmuzi @gabo