### PR TITLE
Add typed collection for Swift support.

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYCart.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYCart.h
@@ -27,8 +27,16 @@
 #import "_BUYCart.h"
 
 @class BUYProductVariant;
+@class BUYLineItem;
 
 @interface BUYCart : _BUYCart {}
+
+/**
+ * Array of BUYCartLineItem objects in the cart
+ *
+ * These are different from BUYLineItem objects. The line item objects do include the BUYProductVariant.
+ */
+- (nonnull NSArray<BUYCartLineItem *> *)lineItemsArray;
 
 /**
  *  Returns true if the cart is acceptable to send to Shopify.

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYCart.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYCart.m
@@ -40,8 +40,13 @@
 	}
 	return self;
 }
-
 #endif
+
+- (nonnull NSArray<BUYCartLineItem *> *)lineItemsArray
+{
+	return self.lineItems.array;
+}
+
 - (BOOL)isValid
 {
 	return [self.lineItems count] > 0;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYCollection.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYCollection.h
@@ -31,6 +31,8 @@
 
 @property (nonatomic, readonly) NSString *stringDescription;
 
+- (NSArray<BUYProduct *> *)productsArray;
+
 /**
  *  Converts the BUYCollectionSort enum to an API-compatible string for the collection sort parameter
  *

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYCollection.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYCollection.m
@@ -32,6 +32,11 @@
 
 @synthesize stringDescription = _stringDescription;
 
+- (NSArray<BUYProduct *> *)productsArray
+{
+	return self.products.array;
+}
+
 - (void)updateStringDescription
 {
 	// Force early cache of this value to prevent spooky behaviour

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYOrder.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYOrder.h
@@ -28,6 +28,8 @@
 
 @interface BUYOrder : _BUYOrder {}
 
+- (NSArray<BUYLineItem *> *)lineItemsArray;
+
 @end
 
 @interface BUYModelManager (BUYOrder)

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYOrder.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYOrder.m
@@ -29,6 +29,11 @@
 
 @implementation BUYOrder
 
+- (NSArray<BUYLineItem *> *)lineItemsArray
+{
+	return self.lineItems.array;
+}
+
 - (NSArray *)formatIDsForLineItemsJSON:(NSArray<NSDictionary *> *)lineItems
 {
 	__block NSMutableArray<NSDictionary *> *mutableLineItems = [NSMutableArray array];

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYProduct.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYProduct.h
@@ -33,6 +33,23 @@
 @property (nonatomic, readonly, copy) NSDate *publishedAtDate;
 @property (nonatomic, readonly, copy) NSString *stringDescription;
 
+/**
+ * An array of BUYImageLink objects, each one representing an image associated with the product.
+ */
+- (NSArray<BUYImageLink *> *)imagesArray;
+
+/**
+ * Custom product property names like "Size", "Color", and "Material".
+ *
+ * An array of BUYOption objects. Products are based on permutations of these options. A product may have a maximum of 3 options. 255 characters limit each.
+ */
+- (NSArray<BUYOption *> *)optionsArray;
+
+/**
+ * An array of BUYProductVariant objects, each one representing a slightly different version of the product.
+ */
+- (NSArray<BUYProductVariant *> *)variantsArray;
+
 @end
 
 @interface BUYProduct (Options)

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYProduct.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYProduct.m
@@ -58,6 +58,21 @@
 	return _stringDescription;
 }
 
+- (NSArray<BUYImageLink *> *)imagesArray
+{
+	return self.images.array;
+}
+
+- (NSArray<BUYOption *> *)optionsArray
+{
+	return self.options.array;
+}
+
+- (NSArray<BUYProductVariant *> *)variantsArray
+{
+	return self.variants.array;
+}
+
 @end
 
 @implementation BUYProduct (Options)

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYCheckout.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYCheckout.h
@@ -42,6 +42,9 @@
 - (instancetype)initWithModelManager:(id<BUYModelManager>)modelManager cart:(BUYCart *)cart;
 - (instancetype)initWithModelManager:(id<BUYModelManager>)modelManager cartToken:(NSString *)token;
 
+- (NSArray<BUYGiftCard *> *)giftCardsArray;
+- (NSArray<BUYCartLineItem *> *)lineItemsArray;
+
 - (void)updateWithCart:(BUYCart *)cart;
 
 - (BUYGiftCard *)giftCardWithIdentifier:(NSNumber *)identifier;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYCheckout.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYCheckout.m
@@ -66,7 +66,8 @@
 	[super setShippingRate:shippingRate];
 	self.shippingRateId = shippingRate.shippingRateIdentifier;
 }
--(void)setPartialAddresses:(NSNumber *)partialAddresses
+
+- (void)setPartialAddresses:(NSNumber *)partialAddresses
 {
 	if (partialAddresses.boolValue == NO) {
 		@throw [NSException exceptionWithName:@"partialAddress" reason:@"partialAddresses can only be set to true and should never be set to false on a complete address" userInfo:nil];
@@ -74,6 +75,7 @@
 	[ super setPartialAddresses:partialAddresses];
 }
 
+#pragma mark - Init -
 
 /**
  * We must initialize to-many relationships to ensure that
@@ -112,6 +114,20 @@
 	return self;
 }
 
+#pragma mark - Accessors -
+
+- (NSArray<BUYGiftCard *> *)giftCardsArray
+{
+	return self.giftCards.array;
+}
+
+- (NSArray<BUYCartLineItem *> *)lineItemsArray
+{
+	return self.lineItems.array;
+}
+
+#pragma mark - Update -
+
 - (void)updateWithCart:(BUYCart *)cart
 {
 	NSArray *lineItems = [[cart.lineItems array] buy_map:^id(BUYCartLineItem *cartLineItem) {
@@ -122,7 +138,7 @@
 	self.lineItems = [NSOrderedSet orderedSetWithArray:lineItems];
 }
 
-#pragma mark - BUYObject
+#pragma mark - BUYObject -
 
 - (NSDictionary *)JSONEncodedProperties
 {
@@ -139,7 +155,7 @@
 	return @{ @"checkout" : json };
 }
 
-#pragma mark - Gift Card management
+#pragma mark - Gift Card management -
 
 - (BUYGiftCard *)giftCardWithIdentifier:(NSNumber *)identifier
 {

--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYPaymentController.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYPaymentController.h
@@ -37,6 +37,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) NSOrderedSet <id <BUYPaymentProvider>> *providers;
 
 /**
+ *  The registered payment providers
+ */
+- (NSArray< id<BUYPaymentProvider> > *)providersArray;
+
+/**
  *  Register a payment provider
  *
  *  @param paymentProvider a payment provider

--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYPaymentController.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYPaymentController.m
@@ -38,6 +38,29 @@ NSString *const BUYPaymentProviderDidCompleteCheckoutNotificationKey = @"BUYPaym
 
 @implementation BUYPaymentController
 
+#pragma mark - Accessors -
+
+- (NSSet <id <BUYPaymentProvider>> *)providers
+{
+	return [self.mutableProviders copy];
+}
+
+- (NSArray< id<BUYPaymentProvider> > *)providersArray
+{
+	return self.mutableProviders.array;
+}
+
+- (NSMutableOrderedSet *)mutableProviders
+{
+	if (_mutableProviders == nil) {
+		_mutableProviders = [[NSMutableOrderedSet alloc] init];
+	}
+	
+	return _mutableProviders;
+}
+
+#pragma mark - Tasks -
+
 - (void)startCheckout:(BUYCheckout *)checkout withProviderType:(NSString *)typeIdentifier;
 {
 	id <BUYPaymentProvider> provider = [self providerForType:typeIdentifier];
@@ -51,20 +74,6 @@ NSString *const BUYPaymentProviderDidCompleteCheckoutNotificationKey = @"BUYPaym
 	}
 	
 	[self.mutableProviders addObject:paymentProvider];
-}
-
-- (NSSet <id <BUYPaymentProvider>> *)providers
-{
-	return [self.mutableProviders copy];
-}
-
-- (NSMutableOrderedSet *)mutableProviders
-{
-	if (_mutableProviders == nil) {
-		_mutableProviders = [[NSMutableOrderedSet alloc] init];
-	}
-	
-	return _mutableProviders;
 }
 
 - (id <BUYPaymentProvider>)providerForType:(NSString *)type


### PR DESCRIPTION
### What this does
Using `CoreData` models required the use of `NSOrderedSet` for certain ordered collections. Since `NSOrderedSet` doesn't have a typed equivalent in Swift, none of the type information transfers over to Swift, making it very inconvenient to use those properties. Here, what we do is:
- add typed collections for `NSOrderedSet` properties

@bgulanowski @davidmuzi 