### PR TITLE
Assign inverse values for 1-to-1 and 1-to-N relationships

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYCoreDataModelAdditionsTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYCoreDataModelAdditionsTests.m
@@ -199,8 +199,9 @@ static NSString * const RootEntity = @"Root";
 	Branch *branch = [self.modelManager buy_objectWithEntityName:BranchEntity JSONDictionary:nil];
 	NSRelationshipDescription *nestRelationship = [self relationshipWithName:@"nest" forEntity:BranchEntity];
 	NSDictionary *expected = @{ @"egg_count" : @2 };
-	id<BUYObject> object = [nestRelationship buy_valueForJSON:expected object:branch];
-	NSDictionary *actual = [nestRelationship buy_JSONForValue:object];
+	Nest *nest = [nestRelationship buy_valueForJSON:expected object:branch];
+	XCTAssertEqual(branch, [nest branch]);
+	NSDictionary *actual = [nestRelationship buy_JSONForValue:nest];
 	XCTAssertEqualObjects(actual, expected);
 }
 
@@ -209,9 +210,9 @@ static NSString * const RootEntity = @"Root";
 	Branch *branch = [self.modelManager buy_objectWithEntityName:BranchEntity JSONDictionary:nil];
 	NSRelationshipDescription *nestRelationship = [self relationshipWithName:@"nest" forEntity:BranchEntity];
 	NSDictionary *json = @{ @"bird_id" : @501 };
-	id object = [nestRelationship buy_valueForJSON:json object:branch];
-	XCTAssertEqualObjects(@501, [[object bird] identifier]);
-	id actual = [nestRelationship buy_JSONForValue:object];
+	Nest *nest = [nestRelationship buy_valueForJSON:json object:branch];
+	XCTAssertEqualObjects(@501, [[nest bird] identifier]);
+	id actual = [nestRelationship buy_JSONForValue:nest];
 	XCTAssertEqualObjects(actual, json);
 }
 
@@ -225,7 +226,10 @@ static NSString * const RootEntity = @"Root";
 										  [self leafWithDate:[self dateWithComponents:[self june21_1970]] tags:[self tagsWithIndexes:@[@9]]],
 										  [self leafWithDate:[self dateWithComponents:[self jan1_2000]] tags:[self tagsWithIndexes:@[@12, @0, @8, @4]]]]];
 	id json = [leafRelationship buy_JSONForValue:branch.leaves];
-	id actual = [leafRelationship buy_valueForJSON:json object:branch];
+	NSSet<Leaf *> *actual = [leafRelationship buy_valueForJSON:json object:branch];
+	for (Leaf *leaf in actual) {
+		XCTAssertEqualObjects(leaf.branch, branch);
+	}
 	XCTAssertEqualObjects(actual, branch.leaves);
 }
 

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/TestModel.h
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/TestModel.h
@@ -43,6 +43,7 @@
 @interface Bird : TestModel
 @property (nonatomic) NSNumber *identifier;
 @property (nonatomic) NSString *colour;
+@property (nonatomic) NSSet<Nest *> *nests;
 @property (nonatomic) NSSet<Researcher *> *researchers;
 + (instancetype)birdWithIdentifier:(NSNumber *)identifier;
 @end
@@ -58,6 +59,7 @@
 @end
 
 @interface Leaf : TestModel
+@property (nonatomic) Branch *branch;
 @property (nonatomic) NSDate *date;
 @property (nonatomic) NSSet<NSString *> *tags;
 @end


### PR DESCRIPTION
# What this does

This enables support for assigning inverse relationship values for standard builds.

Fixes https://github.com/Shopify/mobile-buy-sdk-ios/issues/237

@davidmuzi 