### PR TITLE
Allow nil predicate in in Model Manager API

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYModelManagerProtocol.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYModelManagerProtocol.h
@@ -107,7 +107,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return YES if the purge was successful. NO if there was a problem.
  */
-- (BOOL)buy_purgeObjectsWithEntityName:(NSString *)entityName matchingPredicate:(NSPredicate *)predicate;
+- (BOOL)buy_purgeObjectsWithEntityName:(NSString *)entityName matchingPredicate:(nullable NSPredicate *)predicate;
 
 @end
 


### PR DESCRIPTION
Passing a nil predicate to the fetch request created in `-buy_purgeObjectsWithEntityName:` is legal.
@dbart01 @bgulanowski 