### PR TITLE
Execute completion blocks before marking as finished

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Operations/BUYRequestOperation.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Operations/BUYRequestOperation.m
@@ -82,14 +82,14 @@ typedef void (^BUYRequestJSONCompletion)(NSDictionary *json, NSHTTPURLResponse *
 
 - (void)finishWithJSON:(id)JSON response:(NSHTTPURLResponse *)response
 {
-	[self finishExecution];
 	self.completion(JSON, response, nil);
+	[self finishExecution];
 }
 
 - (void)finishWithError:(NSError *)error response:(NSHTTPURLResponse *)response
 {
-	[self finishExecution];
 	self.completion(nil, response, error);
+	[self finishExecution];
 }
 
 #pragma mark - Start -


### PR DESCRIPTION
For group operations, we need to be able to cancel dependent operations if an operation fails. This will only work if the failed operation has not been declared finished. Determination of success or failure happens in the completion block attached to the operation. So we must execute that completion block to evaluate success before we mark finished. Otherwise, the successive, dependent operations will get executed concurrently with evaluating success/failure, and cause bad things to happen.

This particularly affected the checkout status check. When we get a 424 response for a checkout that was not completed, we don't want to get the checkout, since nothing has changed. Getting the checkout is treated as proof that the previous operation (get status) succeeded, and we always return assume "complete". So that's two problems that this fixes.

There are, to be clear, multiple kinds of completion blocks. The one we care about, `BUYRequestOperation.completion`, is a private property. We are not concerned with either the `NSOperation.completionBlock` (which the SDK does not use), or with the completion handler provided when initiating an `NSURLSessionTask` (although the latter does indirectly invoke one concerned here).

@gabrieloc @dbart01 @davidmuzi 