### PR TITLE
Use NSNumber for product id in Client APIs

### DIFF
--- a/Mobile Buy SDK Sample Apps/Sample App Swift/Mobile Buy SDK Swift Sample/Config.swift
+++ b/Mobile Buy SDK Sample Apps/Sample App Swift/Mobile Buy SDK Swift Sample/Config.swift
@@ -30,5 +30,5 @@ struct Config {
     static let shopDomain = ""
     static let apiKey = ""
     static let appId = ""
-    static let productId = ""
+    static let productId = 0
 }

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClient+StorefrontTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClient+StorefrontTests.m
@@ -177,7 +177,7 @@
 	[OHHTTPStubs stubUsingResponseWithKey:@"testGetNonexistentProduct_0" useMocks:[self shouldUseMocks]];
 	
 	XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
-	[self.client getProductById:@"asdfdsasdfdsasdfdsasdfjkllkj" completion:^(BUYProduct *product, NSError *error) {
+	[self.client getProductById:@123456 completion:^(BUYProduct *product, NSError *error) {
 
 		XCTAssertNil(product);
 		XCTAssertEqual(BUYShopifyError_InvalidProductID, error.code);

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.h
@@ -158,7 +158,7 @@ typedef void (^BUYDataProductListBlock)(NSArray<BUYProduct *> * _Nullable produc
  *
  *  @return The associated BUYRequestOperation
  */
-- (NSOperation *)getProductById:(NSString *)productId completion:(BUYDataProductBlock)block;
+- (NSOperation *)getProductById:(NSNumber *)productId completion:(BUYDataProductBlock)block;
 
 /**
  *  Fetches a list of product by the ID of each product.
@@ -168,7 +168,7 @@ typedef void (^BUYDataProductListBlock)(NSArray<BUYProduct *> * _Nullable produc
  *
  *  @return The associated BUYRequestOperation
  */
-- (NSOperation *)getProductsByIds:(NSArray<NSString *> *)productIds completion:(BUYDataProductsBlock)block;
+- (NSOperation *)getProductsByIds:(NSArray<NSNumber *> *)productIds completion:(BUYDataProductsBlock)block;
 
 /**
  *  Fetches collections based off page

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.m
@@ -94,7 +94,7 @@ static NSString * const BUYCollectionsKey = @"collection_listings";
 	}];
 }
 
-- (NSOperation *)getProductById:(NSString *)productId completion:(BUYDataProductBlock)block
+- (NSOperation *)getProductById:(NSNumber *)productId completion:(BUYDataProductBlock)block
 {
 	BUYAssert(productId, @"Failed to get product by ID. Product ID must not be nil.");
 	


### PR DESCRIPTION
The type for ID in the product model is NSNumber.  We should use the same type in the APIs.

@bgulanowski 