### PR TITLE
Mark buy_emailFromRecord as deprecated

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayAdditions.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayAdditions.h
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface BUYAddress (ApplePay)
 
-+ (nullable NSString *)buy_emailFromRecord:(nullable ABRecordRef)record;
++ (nullable NSString *)buy_emailFromRecord:(nullable ABRecordRef)record NS_DEPRECATED_IOS(8_0, 9_0, "Use the `emailAddress` from the PKContact object instead");
 
 - (void)updateWithRecord:(nullable ABRecordRef)record NS_DEPRECATED_IOS(8_0, 9_0, "Use the CNContact backed `updateWithContact:` instead");
 


### PR DESCRIPTION
The `buy_emailFromRecord:` method in BUYApplePayAdditions.h uses `ABRecordRef` which is deprecated by Apple as of iOS 9.0. Similar methods in the header are marked as deprecated but it looks like this one was missed. This PR just adds the proper deprecation markers so Xcode doesn't complain when using the framework on a iOS 9.0+ project.

Looking at what the method was doing, I don't believe a `buy_` replacement is necessary. Getting the email address from a `PKContact` is a single property access, as opposed to `ABRecordRef` which is lots of fun to get stuff out of.

Please review @bgulanowski 