### PR TITLE
Remove public product url

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Mobile Buy SDK.xcdatamodeld/Mobile Buy SDK.xcdatamodel/contents
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Mobile Buy SDK.xcdatamodeld/Mobile Buy SDK.xcdatamodel/contents
@@ -705,12 +705,6 @@
                 <entry key="documentation" value="A categorization that a product can be tagged with, commonly used for filtering and searching."/>
             </userInfo>
         </attribute>
-        <attribute name="publicURL" optional="YES" attributeType="Transformable" syncable="YES">
-            <userInfo>
-                <entry key="attributeValueClassName" value="NSURL"/>
-                <entry key="documentation" value="A publically accessible link to the product web page"/>
-            </userInfo>
-        </attribute>
         <attribute name="published" optional="YES" attributeType="Boolean" syncable="YES">
             <userInfo>
                 <entry key="documentation" value="The product is published on the current sales channel."/>
@@ -1004,7 +998,7 @@
         <element name="Option" positionX="-576" positionY="907" width="128" height="105"/>
         <element name="OptionValue" positionX="-387" positionY="907" width="128" height="105"/>
         <element name="Order" positionX="682" positionY="922" width="128" height="180"/>
-        <element name="Product" positionX="-765" positionY="712" width="128" height="300"/>
+        <element name="Product" positionX="-765" positionY="712" width="128" height="285"/>
         <element name="ProductVariant" positionX="-182" positionY="787" width="128" height="240"/>
         <element name="ShippingRate" positionX="531" positionY="1035" width="128" height="135"/>
         <element name="Shop" positionX="-279" positionY="450" width="128" height="255"/>

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYProduct.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYProduct.h
@@ -37,7 +37,6 @@ extern const struct BUYProductAttributes {
 	__unsafe_unretained NSString *htmlDescription;
 	__unsafe_unretained NSString *identifier;
 	__unsafe_unretained NSString *productType;
-	__unsafe_unretained NSString *publicURL;
 	__unsafe_unretained NSString *published;
 	__unsafe_unretained NSString *publishedAt;
 	__unsafe_unretained NSString *tags;
@@ -61,8 +60,6 @@ extern const struct BUYProductUserInfo {
 @class BUYImageLink;
 @class BUYOption;
 @class BUYProductVariant;
-
-@class NSURL;
 
 @class NSSet;
 
@@ -119,11 +116,6 @@ extern const struct BUYProductUserInfo {
  * A categorization that a product can be tagged with, commonly used for filtering and searching.
  */
 @property (nonatomic, strong) NSString* productType;
-
-/**
- * A publically accessible link to the product web page
- */
-@property (nonatomic, strong) NSURL* publicURL;
 
 /**
  * The product is published on the current sales channel.
@@ -249,9 +241,6 @@ extern const struct BUYProductUserInfo {
 
 - (NSString*)primitiveProductType;
 - (void)setPrimitiveProductType:(NSString*)value;
-
-- (NSURL*)primitivePublicURL;
-- (void)setPrimitivePublicURL:(NSURL*)value;
 
 - (NSNumber*)primitivePublished;
 - (void)setPrimitivePublished:(NSNumber*)value;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYProduct.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYProduct.m
@@ -35,7 +35,6 @@ const struct BUYProductAttributes BUYProductAttributes = {
 	.htmlDescription = @"htmlDescription",
 	.identifier = @"identifier",
 	.productType = @"productType",
-	.publicURL = @"publicURL",
 	.published = @"published",
 	.publishedAt = @"publishedAt",
 	.tags = @"tags",
@@ -160,19 +159,6 @@ const struct BUYProductUserInfo BUYProductUserInfo = {
     [self willChangeValueForKey:@"productType"];
     [self setPrimitiveValue:value_ forKey:@"productType"];
     [self didChangeValueForKey:@"productType"];
-}
-
-- (NSURL*)publicURL {
-    [self willAccessValueForKey:@"publicURL"];
-    id value = [self primitiveValueForKey:@"publicURL"];
-    [self didAccessValueForKey:@"publicURL"];
-    return value;
-}
-
-- (void)setPublicURL:(NSURL*)value_ {
-    [self willChangeValueForKey:@"publicURL"];
-    [self setPrimitiveValue:value_ forKey:@"publicURL"];
-    [self didChangeValueForKey:@"publicURL"];
 }
 
 - (NSNumber*)published {


### PR DESCRIPTION
### What

This removes the public URL from the product entity, as it is not sent by Shopify

@bgulanowski 