### PR TITLE
Improve support in private methods

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK.xcodeproj/project.pbxproj
+++ b/Mobile Buy SDK/Mobile Buy SDK.xcodeproj/project.pbxproj
@@ -250,6 +250,7 @@
 		9A6C1D421D07485F00BFF4F9 /* BUYStatusOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A6C1D401D07485F00BFF4F9 /* BUYStatusOperation.m */; };
 		9A6C1D451D0749FC00BFF4F9 /* BUYGroupOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A6C1D431D0749FC00BFF4F9 /* BUYGroupOperation.h */; };
 		9A6C1D461D0749FC00BFF4F9 /* BUYGroupOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A6C1D441D0749FC00BFF4F9 /* BUYGroupOperation.m */; };
+		9A6C1DC41D089E4700BFF4F9 /* BUYClientTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A6C1DC31D089E4700BFF4F9 /* BUYClientTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9A7652C31CF487BD00220E4B /* BUYOperationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A7652C21CF487BD00220E4B /* BUYOperationTests.m */; };
 		9A807E841CF74EBE00023160 /* BUYClient+Address.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A807E811CF74EBE00023160 /* BUYClient+Address.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9A807E861CF74EBE00023160 /* BUYClient+Address.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A807E821CF74EBE00023160 /* BUYClient+Address.m */; };
@@ -496,6 +497,7 @@
 		9A6C1D401D07485F00BFF4F9 /* BUYStatusOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BUYStatusOperation.m; sourceTree = "<group>"; };
 		9A6C1D431D0749FC00BFF4F9 /* BUYGroupOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BUYGroupOperation.h; sourceTree = "<group>"; };
 		9A6C1D441D0749FC00BFF4F9 /* BUYGroupOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BUYGroupOperation.m; sourceTree = "<group>"; };
+		9A6C1DC31D089E4700BFF4F9 /* BUYClientTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BUYClientTypes.h; sourceTree = "<group>"; };
 		9A7652C21CF487BD00220E4B /* BUYOperationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BUYOperationTests.m; sourceTree = "<group>"; };
 		9A807E811CF74EBE00023160 /* BUYClient+Address.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "BUYClient+Address.h"; sourceTree = "<group>"; };
 		9A807E821CF74EBE00023160 /* BUYClient+Address.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "BUYClient+Address.m"; sourceTree = "<group>"; };
@@ -1038,6 +1040,7 @@
 			isa = PBXGroup;
 			children = (
 				8498DCB01CDD1B4A00BD12A8 /* BUYClient+Internal.h */,
+				9A6C1DC31D089E4700BFF4F9 /* BUYClientTypes.h */,
 				F7FDA17019C93F6F00AF4E93 /* BUYClient.h */,
 				F7FDA17119C93F6F00AF4E93 /* BUYClient.m */,
 				9A0B0C641CEA703E0037D68F /* BUYClient+Routing.h */,
@@ -1147,6 +1150,7 @@
 				9A585C0B1CE6440B001F20F0 /* BUYOperation.h in Headers */,
 				9A0B0C791CEB5BBD0037D68F /* BUYAuthenticatedResponse.h in Headers */,
 				849810971CB7E07900CFAB58 /* BUYFlatCollectionTransformer.h in Headers */,
+				9A6C1DC41D089E4700BFF4F9 /* BUYClientTypes.h in Headers */,
 				901931641BC5B9BC00D1134E /* BUYCartLineItem.h in Headers */,
 				8498DCAE1CDD1B2F00BD12A8 /* BUYError+BUYAdditions.h in Headers */,
 				901931661BC5B9BC00D1134E /* BUYCheckout.h in Headers */,

--- a/Mobile Buy SDK/Mobile Buy SDK/Buy.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Buy.h
@@ -62,6 +62,7 @@ FOUNDATION_EXPORT const unsigned char BuyVersionString[];
 #import <Buy/BUYPaymentProvider.h>
 #import <Buy/BUYWebCheckoutPaymentProvider.h>
 
+#import <Buy/BUYClientTypes.h>
 #import <Buy/BUYClient.h>
 #import <Buy/BUYClient+Address.h>
 #import <Buy/BUYClient+Customers.h>

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Checkout.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Checkout.m
@@ -153,11 +153,9 @@
 	}];
 }
 
-- (NSOperation *)pollCompletionStatusAndGetCheckoutWithToken:(NSString *)token start:(BOOL)start completion:(BUYDataCheckoutBlock)block
+- (NSOperation *)pollCompletionStatusAndGetCheckoutWithToken:(NSString *)token start:(BOOL)start completion:(BUYCheckoutStatusOperationCompletion)block
 {
-	BUYStatusOperation *operation = [BUYStatusOperation operationWithClient:self checkoutToken:token completion:^(BUYStatus status, BUYCheckout *checkout, NSError *error) {
-		block(checkout, error);
-	}];
+	BUYStatusOperation *operation = [BUYStatusOperation operationWithClient:self checkoutToken:token completion:block];
 	if (start) {
 		[self startOperation:operation];
 	}

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Checkout.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Checkout.m
@@ -155,7 +155,9 @@
 
 - (NSOperation *)pollCompletionStatusAndGetCheckoutWithToken:(NSString *)token start:(BOOL)start completion:(BUYDataCheckoutBlock)block
 {
-	BUYStatusOperation *operation = [BUYStatusOperation operationWithClient:self checkoutToken:token completion:block];
+	BUYStatusOperation *operation = [BUYStatusOperation operationWithClient:self checkoutToken:token completion:^(BUYStatus status, BUYCheckout *checkout, NSError *error) {
+		block(checkout, error);
+	}];
 	if (start) {
 		[self startOperation:operation];
 	}

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Internal.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Internal.h
@@ -37,7 +37,7 @@ typedef void (^BUYClientRequestJSONCompletion)(NSDictionary *json, NSHTTPURLResp
 
 @property (nonatomic, strong) NSOperationQueue *requestQueue;
 
-- (NSOperation *)pollCompletionStatusAndGetCheckoutWithToken:(NSString *)token start:(BOOL)start completion:(BUYDataCheckoutBlock)block;
+- (NSOperation *)pollCompletionStatusAndGetCheckoutWithToken:(NSString *)token start:(BOOL)start completion:(BUYCheckoutStatusOperationCompletion)block;
 
 - (NSOperation *)getRequestForURL:(NSURL *)url    completionHandler:(BUYClientRequestJSONCompletion)completionHandler;
 - (NSOperation *)deleteRequestForURL:(NSURL *)url completionHandler:(BUYClientRequestJSONCompletion)completionHandler;

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.h
@@ -25,49 +25,11 @@
 //
 
 @import Foundation;
+#import "BUYClientTypes.h"
 
 @class BUYModelManager;
 @class BUYOperation;
 @class BUYRequestOperation;
-
-/**
- *  A BUYStatus is associated with the completion of an enqueued job on Shopify.
- *  BUYStatus is equal is HTTP status codes returned from the server
- */
-typedef NS_ENUM(NSUInteger, BUYStatus) {
-	/**
-	 *  The job is complete
-	 */
-	BUYStatusComplete = 200,
-	/**
-	 *  The job is still processing
-	 */
-	BUYStatusProcessing = 202,
-	/**
-	 *  The job is not found, please check the identifier
-	 */
-	BUYStatusNotFound = 404,
-	/**
-	 *  The precondition given in one or more of the request-header fields evaluated to false when it was tested on the server.
-	 */
-	BUYStatusPreconditionFailed = 412,
-	/**
-	 *  The request failed, refer to an NSError for details
-	 */
-	BUYStatusFailed = 424,
-	/**
-	 *  The status is unknown
-	 */
-	BUYStatusUnknown
-};
-
-/**
- *  Return block containing a BUYCheckout, a BUYStatus and/or an NSError
- *
- *  @param status   A BUYStatus specifying the requested job's completion status
- *  @param error    Optional NSError
- */
-typedef void (^BUYDataStatusBlock)(BUYStatus status, NSError * _Nullable error);
 
 /**
  The BUYDataClient provides all requests needed to perform request on the Shopify Checkout API.

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClientTypes.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClientTypes.h
@@ -1,0 +1,83 @@
+//
+//  BUYClientTypes.h
+//  Mobile Buy SDK
+//
+//  Created by Shopify.
+//  Copyright (c) 2015 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+@class BUYCheckout;
+
+/**
+ *  A BUYStatus is associated with the completion of an enqueued job on Shopify.
+ *  BUYStatus is equal is HTTP status codes returned from the server
+ */
+typedef NS_ENUM(NSUInteger, BUYStatus) {
+	/**
+	 *  The job is complete
+	 */
+	BUYStatusComplete = 200,
+	/**
+	 *  The job is still processing
+	 */
+	BUYStatusProcessing = 202,
+	/**
+	 *  The job is not found, please check the identifier
+	 */
+	BUYStatusNotFound = 404,
+	/**
+	 *  The precondition given in one or more of the request-header fields evaluated to false when it was tested on the server.
+	 */
+	BUYStatusPreconditionFailed = 412,
+	/**
+	 *  The request failed, refer to an NSError for details
+	 */
+	BUYStatusFailed = 424,
+	/**
+	 *  The status is unknown
+	 */
+	BUYStatusUnknown
+};
+
+/**
+ *  Return block containing a BUYStatus and/or an NSError
+ *
+ *  @param status   A BUYStatus specifying the requested job's completion status
+ *  @param error    Optional NSError
+ */
+typedef void (^BUYDataStatusBlock)(BUYStatus status, NSError * _Nullable error);
+
+/**
+ *  Return block containing a BUYCheckout and an NSError
+ *
+ *  @param checkout A BUYCheckout object
+ *  @param error    Optional NSError
+ */
+typedef void (^BUYCheckoutOperationCompletion)(BUYCheckout * _Nullable checkout, NSError * _Nullable error);
+
+/**
+ *  Return block containing a BUYStatus, a BUYCheckout and/or an NSError
+ *
+ *  @param status   A BUYStatus specifying the requested job's completion status
+ *  @param checkout A BUYCheckout object
+ *  @param error    Optional NSError
+ */
+typedef void (^BUYCheckoutStatusOperationCompletion)(BUYStatus status, BUYCheckout * _Nullable checkout, NSError * _Nullable error);

--- a/Mobile Buy SDK/Mobile Buy SDK/Operations/BUYCheckoutOperation.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Operations/BUYCheckoutOperation.h
@@ -33,6 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol BUYPaymentToken;
 
+typedef void (^BUYCheckoutOperationCompletion)(BUYCheckout * _Nullable checkout, NSError * _Nullable error);
+
 @interface BUYCheckoutOperation : BUYGroupOperation
 
 + (instancetype)operationWithClient:(BUYClient *)client checkoutToken:(NSString *)checkoutToken token:(id<BUYPaymentToken>)token completion:(BUYCheckoutOperationCompletion)completion;

--- a/Mobile Buy SDK/Mobile Buy SDK/Operations/BUYCheckoutOperation.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Operations/BUYCheckoutOperation.h
@@ -26,14 +26,13 @@
 
 #import <Buy/BUYGroupOperation.h>
 #import <Buy/BUYStatusOperation.h>
+#import <Buy/BUYClientTypes.h>
 NS_ASSUME_NONNULL_BEGIN
 
 @class BUYClient;
 @class BUYCheckout;
 
 @protocol BUYPaymentToken;
-
-typedef void (^BUYCheckoutOperationCompletion)(BUYCheckout * _Nullable checkout, NSError * _Nullable error);
 
 @interface BUYCheckoutOperation : BUYGroupOperation
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Operations/BUYCheckoutOperation.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Operations/BUYCheckoutOperation.m
@@ -112,7 +112,7 @@
 
 - (NSOperation *)createStatusOperation
 {
-	return [self.client pollCompletionStatusAndGetCheckoutWithToken:self.checkoutToken start:NO completion:^(BUYCheckout *checkout, NSError *error) {
+	return [self.client pollCompletionStatusAndGetCheckoutWithToken:self.checkoutToken start:NO completion:^(BUYStatus status, BUYCheckout *checkout, NSError *error) {
 		if (checkout) {
 			[self finishWithObject:checkout];
 		} else {

--- a/Mobile Buy SDK/Mobile Buy SDK/Operations/BUYStatusOperation.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Operations/BUYStatusOperation.h
@@ -26,11 +26,10 @@
 
 #import "BUYGroupOperation.h"
 #import "BUYClient.h"
+#import "BUYClientTypes.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @class BUYCheckout;
-
-typedef void (^BUYCheckoutStatusOperationCompletion)(BUYStatus status, BUYCheckout * _Nullable checkout, NSError * _Nullable error);
 
 @interface BUYStatusOperation : BUYGroupOperation
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Operations/BUYStatusOperation.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Operations/BUYStatusOperation.h
@@ -25,17 +25,17 @@
 //
 
 #import "BUYGroupOperation.h"
+#import "BUYClient.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @class BUYCheckout;
-@class BUYClient;
 
-typedef void (^BUYCheckoutOperationCompletion)(BUYCheckout * _Nullable checkout, NSError * _Nullable error);
+typedef void (^BUYCheckoutStatusOperationCompletion)(BUYStatus status, BUYCheckout * _Nullable checkout, NSError * _Nullable error);
 
 @interface BUYStatusOperation : BUYGroupOperation
 
-+ (instancetype)operationWithClient:(BUYClient *)client checkoutToken:(NSString *)checkoutToken completion:(BUYCheckoutOperationCompletion)completion;
-- (instancetype)initWithClient:(BUYClient *)client checkoutToken:(NSString *)checkoutToken completion:(BUYCheckoutOperationCompletion)completion;
++ (instancetype)operationWithClient:(BUYClient *)client checkoutToken:(NSString *)checkoutToken completion:(BUYCheckoutStatusOperationCompletion)completion;
+- (instancetype)initWithClient:(BUYClient *)client checkoutToken:(NSString *)checkoutToken completion:(BUYCheckoutStatusOperationCompletion)completion;
 
 @end
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Static Framework/Buy.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Static Framework/Buy.h
@@ -58,6 +58,7 @@
 #import "BUYPaymentProvider.h"
 #import "BUYWebCheckoutPaymentProvider.h"
 
+#import "BUYClientTypes.h"
 #import "BUYClient.h"
 #import "BUYClient+Address.h"
 #import "BUYClient+Customers.h"


### PR DESCRIPTION
### What this does
- adds status to `BUYStatusOperation` completion for internal use
- moves `BUYClient` types into separate header

@bgulanowski @gabrieloc 