### PR TITLE
Improve consistency check when starting checkout

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYWebCheckoutPaymentProvider.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYWebCheckoutPaymentProvider.m
@@ -108,7 +108,7 @@ static NSString *const WebCheckoutCustomerAccessToken = @"customer_access_token"
 
 - (void)startCheckout:(BUYCheckout *)checkout
 {	
-	if (self.isInProgress) {
+	if (self.isInProgress && ![checkout.token isEqual:self.checkout.token]) {
 		[[NSException exceptionWithName:NSInternalInconsistencyException reason:[NSString stringWithFormat:@"Asked to start checkout; but checkout has already started in %@", self] userInfo:nil] raise];
 	}
 	


### PR DESCRIPTION
# What

This allows checkout to continue if already started, if the checkout being passed in matches the one currently in progress.

# Why

This allows an app to continue an existing web checkout that the user interrupted. On iOS 8, when starting a checkout, we open Safari. If the user returns from Safari without finishing their checkout, perhaps to modify their cart, we should allow checkout to continue.

An alternative approach would be to put more onus on the app to make sure that the payment provider state is reset, but this is simple and should be safe.

@davidmuzi @gabrieloc 