### PR TITLE
Fix customer app

### DIFF
--- a/Mobile Buy SDK Sample Apps/Sample App Customers/Sample App Customers/OrdersViewController.swift
+++ b/Mobile Buy SDK Sample Apps/Sample App Customers/Sample App Customers/OrdersViewController.swift
@@ -95,7 +95,7 @@ extension OrdersViewController: UITableViewDataSource {
     
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCellWithIdentifier("cell", forIndexPath: indexPath) as! LineItemCell
-        let lineItem = self.orders[indexPath.section].lineItemsArray[indexPath.row]
+        let lineItem = self.orders[indexPath.section].arrayOfLineItems[indexPath.row]
         
         cell.setLineItem(lineItem)
         
@@ -108,7 +108,7 @@ extension OrdersViewController: UITableViewDataSource {
 //
 extension BUYOrder {
     
-    var lineItemsArray: [BUYLineItem] {
+    var arrayOfLineItems: [BUYLineItem] {
         return self.lineItems.array as! [BUYLineItem]
     }
 }

--- a/Mobile Buy SDK Sample Apps/Sample App Customers/Sample App Customers/OrdersViewController.swift
+++ b/Mobile Buy SDK Sample Apps/Sample App Customers/Sample App Customers/OrdersViewController.swift
@@ -95,20 +95,10 @@ extension OrdersViewController: UITableViewDataSource {
     
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCellWithIdentifier("cell", forIndexPath: indexPath) as! LineItemCell
-        let lineItem = self.orders[indexPath.section].arrayOfLineItems[indexPath.row]
+        let lineItem = self.orders[indexPath.section].lineItemsArray()[indexPath.row]
         
         cell.setLineItem(lineItem)
         
         return cell
-    }
-}
-
-// ----------------------------------
-//  MARK: - BUYOrder -
-//
-extension BUYOrder {
-    
-    var arrayOfLineItems: [BUYLineItem] {
-        return self.lineItems.array as! [BUYLineItem]
     }
 }


### PR DESCRIPTION
The customer sample app is written in Swift, and has an extension on BUYOrder to type the array of line items (which is exposed as an NSOrderedSet in the SDK.  To avoid a naming conflict, this change modifies the method name in the sample app.

@bgulanowski 