### PR TITLE
Introduce BUYCustomerToken and update APIs

### DIFF
--- a/Mobile Buy SDK Sample Apps/Customers App - Swift/Sample App Customers/LoginViewController.swift
+++ b/Mobile Buy SDK Sample Apps/Customers App - Swift/Sample App Customers/LoginViewController.swift
@@ -65,7 +65,7 @@ class LoginViewController: UITableViewController {
             if let customer = customer,
                 let token = token {
                 self.clear()
-                self.delegate?.authenticationDidSucceedForCustomer(customer, withToken: token)
+                self.delegate?.authenticationDidSucceedForCustomer(customer, withToken: token.accessToken)
             } else {
                 self.delegate?.authenticationDidFailWithError(error)
             }

--- a/Mobile Buy SDK Sample Apps/Customers App - Swift/Sample App Customers/OrdersViewController.swift
+++ b/Mobile Buy SDK Sample Apps/Customers App - Swift/Sample App Customers/OrdersViewController.swift
@@ -52,7 +52,7 @@ class OrdersViewController: UIViewController {
     }
     
     private func loadOrders() {
-        BUYClient.sharedClient.getOrdersForCustomerWithID(String(self.customer.identifier)) { (orders, error) in
+        BUYClient.sharedClient.getOrdersForCustomerCallback { (orders, error) in
             if let orders = orders {
                 self.orders = orders
                 self.tableView.reloadData()

--- a/Mobile Buy SDK Sample Apps/Customers App - Swift/Sample App Customers/SignupViewController.swift
+++ b/Mobile Buy SDK Sample Apps/Customers App - Swift/Sample App Customers/SignupViewController.swift
@@ -73,7 +73,7 @@ class SignupViewController: UITableViewController {
             if let customer = customer,
                 let token = token {
                 self.clear()
-                self.delegate?.authenticationDidSucceedForCustomer(customer, withToken: token)
+                self.delegate?.authenticationDidSucceedForCustomer(customer, withToken: token.accessToken)
             } else {
                 self.delegate?.authenticationDidFailWithError(error)
             }

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClient+CustomerTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClient+CustomerTests.m
@@ -64,7 +64,7 @@
 	[OHHTTPStubs stubUsingResponseWithKey:@"testCustomerLogin" useMocks:[self shouldUseMocks]];
 	
 	XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
-	[self.client loginCustomerWithCredentials:[self credentialsForLogin] callback:^(BUYCustomer *customer, NSString *token, NSError *error) {
+	[self.client loginCustomerWithCredentials:[self credentialsForLogin] callback:^(BUYCustomer *customer, BUYCustomerToken *token, NSError *error) {
 		
 		XCTAssertNil(error);
 		XCTAssertNotNil(customer);
@@ -87,7 +87,7 @@
 	[OHHTTPStubs stubUsingResponseWithKey:@"testCustomerDuplicateEmail" useMocks:[self shouldUseMocks]];
 	
 	XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
-	[self.client createCustomerWithCredentials:[self credentialsForCreation] callback:^(BUYCustomer *customer, NSString *token, NSError *error) {
+	[self.client createCustomerWithCredentials:[self credentialsForCreation] callback:^(BUYCustomer *customer, BUYCustomerToken *token, NSError *error) {
 		
 		XCTAssertNil(customer);
 		XCTAssertNotNil(error);
@@ -114,7 +114,7 @@
 	[OHHTTPStubs stubUsingResponseWithKey:@"testCustomerInvalidEmailPassword" useMocks:[self shouldUseMocks]];
 	
 	XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
-	[self.client createCustomerWithCredentials:[self credentialsForFailure] callback:^(BUYCustomer *customer, NSString *token, NSError *error) {
+	[self.client createCustomerWithCredentials:[self credentialsForFailure] callback:^(BUYCustomer *customer, BUYCustomerToken *token, NSError *error) {
 		
 		XCTAssertNil(customer);
 		XCTAssertNotNil(error);
@@ -149,7 +149,7 @@
 	[OHHTTPStubs stubUsingResponseWithKey:@"testCustomerLogout" useMocks:[self shouldUseMocks]];
 	
 	XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
-	[self.client logoutCustomerID:self.customer.identifier.stringValue callback:^(BUYStatus status, NSError * _Nullable error) {
+	[self.client logoutCustomerCallback:^(BUYStatus status, NSError * _Nullable error) {
 		
 		XCTAssertNil(error);
 		XCTAssertEqual(status, 204);
@@ -167,7 +167,7 @@
 	[OHHTTPStubs stubUsingResponseWithKey:@"testCustomerGetOrders" useMocks:[self shouldUseMocks]];
 	
 	XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
-	[self.client getOrdersForCustomerWithID:self.customer.identifier.stringValue callback:^(NSArray<BUYOrder *> * _Nullable orders, NSError * _Nullable error) {
+	[self.client getOrdersForCustomerCallback:^(NSArray<BUYOrder *> * _Nullable orders, NSError * _Nullable error) {
 		
 		XCTAssertNotNil(orders);
 		XCTAssertNil(error);
@@ -186,7 +186,7 @@
 	[OHHTTPStubs stubUsingResponseWithKey:@"testCustomerGetOrder" useMocks:[self shouldUseMocks]];
 	
 	XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
-	[self.client getOrderWithID:self.customerOrderIDs.firstObject customerID:self.customer.identifier.stringValue callback:^(BUYOrder * _Nullable order, NSError * _Nullable error) {
+	[self.client getOrderWithID:self.customerOrderIDs.firstObject callback:^(BUYOrder * _Nullable order, NSError * _Nullable error) {
 		
 		XCTAssertNil(error);
 		XCTAssertTrue([order isKindOfClass:[BUYOrder class]]);
@@ -208,7 +208,7 @@
 	BUYAccountCredentialItem *email    = [BUYAccountCredentialItem itemWithEmail:self.customerEmail];
 	BUYAccountCredentials *credentials = [BUYAccountCredentials credentialsWithItems:@[email]];
 	
-	[self.client updateCustomerWithCredentials:credentials customerID:self.customer.identifier.stringValue callback:^(BUYCustomer *customer, NSError *error) {
+	[self.client updateCustomerWithCredentials:credentials callback:^(BUYCustomer *customer, NSError *error) {
 		
 		XCTAssertNil(error);
 		XCTAssertNotNil(customer);
@@ -231,7 +231,7 @@
 	}];
 	
 	XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
-	[self.client  getAddressesForCustomerID:self.customer.identifier.stringValue callback:^(NSArray<BUYAddress *> * _Nullable addresses, NSError * _Nullable error) {
+	[self.client  getAddressesCallback:^(NSArray<BUYAddress *> * _Nullable addresses, NSError * _Nullable error) {
 		
 		XCTAssertNotNil(addresses);
 		XCTAssertTrue(addresses.count > 0);
@@ -264,7 +264,7 @@
 	
 	BUYAddress *address = [self address];
 	
-	[self.client createAddress:address customerID:self.customer.identifier.stringValue callback:^(BUYAddress * _Nullable returnedAddress, NSError * _Nullable error) {
+	[self.client createAddress:address callback:^(BUYAddress * _Nullable returnedAddress, NSError * _Nullable error) {
 		
 		[OHHTTPStubs stubUsingResponseWithKey:@"testCustomerLogin" useMocks:[self shouldUseMocks]];
 		
@@ -299,7 +299,7 @@
 	}];
 	
 	XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
-	[self.client getAddressWithID:self.createdAddress.identifier customerID:self.customer.identifier.stringValue callback:^(BUYAddress * _Nullable address, NSError * _Nullable error) {
+	[self.client getAddressWithID:self.createdAddress.identifier callback:^(BUYAddress * _Nullable address, NSError * _Nullable error) {
 		
 		XCTAssertNotNil(address);
 		XCTAssertNil(error);
@@ -323,7 +323,7 @@
 	
 	BUYAddress *modifiedAddress = [self addressByModyfyingAddress:self.createdAddress];
 	
-	[self.client updateAddress:modifiedAddress customerID:self.customer.identifier.stringValue callback:^(BUYAddress * _Nullable returnedAddress, NSError * _Nullable error) {
+	[self.client updateAddress:modifiedAddress callback:^(BUYAddress * _Nullable returnedAddress, NSError * _Nullable error) {
 		
 		XCTAssertNotNil(returnedAddress);
 		XCTAssertNil(error);
@@ -353,7 +353,7 @@
 	}];
 	
 	XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
-	[self.client  deleteAddressWithID:self.createdAddress.identifier customerID:self.customer.identifier.stringValue callback:^(BUYStatus status, NSError * _Nullable error) {
+	[self.client  deleteAddressWithID:self.createdAddress.identifier callback:^(BUYStatus status, NSError * _Nullable error) {
 		
 		XCTAssertEqual(status, 204);
 		XCTAssertNil(error);

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClient+RoutingTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClient+RoutingTests.m
@@ -26,6 +26,7 @@
 
 #import <XCTest/XCTest.h>
 #import "BUYClient+Routing.h"
+#import "BUYCustomerToken.h"
 
 @interface BUYClient_RoutingTests : XCTestCase
 
@@ -42,13 +43,14 @@
     [super setUp];
 	
 	self.client = [[BUYClient alloc] initWithShopDomain:@"_DOMAIN_" apiKey:@"_API_KEY_" appId:@"_APP_ID_"];
+	self.client.customerToken = [[BUYCustomerToken alloc] initWithCustomerID:@1 accessToken:@"token" expiry:[NSDate date]];
 }
 
 #pragma mark - Test Routes -
 
 - (void)testRoutes
 {
-	NSString *identifier     = @"_ID_";
+	NSString *identifier     = @"1";
 	NSString *token          = @"_TOKEN_";
 	NSDictionary *parameters = @{ @"param" : @"value" };
 	
@@ -122,41 +124,37 @@
 						  @"https://_DOMAIN_/api/customers/recover.json"
 						  );
 	XCTAssertEqualObjects(
-						  [self.client urlForCustomersOrdersWithID:identifier].absoluteString,
-						  @"https://_DOMAIN_/api/customers/_ID_/orders.json"
+						  [self.client urlForCustomersOrders].absoluteString,
+						  @"https://_DOMAIN_/api/customers/1/orders.json"
 						  );
 	XCTAssertEqualObjects(
-						  [self.client urlForCustomersOrdersWithID:identifier orderID:@99].absoluteString,
-						  @"https://_DOMAIN_/api/customers/_ID_/orders/99.json"
+						  [self.client urlForCustomersOrdersWithOrderID:@99].absoluteString,
+						  @"https://_DOMAIN_/api/customers/1/orders/99.json"
 						  );
 	XCTAssertEqualObjects(
 						  [self.client urlForCustomersWithID:identifier].absoluteString,
-						  @"https://_DOMAIN_/api/customers/_ID_.json"
+						  @"https://_DOMAIN_/api/customers/1.json"
 						  );
 	XCTAssertEqualObjects(
 						  [self.client urlForCustomersActivationWithID:identifier parameters:parameters].absoluteString,
-						  @"https://_DOMAIN_/api/customers/_ID_/activate.json?param=value"
+						  @"https://_DOMAIN_/api/customers/1/activate.json?param=value"
 						  );
 	XCTAssertEqualObjects(
-						  [self.client urlForCustomersTokenWithID:identifier].absoluteString,
-						  @"https://_DOMAIN_/api/customers/_ID_/customer_token.json"
-						  );
-	XCTAssertEqualObjects(
-						  [self.client urlForCustomersTokenRenewalWithID:identifier].absoluteString,
-						  @"https://_DOMAIN_/api/customers/_ID_/customer_token/renew.json"
+						  [self.client urlForCustomersTokenRenewal].absoluteString,
+						  @"https://_DOMAIN_/api/customers/1/customer_token/renew.json"
 						  );
 	XCTAssertEqualObjects(
 						  [self.client urlForCustomersPasswordResetWithID:identifier parameters:parameters].absoluteString,
-						  @"https://_DOMAIN_/api/customers/_ID_/reset.json?param=value"
+						  @"https://_DOMAIN_/api/customers/1/reset.json?param=value"
 						  );
 	
 	XCTAssertEqualObjects(
-						  [self.client urlForCustomersAddressesWithID:identifier].absoluteString,
-						  @"https://_DOMAIN_/api/customers/_ID_/addresses.json"
+						  [self.client urlForCustomersAddresses].absoluteString,
+						  @"https://_DOMAIN_/api/customers/1/addresses.json"
 						  );
 	XCTAssertEqualObjects(
-						  [self.client urlForCustomersAddressWithID:identifier addressID:@999].absoluteString,
-						  @"https://_DOMAIN_/api/customers/_ID_/addresses/999.json"
+						  [self.client urlForCustomersAddressWithAddressID:@999].absoluteString,
+						  @"https://_DOMAIN_/api/customers/1/addresses/999.json"
 						  );
 }
 

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClientTest.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClientTest.m
@@ -342,7 +342,7 @@
 					   [BUYAccountCredentialItem itemWithPassword:@"12345"]
 					   ];
 	BUYAccountCredentials *credentials = [BUYAccountCredentials credentialsWithItems:items];
-	NSString *customerID = @"12345";
+	NSNumber *customerID = @12345;
 	NSString *token      = @"12345";
 	BUYRequestOperation *task = (BUYRequestOperation *)[self.client activateCustomerWithCredentials:credentials customerID:customerID token:token callback:^(BUYCustomer *customer, BUYCustomerToken *token, NSError *error) {
 		

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClientTest.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClientTest.m
@@ -38,8 +38,6 @@
 #import "BUYApplePayTestToken.h"
 #import "BUYRequestOperation.h"
 
-NSString * const BUYFakeCustomerToken = @"dsfasdgafdg";
-
 @interface BUYClient_Test : BUYClient
 
 @end
@@ -57,6 +55,23 @@ NSString * const BUYFakeCustomerToken = @"dsfasdgafdg";
 @end
 
 @implementation BUYClientTest
+
+- (void)setUp
+{
+	[super setUp];
+	self.client.customerToken = [self customerTokenForTesting];
+}
+
+- (void)tearDown
+{
+	self.client.customerToken = nil;
+	[super tearDown];
+}
+
+- (BUYCustomerToken *)customerTokenForTesting
+{
+	return [[BUYCustomerToken alloc] initWithCustomerID:@1 accessToken:@"" expiry:[NSDate dateWithTimeIntervalSinceNow:3600]];
+}
 
 - (void)setupClient
 {
@@ -211,7 +226,7 @@ NSString * const BUYFakeCustomerToken = @"dsfasdgafdg";
 					   ];
 	BUYAccountCredentials *credentials = [BUYAccountCredentials credentialsWithItems:items];
 	
-	BUYRequestOperation *task = (BUYRequestOperation *)[self.client createCustomerWithCredentials:credentials callback:^(BUYCustomer *customer, NSString *token, NSError *error) {
+	BUYRequestOperation *task = (BUYRequestOperation *)[self.client createCustomerWithCredentials:credentials callback:^(BUYCustomer *customer, BUYCustomerToken *token, NSError *error) {
 		
 	}];
 	
@@ -239,7 +254,7 @@ NSString * const BUYFakeCustomerToken = @"dsfasdgafdg";
 					   [BUYAccountCredentialItem itemWithPassword:@"password"],
 					   ];
 	BUYAccountCredentials *credentials = [BUYAccountCredentials credentialsWithItems:items];
-	BUYRequestOperation *task = (BUYRequestOperation *)[self.client loginCustomerWithCredentials:credentials callback:^(BUYCustomer *customer, NSString *token, NSError *error) {
+	BUYRequestOperation *task = (BUYRequestOperation *)[self.client loginCustomerWithCredentials:credentials callback:^(BUYCustomer *customer, BUYCustomerToken *token, NSError *error) {
 		
 	}];
 	
@@ -260,28 +275,28 @@ NSString * const BUYFakeCustomerToken = @"dsfasdgafdg";
 
 - (void)testGetCustomerURL
 {
-	BUYRequestOperation *task = (BUYRequestOperation *)[self.client getCustomerWithID:@"" callback:^(BUYCustomer *customer, NSError *error) {
-		
+	BUYRequestOperation *task = (BUYRequestOperation *)[self.client getCustomerCallback:^(BUYCustomer *customer, NSError *error) {
+	
 	}];
 	
 	XCTAssertEqualObjects(task.originalRequest.URL.scheme, @"https");
-	XCTAssertEqualObjects(task.originalRequest.URL.path, @"/api/customers.json");
+	XCTAssertEqualObjects(task.originalRequest.URL.path, @"/api/customers/1.json");
 	XCTAssertEqualObjects(task.originalRequest.HTTPMethod, @"GET");
 	
-	XCTAssertEqualObjects(self.client.customerToken, task.originalRequest.allHTTPHeaderFields[BUYClientCustomerAccessToken]);
+	XCTAssertEqualObjects(self.client.customerToken.accessToken, task.originalRequest.allHTTPHeaderFields[BUYClientCustomerAccessToken]);
 }
 
 - (void)testGetOrdersForCustomerURL
 {
-	BUYRequestOperation *task = (BUYRequestOperation *)[self.client getOrdersForCustomerWithID:@"99" callback:^(NSArray<BUYOrder *> *orders, NSError *error) {
-		
+	BUYRequestOperation *task = (BUYRequestOperation *)[self.client getOrdersForCustomerCallback:^(NSArray<BUYOrder *> *orders, NSError *error) {
+	
 	}];
 	
 	XCTAssertEqualObjects(task.originalRequest.URL.scheme, @"https");
-	XCTAssertEqualObjects(task.originalRequest.URL.path, @"/api/customers/99/orders.json");
+	XCTAssertEqualObjects(task.originalRequest.URL.path, @"/api/customers/1/orders.json");
 	XCTAssertEqualObjects(task.originalRequest.HTTPMethod, @"GET");
 	
-	XCTAssertEqualObjects(self.client.customerToken, task.originalRequest.allHTTPHeaderFields[BUYClientCustomerAccessToken]);
+	XCTAssertEqualObjects(self.client.customerToken.accessToken, task.originalRequest.allHTTPHeaderFields[BUYClientCustomerAccessToken]);
 }
 
 - (void)testCustomerRecovery
@@ -307,11 +322,12 @@ NSString * const BUYFakeCustomerToken = @"dsfasdgafdg";
 {
 	self.client.customerToken = nil;
 	
-	BUYRequestOperation *task = (BUYRequestOperation *)[self.client renewCustomerTokenWithID:@"" callback:^(NSString *token, NSError *error) {}];
+	BUYRequestOperation *task = (BUYRequestOperation *)[self.client renewCustomerTokenCallback:^(NSString *token, NSError *error) {}];
 	XCTAssertNil(task); // task should be nil if no customer token was set on the client
 	
-	self.client.customerToken = BUYFakeCustomerToken;
-	task = (BUYRequestOperation *)[self.client renewCustomerTokenWithID:@"1" callback:^(NSString *token, NSError *error) {
+	
+	self.client.customerToken = [[BUYCustomerToken alloc] initWithCustomerID:@1 accessToken:@"fake_token" expiry:[NSDate dateWithTimeIntervalSinceNow:3600]];
+	task = (BUYRequestOperation *)[self.client renewCustomerTokenCallback:^(NSString *token, NSError *error) {
 		
 	}];
 	
@@ -328,7 +344,7 @@ NSString * const BUYFakeCustomerToken = @"dsfasdgafdg";
 	BUYAccountCredentials *credentials = [BUYAccountCredentials credentialsWithItems:items];
 	NSString *customerID = @"12345";
 	NSString *token      = @"12345";
-	BUYRequestOperation *task = (BUYRequestOperation *)[self.client activateCustomerWithCredentials:credentials customerID:customerID token:token callback:^(BUYCustomer *customer, NSString *token, NSError *error) {
+	BUYRequestOperation *task = (BUYRequestOperation *)[self.client activateCustomerWithCredentials:credentials customerID:customerID token:token callback:^(BUYCustomer *customer, BUYCustomerToken *token, NSError *error) {
 		
 	}];
 	

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClientTest.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClientTest.m
@@ -322,12 +322,12 @@
 {
 	self.client.customerToken = nil;
 	
-	BUYRequestOperation *task = (BUYRequestOperation *)[self.client renewCustomerTokenCallback:^(NSString *token, NSError *error) {}];
+	BUYRequestOperation *task = (BUYRequestOperation *)[self.client renewCustomerTokenCallback:^(BUYCustomerToken *token, NSError *error) {}];
 	XCTAssertNil(task); // task should be nil if no customer token was set on the client
 	
 	
 	self.client.customerToken = [[BUYCustomerToken alloc] initWithCustomerID:@1 accessToken:@"fake_token" expiry:[NSDate dateWithTimeIntervalSinceNow:3600]];
-	task = (BUYRequestOperation *)[self.client renewCustomerTokenCallback:^(NSString *token, NSError *error) {
+	task = (BUYRequestOperation *)[self.client renewCustomerTokenCallback:^(BUYCustomerToken *token, NSError *error) {
 		
 	}];
 	

--- a/Mobile Buy SDK/Mobile Buy SDK.xcodeproj/project.pbxproj
+++ b/Mobile Buy SDK/Mobile Buy SDK.xcodeproj/project.pbxproj
@@ -226,8 +226,8 @@
 		9A0B0C6D1CEB4D300037D68F /* BUYClient+Storefront.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A0B0C6A1CEB4D300037D68F /* BUYClient+Storefront.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9A0B0C6F1CEB4D300037D68F /* BUYClient+Storefront.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A0B0C6B1CEB4D300037D68F /* BUYClient+Storefront.m */; };
 		9A0B0C731CEB52B90037D68F /* BUYClient+Checkout.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A0B0C701CEB52B90037D68F /* BUYClient+Checkout.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9A0B0C791CEB5BBD0037D68F /* BUYAuthenticatedResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A0B0C761CEB5BBD0037D68F /* BUYAuthenticatedResponse.h */; };
-		9A0B0C7B1CEB5BBD0037D68F /* BUYAuthenticatedResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A0B0C771CEB5BBD0037D68F /* BUYAuthenticatedResponse.m */; };
+		9A0B0C791CEB5BBD0037D68F /* BUYCustomerToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A0B0C761CEB5BBD0037D68F /* BUYCustomerToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9A0B0C7B1CEB5BBD0037D68F /* BUYCustomerToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A0B0C771CEB5BBD0037D68F /* BUYCustomerToken.m */; };
 		9A0B0C831CEB981C0037D68F /* BUYClient+RoutingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A0B0C821CEB981C0037D68F /* BUYClient+RoutingTests.m */; };
 		9A0B0CA21CECC1BC0037D68F /* BUYClient+Checkout.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A0B0C711CEB52B90037D68F /* BUYClient+Checkout.m */; };
 		9A0B0CA81CED0A860037D68F /* BUYCheckoutOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A0B0CA51CED0A860037D68F /* BUYCheckoutOperation.h */; };
@@ -470,8 +470,8 @@
 		9A0B0C6B1CEB4D300037D68F /* BUYClient+Storefront.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "BUYClient+Storefront.m"; sourceTree = "<group>"; };
 		9A0B0C701CEB52B90037D68F /* BUYClient+Checkout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "BUYClient+Checkout.h"; sourceTree = "<group>"; };
 		9A0B0C711CEB52B90037D68F /* BUYClient+Checkout.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "BUYClient+Checkout.m"; sourceTree = "<group>"; };
-		9A0B0C761CEB5BBD0037D68F /* BUYAuthenticatedResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BUYAuthenticatedResponse.h; sourceTree = "<group>"; };
-		9A0B0C771CEB5BBD0037D68F /* BUYAuthenticatedResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BUYAuthenticatedResponse.m; sourceTree = "<group>"; };
+		9A0B0C761CEB5BBD0037D68F /* BUYCustomerToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BUYCustomerToken.h; sourceTree = "<group>"; };
+		9A0B0C771CEB5BBD0037D68F /* BUYCustomerToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BUYCustomerToken.m; sourceTree = "<group>"; };
 		9A0B0C821CEB981C0037D68F /* BUYClient+RoutingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "BUYClient+RoutingTests.m"; sourceTree = "<group>"; };
 		9A0B0CA51CED0A860037D68F /* BUYCheckoutOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BUYCheckoutOperation.h; sourceTree = "<group>"; };
 		9A0B0CA61CED0A860037D68F /* BUYCheckoutOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BUYCheckoutOperation.m; sourceTree = "<group>"; };
@@ -960,8 +960,8 @@
 		F773744419C779C20039681C /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				9A0B0C761CEB5BBD0037D68F /* BUYAuthenticatedResponse.h */,
-				9A0B0C771CEB5BBD0037D68F /* BUYAuthenticatedResponse.m */,
+				9A0B0C761CEB5BBD0037D68F /* BUYCustomerToken.h */,
+				9A0B0C771CEB5BBD0037D68F /* BUYCustomerToken.m */,
 				8498DCB91CDD1FA400BD12A8 /* BUYAccountCredentials.h */,
 				8498DCBA1CDD1FA400BD12A8 /* BUYAccountCredentials.m */,
 				F77374AA19C796BD0039681C /* BUYCreditCard.h */,
@@ -1146,7 +1146,7 @@
 				9A0B0CA81CED0A860037D68F /* BUYCheckoutOperation.h in Headers */,
 				901931611BC5B9BC00D1134E /* BUYClient.h in Headers */,
 				9A585C0B1CE6440B001F20F0 /* BUYOperation.h in Headers */,
-				9A0B0C791CEB5BBD0037D68F /* BUYAuthenticatedResponse.h in Headers */,
+				9A0B0C791CEB5BBD0037D68F /* BUYCustomerToken.h in Headers */,
 				849810971CB7E07900CFAB58 /* BUYFlatCollectionTransformer.h in Headers */,
 				9A6C1DC41D089E4700BFF4F9 /* BUYClientTypes.h in Headers */,
 				901931641BC5B9BC00D1134E /* BUYCartLineItem.h in Headers */,
@@ -1332,7 +1332,7 @@
 				9A0B0CAA1CED0A860037D68F /* BUYCheckoutOperation.m in Sources */,
 				84B0A7211CDD261100253EB0 /* BUYSerializable.m in Sources */,
 				9A47CEFE1CE39F6100A6D5BA /* BUYCreditCardToken.m in Sources */,
-				9A0B0C7B1CEB5BBD0037D68F /* BUYAuthenticatedResponse.m in Sources */,
+				9A0B0C7B1CEB5BBD0037D68F /* BUYCustomerToken.m in Sources */,
 				901930F21BC5B9BC00D1134E /* BUYOrder.m in Sources */,
 				849810991CB7E07900CFAB58 /* BUYFlatCollectionTransformer.m in Sources */,
 				84DD12A41CC63FE600A2442D /* _BUYLineItem.m in Sources */,

--- a/Mobile Buy SDK/Mobile Buy SDK/Buy.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Buy.h
@@ -36,6 +36,7 @@
 #import <Buy/BUYCollection.h>
 #import <Buy/BUYCreditCard.h>
 #import <Buy/BUYCustomer.h>
+#import <Buy/BUYCustomerToken.h>
 #import <Buy/BUYDiscount.h>
 #import <Buy/BUYGiftCard.h>
 #import <Buy/BUYImageLink.h>

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Address.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Address.h
@@ -51,60 +51,55 @@ typedef void (^BUYDataAddressBlock)(BUYAddress * _Nullable address, NSError * _N
  *  GET /api/customers/:customer_id/addresses
  *  Fetch all customer addresses
  *
- *  @param customerID Customer ID for which to fetch all address
  *  @param block      (NSArray<BUYAddress *> *addresses, NSError *error)
  *
  *  @return The associated BUYRequestOperation
  */
-- (NSOperation *)getAddressesForCustomerID:(NSString *)customerID callback:(BUYDataAddressesBlock)block;
+- (NSOperation *)getAddressesCallback:(BUYDataAddressesBlock)block;
 
 /**
  *  GET /api/customers/:customer_id/addresses/:id
  *  Fetch a customer address by ID
  *
  *  @param addressID  Identifier of the address to fetch
- *  @param customerID Customer ID for which to fetch the address
  *  @param block      (BUYAddress *address, NSError *error)
  *
  *  @return The associated BUYRequestOperation
  */
-- (NSOperation *)getAddressWithID:(NSNumber *)addressID customerID:(NSString *)customerID callback:(BUYDataAddressBlock)block;
+- (NSOperation *)getAddressWithID:(NSNumber *)addressID callback:(BUYDataAddressBlock)block;
 
 /**
  *  POST /api/customers/:customer_id/addresses
  *  Creates a new customer address
  *
  *  @param address  Address to create
- *  @param customer Customer ID for which to create the address
  *  @param block    (BUYAddress *address, NSError *error)
  *
  *  @return The associated BUYRequestOperation
  */
-- (NSOperation *)createAddress:(BUYAddress *)address customerID:(NSString *)customerID callback:(BUYDataAddressBlock)block;
+- (NSOperation *)createAddress:(BUYAddress *)address callback:(BUYDataAddressBlock)block;
 
 /**
  *  PUT /api/customers/:customer_id/addresses/:id
  *  Updates the customer address
  *
  *  @param address    Address to update, containing updated values
- *  @param customerID Customer ID for which to update the address
  *  @param block      (BUYAddress *address, NSError *error)
  *
  *  @return The associated BUYRequestOperation
  */
-- (NSOperation *)updateAddress:(BUYAddress *)address customerID:(NSString *)customerID callback:(BUYDataAddressBlock)block;
+- (NSOperation *)updateAddress:(BUYAddress *)address callback:(BUYDataAddressBlock)block;
 
 /**
  *  DELETE /api/customers/:customer_id/addresses/:id
  *  Delete the customer address
  *
  *  @param addressID  Address ID to delete
- *  @param customerID Customer ID for which to delete the address
  *  @param block      (BUYStatus status, NSError *error)
  *
  *  @return The associated BUYRequestOperation
  */
-- (NSOperation *)deleteAddressWithID:(NSNumber *)addressID customerID:(NSString *)customerID callback:(BUYDataStatusBlock)block;
+- (NSOperation *)deleteAddressWithID:(NSNumber *)addressID callback:(BUYDataStatusBlock)block;
 
 @end
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Address.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Address.m
@@ -33,9 +33,9 @@
 
 @implementation BUYClient (Address)
 
-- (NSOperation *)getAddressesForCustomerID:(NSString *)customerID callback:(BUYDataAddressesBlock)block
+- (NSOperation *)getAddressesCallback:(BUYDataAddressesBlock)block
 {
-	NSURL *route = [self urlForCustomersAddressesWithID:customerID];
+	NSURL *route = [self urlForCustomersAddresses];
 	return [self getRequestForURL:route completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
 		NSArray<BUYAddress *> *addresses = nil;
 		if (json && !error) {
@@ -45,9 +45,9 @@
 	}];
 }
 
-- (NSOperation *)getAddressWithID:(NSNumber *)addressID customerID:(NSString *)customerID callback:(BUYDataAddressBlock)block
+- (NSOperation *)getAddressWithID:(NSNumber *)addressID callback:(BUYDataAddressBlock)block
 {
-	NSURL *route = [self urlForCustomersAddressWithID:customerID addressID:addressID];
+	NSURL *route = [self urlForCustomersAddressWithAddressID:addressID];
 	return [self getRequestForURL:route completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
 		BUYAddress *address = nil;
 		if (json && !error) {
@@ -57,9 +57,9 @@
 	}];
 }
 
-- (NSOperation *)createAddress:(BUYAddress *)address customerID:(NSString *)customerID callback:(BUYDataAddressBlock)block
+- (NSOperation *)createAddress:(BUYAddress *)address callback:(BUYDataAddressBlock)block
 {
-	NSURL *route = [self urlForCustomersAddressesWithID:customerID];
+	NSURL *route = [self urlForCustomersAddresses];
 	return [self postRequestForURL:route object:@{ @"address" : address.JSONDictionary } completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
 		BUYAddress *address = nil;
 		if (json && !error) {
@@ -69,11 +69,11 @@
 	}];
 }
 
-- (NSOperation *)updateAddress:(BUYAddress *)address customerID:(NSString *)customerID callback:(BUYDataAddressBlock)block
+- (NSOperation *)updateAddress:(BUYAddress *)address callback:(BUYDataAddressBlock)block
 {
 	BUYAssert(address.identifier, @"Failed to update address. Address must have a valid identifier.");
 	
-	NSURL *route = [self urlForCustomersAddressWithID:customerID addressID:address.identifier];
+	NSURL *route = [self urlForCustomersAddressWithAddressID:address.identifier];
 	return [self putRequestForURL:route object:@{ @"address" : address.JSONDictionary } completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
 		BUYAddress *address = nil;
 		if (json && !error) {
@@ -83,11 +83,11 @@
 	}];
 }
 
-- (NSOperation *)deleteAddressWithID:(NSNumber *)addressID customerID:(NSString *)customerID callback:(BUYDataStatusBlock)block
+- (NSOperation *)deleteAddressWithID:(NSNumber *)addressID callback:(BUYDataStatusBlock)block
 {
 	BUYAssert(addressID, @"Failed to update address. Address must have a valid identifier.");
 	
-	NSURL *route = [self urlForCustomersAddressWithID:customerID addressID:addressID];
+	NSURL *route = [self urlForCustomersAddressWithAddressID:addressID];
 	return [self deleteRequestForURL:route completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
 		block(response.statusCode, error);
 	}];

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.h
@@ -116,7 +116,7 @@ typedef void (^BUYDataOrderBlock)(BUYOrder * _Nullable order, NSError * _Nullabl
  *
  *  @return The associated BUYRequestOperation
  */
-- (NSOperation *)activateCustomerWithCredentials:(BUYAccountCredentials *)credentials customerID:(NSString *)customerID token:(NSString *)token callback:(BUYDataCustomerTokenBlock)block;
+- (NSOperation *)activateCustomerWithCredentials:(BUYAccountCredentials *)credentials customerID:(NSNumber *)customerID token:(NSString *)token callback:(BUYDataCustomerTokenBlock)block;
 
 /**
  *  PUT /api/customers/:customer_id
@@ -141,7 +141,7 @@ typedef void (^BUYDataOrderBlock)(BUYOrder * _Nullable order, NSError * _Nullabl
  *
  *  @return The associated BUYRequestOperation
  */
-- (NSOperation *)resetPasswordWithCredentials:(BUYAccountCredentials *)credentials customerID:(NSString *)customerID token:(NSString *)token callback:(BUYDataCustomerTokenBlock)block;
+- (NSOperation *)resetPasswordWithCredentials:(BUYAccountCredentials *)credentials customerID:(NSNumber *)customerID token:(NSString *)token callback:(BUYDataCustomerTokenBlock)block;
 
 #pragma mark - Token -
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.h
@@ -82,7 +82,6 @@ typedef void (^BUYDataOrderBlock)(BUYOrder * _Nullable order, NSError * _Nullabl
  *  GET /api/customers/:customer_id
  *  Gets an existing customer
  *
- *  @param customerID A customer ID retrieved from either customer creation or login
  *  @param block      (BUYCustomer *customer, NSError *error)
  *
  *  @return The associated BUYRequestOperation
@@ -123,7 +122,6 @@ typedef void (^BUYDataOrderBlock)(BUYOrder * _Nullable order, NSError * _Nullabl
  *  Update customer credentials represented by BUYAccountCredentials object
  *
  *  @param credentials   Credentials containing a password
- *  @param customerID    ID of customer being activated
  *  @param block         (BUYCustomer *customer, NSError *error)
  *
  *  @return The associated BUYRequestOperation
@@ -149,7 +147,6 @@ typedef void (^BUYDataOrderBlock)(BUYOrder * _Nullable order, NSError * _Nullabl
  *  PUT /api/customers/:customer_id/customer_token/renew
  *  Renews an existing customer's token
  *
- *  @param customerID ID of customer renewing token
  *  @param block      (NSString *token, NSError *error)
  *
  *  @return the associated BUYRequestOperation
@@ -173,9 +170,7 @@ typedef void (^BUYDataOrderBlock)(BUYOrder * _Nullable order, NSError * _Nullabl
 /**
  *  DELETE /api/customers/:customer_id/customer_token
  *  Logs out an existing customer
- *  Expects a customerID string
  *
- *  @param customer A customerID represented by a string
  *  @param block    (BUYStatus status, NSError *error)
  *
  *  @return The associated BUYRequestOperation
@@ -199,7 +194,6 @@ typedef void (^BUYDataOrderBlock)(BUYOrder * _Nullable order, NSError * _Nullabl
  *  GET /api/customers/:customer_id/orders
  *  Gets orders for a given customer
  *
- *  @param customerID A customer ID for which to retrieve the order
  *  @param block      (NSArray <BUYOrder*> *orders, NSError *error)
  *
  *  @return The associated BUYRequestOperation
@@ -210,7 +204,6 @@ typedef void (^BUYDataOrderBlock)(BUYOrder * _Nullable order, NSError * _Nullabl
  *  GET /api/customers/:customer_id/orders/:id
  *  Gets order with a given identifier
  *
- *  @param customerID A customer ID for which to retrieve the order
  *  @param orderID    An order ID to retrieve
  *  @param block      (NSArray <BUYOrder*> *orders, NSError *error)
  *

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.h
@@ -27,9 +27,10 @@
 #import <Buy/BUYClient.h>
 NS_ASSUME_NONNULL_BEGIN
 
-@class BUYCustomer;
-@class BUYOrder;
 @class BUYAccountCredentials;
+@class BUYCustomer;
+@class BUYCustomerToken;
+@class BUYOrder;
 
 /**
  *  Return block containing a BUYCustomer object for an existing customer of the shop
@@ -46,7 +47,7 @@ typedef void (^BUYDataCustomerBlock)(BUYCustomer * _Nullable customer, NSError *
  *  @param token    An authentication token to retrieve the customer later.  Store this token securely on the device.
  *  @param error    An optional NSError
  */
-typedef void (^BUYDataCustomerTokenBlock)(BUYCustomer * _Nullable customer, NSString * _Nullable token, NSError * _Nullable error);
+typedef void (^BUYDataCustomerTokenBlock)(BUYCustomer * _Nullable customer, BUYCustomerToken * _Nullable token, NSError * _Nullable error);
 
 /**
  *  Return block containing a customer auth token
@@ -86,7 +87,7 @@ typedef void (^BUYDataOrderBlock)(BUYOrder * _Nullable order, NSError * _Nullabl
  *
  *  @return The associated BUYRequestOperation
  */
-- (NSOperation *)getCustomerWithID:(NSString *)customerID callback:(BUYDataCustomerBlock)block;
+- (NSOperation *)getCustomerCallback:(BUYDataCustomerBlock)block;
 
 #pragma mark - Customer -
 
@@ -127,7 +128,7 @@ typedef void (^BUYDataOrderBlock)(BUYOrder * _Nullable order, NSError * _Nullabl
  *
  *  @return The associated BUYRequestOperation
  */
-- (NSOperation *)updateCustomerWithCredentials:(BUYAccountCredentials *)credentials customerID:(NSString *)customerID callback:(BUYDataCustomerBlock)block;
+- (NSOperation *)updateCustomerWithCredentials:(BUYAccountCredentials *)credentials callback:(BUYDataCustomerBlock)block;
 
 /**
  *  PUT /api/customers/:customer_id/reset
@@ -153,7 +154,7 @@ typedef void (^BUYDataOrderBlock)(BUYOrder * _Nullable order, NSError * _Nullabl
  *
  *  @return the associated BUYRequestOperation
  */
-- (NSOperation *)renewCustomerTokenWithID:(NSString *)customerID callback:(BUYDataTokenBlock)block;
+- (NSOperation *)renewCustomerTokenCallback:(BUYDataTokenBlock)block;
 
 #pragma mark - Login -
 
@@ -179,7 +180,7 @@ typedef void (^BUYDataOrderBlock)(BUYOrder * _Nullable order, NSError * _Nullabl
  *
  *  @return The associated BUYRequestOperation
  */
-- (NSOperation *)logoutCustomerID:(NSString *)customerID callback:(BUYDataStatusBlock)block;
+- (NSOperation *)logoutCustomerCallback:(BUYDataStatusBlock)block;
 
 /**
  *  POST /api/customers/recover
@@ -203,7 +204,7 @@ typedef void (^BUYDataOrderBlock)(BUYOrder * _Nullable order, NSError * _Nullabl
  *
  *  @return The associated BUYRequestOperation
  */
-- (NSOperation *)getOrdersForCustomerWithID:(NSString *)customerID callback:(BUYDataOrdersBlock)block;
+- (NSOperation *)getOrdersForCustomerCallback:(BUYDataOrdersBlock)block;
 
 /**
  *  GET /api/customers/:customer_id/orders/:id
@@ -215,7 +216,7 @@ typedef void (^BUYDataOrderBlock)(BUYOrder * _Nullable order, NSError * _Nullabl
  *
  *  @return The associated BUYRequestOperation
  */
-- (NSOperation *)getOrderWithID:(NSNumber *)orderID customerID:(NSString *)customerID callback:(BUYDataOrderBlock)block;
+- (NSOperation *)getOrderWithID:(NSNumber *)orderID callback:(BUYDataOrderBlock)block;
 
 @end
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.h
@@ -55,7 +55,7 @@ typedef void (^BUYDataCustomerTokenBlock)(BUYCustomer * _Nullable customer, BUYC
  *  @param token    An authentication token to retrieve the customer later.  Store this token securely on the device.
  *  @param error    An optional NSError
  */
-typedef void (^BUYDataTokenBlock)(NSString * _Nullable token, NSError * _Nullable error);
+typedef void (^BUYDataTokenBlock)(BUYCustomerToken * _Nullable token, NSError * _Nullable error);
 
 /**
  *  Return block containing an array of BUYOrders

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.m
@@ -66,9 +66,9 @@
 	}];
 }
 
-- (NSOperation *)activateCustomerWithCredentials:(BUYAccountCredentials *)credentials customerID:(NSString *)customerID token:(NSString *)token callback:(BUYDataCustomerTokenBlock)block
+- (NSOperation *)activateCustomerWithCredentials:(BUYAccountCredentials *)credentials customerID:(NSNumber *)customerID token:(NSString *)token callback:(BUYDataCustomerTokenBlock)block
 {
-	NSURL *url = [self urlForCustomersActivationWithID:customerID parameters:@{ @"token": token }];
+	NSURL *url = [self urlForCustomersActivationWithID:customerID.stringValue parameters:@{ @"token": token }];
 	
 	return [self putRequestForURL:url object:credentials.JSONRepresentation completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
 		NSString *email = json[@"customer"][@"email"];
@@ -94,9 +94,9 @@
 	}];
 }
 
-- (NSOperation *)resetPasswordWithCredentials:(BUYAccountCredentials *)credentials customerID:(NSString *)customerID token:(NSString *)token callback:(BUYDataCustomerTokenBlock)block
+- (NSOperation *)resetPasswordWithCredentials:(BUYAccountCredentials *)credentials customerID:(NSNumber *)customerID token:(NSString *)token callback:(BUYDataCustomerTokenBlock)block
 {
-	NSURL *url = [self urlForCustomersPasswordResetWithID:customerID parameters:@{ @"token": token }];
+	NSURL *url = [self urlForCustomersPasswordResetWithID:customerID.stringValue parameters:@{ @"token": token }];
 	
 	return [self putRequestForURL:url object:credentials.JSONRepresentation completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
 		NSString *email = json[@"customer"][@"email"];

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.m
@@ -30,7 +30,7 @@
 #import "NSDateFormatter+BUYAdditions.h"
 #import "BUYCustomer.h"
 #import "BUYAccountCredentials.h"
-#import "BUYAuthenticatedResponse.h"
+#import "BUYCustomerToken.h"
 #import "BUYOrder.h"
 #import "BUYShopifyErrorCodes.h"
 
@@ -119,7 +119,7 @@
 		return [self putRequestForURL:url object:nil completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
 			NSString *accessToken = nil;
 			if (json && !error) {
-				BUYAuthenticatedResponse *authenticatedResponse = [BUYAuthenticatedResponse responseWithJSON:json];
+				BUYCustomerToken *authenticatedResponse = [BUYCustomerToken responseWithJSON:json];
 				accessToken = authenticatedResponse.accessToken;
 			}
 			
@@ -190,7 +190,7 @@
 	NSURL *url = [self urlForCustomersToken];
 	return [self postRequestForURL:url object:credentials.JSONRepresentation completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
 		if (json && !error) {
-			BUYAuthenticatedResponse *authenticatedResponse = [BUYAuthenticatedResponse responseWithJSON:json];
+			BUYCustomerToken *authenticatedResponse = [BUYCustomerToken responseWithJSON:json];
 			self.customerToken = authenticatedResponse.accessToken;
 			
 			if (!customerJSON) {

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.m
@@ -115,7 +115,7 @@
 - (NSOperation *)renewCustomerTokenCallback:(BUYDataTokenBlock)block
 {
 	if (self.customerToken) {
-		NSURL *url = [self urlForCustomersTokenRenewalWithID:self.customerToken.customerID];
+		NSURL *url = [self urlForCustomersTokenRenewal];
 		
 		return [self putRequestForURL:url object:nil completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
 			NSString *accessToken = nil;
@@ -137,7 +137,7 @@
 
 - (NSOperation *)logoutCustomerCallback:(BUYDataStatusBlock)block
 {
-	NSURL *url = [self urlForLoggedInCustomer];
+	NSURL *url = [self urlForLoggedInCustomerToken];
 	return [self deleteRequestForURL:url completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
 		block(response.statusCode, error);
 	}];
@@ -160,7 +160,7 @@
 
 - (NSOperation *)getOrdersForCustomerCallback:(BUYDataOrdersBlock)block
 {
-	NSURL *url = [self urlForLoggedInCustomer];
+	NSURL *url = [self urlForCustomersOrders];
 	return [self getRequestForURL:url completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
 		if (json && !error) {
 			NSArray *orders = [self.modelManager ordersWithJSONDictionary:json];
@@ -173,7 +173,7 @@
 
 - (NSOperation *)getOrderWithID:(NSNumber *)orderID callback:(BUYDataOrderBlock)block
 {
-	NSURL *url = [self urlForCustomersOrdersWithID:self.customerToken.customerID orderID:orderID];
+	NSURL *url = [self urlForCustomersOrdersWithOrderID:orderID];
 	return [self getRequestForURL:url completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
 		if (json && !error) {
 			BUYOrder *order = [self.modelManager orderWithJSONDictionary:json];

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.m
@@ -190,7 +190,7 @@
 	NSURL *url = [self urlForCustomersToken];
 	return [self postRequestForURL:url object:credentials.JSONRepresentation completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
 		if (json && !error) {
-			BUYCustomerToken *authenticatedResponse = [BUYCustomerToken responseWithJSON:json];
+			BUYCustomerToken *authenticatedResponse = [BUYCustomerToken customerTokenWithJSON:json];
 			self.customerToken = authenticatedResponse.accessToken;
 			
 			if (!customerJSON) {

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.m
@@ -119,7 +119,7 @@
 		return [self putRequestForURL:url object:nil completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
 			NSString *accessToken = nil;
 			if (json && !error) {
-				BUYCustomerToken *authenticatedResponse = [BUYCustomerToken responseWithJSON:json];
+				BUYCustomerToken *authenticatedResponse = [BUYCustomerToken customerTokenWithJSON:json];
 				accessToken = authenticatedResponse.accessToken;
 			}
 			
@@ -191,16 +191,16 @@
 	return [self postRequestForURL:url object:credentials.JSONRepresentation completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
 		if (json && !error) {
 			BUYCustomerToken *authenticatedResponse = [BUYCustomerToken customerTokenWithJSON:json];
-			self.customerToken = authenticatedResponse.accessToken;
+			self.customerToken = authenticatedResponse;
 			
 			if (!customerJSON) {
 				[self getCustomerWithID:authenticatedResponse.customerID callback:^(BUYCustomer *customer, NSError *error) {
-					block(customer, self.customerToken, error);
+					block(customer, self.customerToken.accessToken, error);
 				}];
 			}
 			else {
 				BUYCustomer *customer = [self.modelManager customerWithJSONDictionary:customerJSON];
-				block(customer, self.customerToken, error);
+				block(customer, self.customerToken.accessToken, error);
 			}
 		}
 		else {

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.m
@@ -191,7 +191,7 @@
 	NSURL *url = [self urlForCustomersToken];
 	return [self postRequestForURL:url object:credentials.JSONRepresentation completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
 		if (json && !error) {
-			self.customerToken = [BUYCustomerToken customerTokenWithJSON:json];
+			self.customerToken = [BUYCustomerToken customerTokenWithJSONDictionary:json];
 			if (!customerJSON) {
 				[self getCustomerCallback:^(BUYCustomer *customer, NSError *error) {
 					block(customer, self.customerToken, error);

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.m
@@ -118,13 +118,12 @@
 		NSURL *url = [self urlForCustomersTokenRenewal];
 		
 		return [self putRequestForURL:url object:nil completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
-			NSString *accessToken = nil;
+			BUYCustomerToken *customerToken = nil;
 			if (json && !error) {
-				BUYCustomerToken *customerToken = [BUYCustomerToken customerTokenWithJSON:json];
-				accessToken = customerToken.accessToken;
+				customerToken = [BUYCustomerToken customerTokenWithJSONDictionary:json];
 			}
 			
-			block(accessToken, error);
+			block(customerToken, error);
 		}];
 	}
 	else {

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Routing.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Routing.h
@@ -49,6 +49,7 @@
 - (NSURL *)urlForCustomers;
 - (NSURL *)urlForCustomersToken;
 - (NSURL *)urlForCustomersPasswordRecovery;
+- (NSURL *)urlForLoggedInCustomer;
 
 - (NSURL *)urlForCustomersOrdersWithID:(NSString *)identifier;
 - (NSURL *)urlForCustomersOrdersWithID:(NSString *)identifier orderID:(NSNumber *)orderID;

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Routing.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Routing.h
@@ -50,13 +50,14 @@
 - (NSURL *)urlForCustomersToken;
 - (NSURL *)urlForCustomersPasswordRecovery;
 - (NSURL *)urlForLoggedInCustomer;
+- (NSURL *)urlForLoggedInCustomerToken;
+- (NSURL *)urlForCustomersTokenRenewal;
 
-- (NSURL *)urlForCustomersOrdersWithID:(NSString *)identifier;
-- (NSURL *)urlForCustomersOrdersWithID:(NSString *)identifier orderID:(NSNumber *)orderID;
+- (NSURL *)urlForCustomersOrders;
+- (NSURL *)urlForCustomersOrdersWithOrderID:(NSNumber *)orderID;
+
 - (NSURL *)urlForCustomersWithID:(NSString *)identifier;
 - (NSURL *)urlForCustomersActivationWithID:(NSString *)identifier parameters:(NSDictionary *)parameters;
-- (NSURL *)urlForCustomersTokenWithID:(NSString *)customerID;
-- (NSURL *)urlForCustomersTokenRenewalWithID:(NSString *)customerID;
 - (NSURL *)urlForCustomersPasswordResetWithID:(NSString *)identifier parameters:(NSDictionary *)parameters;
 
 - (NSURL *)urlForCustomersAddressesWithID:(NSString *)customerID;

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Routing.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Routing.h
@@ -60,7 +60,7 @@
 - (NSURL *)urlForCustomersActivationWithID:(NSString *)identifier parameters:(NSDictionary *)parameters;
 - (NSURL *)urlForCustomersPasswordResetWithID:(NSString *)identifier parameters:(NSDictionary *)parameters;
 
-- (NSURL *)urlForCustomersAddressesWithID:(NSString *)customerID;
-- (NSURL *)urlForCustomersAddressWithID:(NSString *)customerID addressID:(NSNumber *)addressID;
+- (NSURL *)urlForCustomersAddresses;
+- (NSURL *)urlForCustomersAddressWithAddressID:(NSNumber *)addressID;
 
 @end

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Routing.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Routing.m
@@ -233,14 +233,14 @@
 
 #pragma mark - Customer Addresses -
 
-- (NSURL *)urlForCustomersAddressesWithID:(NSString *)customerID
+- (NSURL *)urlForCustomersAddresses
 {
-	return [[[self urlForCustomersWithID:customerID] appendPath:@"/addresses"] appendExtension];
+	return [[[self urlForLoggedInCustomer] appendPath:@"/addresses"] appendExtension];
 }
 
-- (NSURL *)urlForCustomersAddressWithID:(NSString *)customerID addressID:(NSNumber *)addressID
+- (NSURL *)urlForCustomersAddressWithAddressID:(NSNumber *)addressID
 {
-	return [[[[self urlForCustomersWithID:customerID] appendPath:@"/addresses"] appendIdentifier:addressID] appendExtension];
+	return [[[[self urlForLoggedInCustomer] appendPath:@"/addresses"] appendIdentifier:addressID] appendExtension];
 }
 
 #pragma mark - Utilities -

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Routing.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Routing.m
@@ -25,6 +25,7 @@
 //
 
 #import "BUYClient+Routing.h"
+#import "BUYCustomerToken.h"
 
 #pragma mark - NSURL (Private Routing) -
 
@@ -186,6 +187,11 @@
 - (NSURL *)urlForCustomersPasswordRecovery
 {
 	return [[[self urlForCustomers] appendPath:@"/recover"] appendExtension];
+}
+
+- (NSURL *)urlForLoggedInCustomer
+{
+	return [self urlForCustomersWithID:self.customerToken.customerID];
 }
 
 #pragma mark - Customer With ID -

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Routing.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Routing.m
@@ -191,7 +191,12 @@
 
 - (NSURL *)urlForLoggedInCustomer
 {
-	return [self urlForCustomersWithID:self.customerToken.customerID];
+	return [self urlForCustomersWithID:[self.customerToken.customerID stringValue]];
+}
+
+- (NSURL *)urlForLoggedInCustomerToken
+{
+	return [[[self urlForLoggedInCustomer] appendPath:@"/customer_token"] appendExtension];
 }
 
 #pragma mark - Customer With ID -
@@ -201,14 +206,14 @@
 	return [[[self urlForCustomers] appendPath:identifier] appendExtension];
 }
 
-- (NSURL *)urlForCustomersOrdersWithID:(NSString *)identifier
+- (NSURL *)urlForCustomersOrders
 {
-	return [[[self urlForCustomersWithID:identifier] appendPath:@"/orders"] appendExtension];
+	return [[[self urlForLoggedInCustomer] appendPath:@"/orders"] appendExtension];
 }
 
-- (NSURL *)urlForCustomersOrdersWithID:(NSString *)identifier orderID:(NSNumber *)orderID
+- (NSURL *)urlForCustomersOrdersWithOrderID:(NSNumber *)orderID
 {
-	return [[[self urlForCustomersOrdersWithID:identifier] appendIdentifier:orderID] appendExtension];
+	return [[[self urlForCustomersOrders] appendIdentifier:orderID] appendExtension];
 }
 
 - (NSURL *)urlForCustomersActivationWithID:(NSString *)identifier parameters:(NSDictionary *)parameters
@@ -216,14 +221,9 @@
 	return [[[[self urlForCustomersWithID:identifier] appendPath:@"/activate"] appendParameters:parameters] appendExtension];
 }
 
-- (NSURL *)urlForCustomersTokenWithID:(NSString *)customerID
+- (NSURL *)urlForCustomersTokenRenewal
 {
-	return [[[self urlForCustomersWithID:customerID] appendPath:@"/customer_token"] appendExtension];
-}
-
-- (NSURL *)urlForCustomersTokenRenewalWithID:(NSString *)customerID
-{
-	return [[[self urlForCustomersWithID:customerID] appendPath:@"/customer_token/renew"] appendExtension];
+	return [[[self urlForLoggedInCustomer] appendPath:@"/customer_token/renew"] appendExtension];
 }
 
 - (NSURL *)urlForCustomersPasswordResetWithID:(NSString *)identifier parameters:(NSDictionary *)parameters

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.h
@@ -25,8 +25,9 @@
 //
 
 @import Foundation;
-#import "BUYClientTypes.h"
+#import <Buy/BUYClientTypes.h>
 
+@class BUYCustomerToken;
 @class BUYModelManager;
 @class BUYOperation;
 @class BUYRequestOperation;
@@ -97,7 +98,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param token The token received from the create and login callbacks
  */
-@property (strong, nonatomic, nullable) NSString *customerToken;
+@property (strong, nonatomic, nullable) BUYCustomerToken *customerToken;
 
 @end
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.m
@@ -26,6 +26,7 @@
 
 #import "BUYClient+Internal.h"
 #import "BUYAssert.h"
+#import "BUYCustomerToken.h"
 #import "BUYModelManager.h"
 #import "BUYRequestOperation.h"
 
@@ -222,7 +223,7 @@ static NSString * const BUYClientJSONMimeType = @"application/json";
 	[request addValue:BUYClientJSONMimeType forHTTPHeaderField:@"Accept"];
 	
 	if (self.customerToken) {
-		[request addValue:self.customerToken forHTTPHeaderField:BUYClientCustomerAccessToken];
+		[request addValue:self.customerToken.accessToken forHTTPHeaderField:BUYClientCustomerAccessToken];
 	}
 	
 	request.HTTPMethod = method;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYAccountCredentials.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYAccountCredentials.h
@@ -48,6 +48,7 @@ OBJC_EXTERN NSString * const BUYAccountPasswordKey;
 
 + (BUYAccountCredentials *)credentialsWithItems:(NSArray<BUYAccountCredentialItem *> *)items;
 - (instancetype)initWithItems:(NSArray<BUYAccountCredentialItem *> *)items;
+- (BUYAccountCredentialItem *)credentialItemForKey:(NSString *)key;
 
 - (BUYAccountCredentials *)credentialsByAddingItems:(NSArray<BUYAccountCredentialItem *> *)items;
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYAccountCredentials.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYAccountCredentials.m
@@ -75,6 +75,11 @@ NSString * const BUYAccountPasswordKey             = @"password";
 	return self.credentialItems.allValues;
 }
 
+- (BUYAccountCredentialItem *)credentialItemForKey:(NSString *)key
+{
+	return _credentialItems[key];
+}
+
 - (NSUInteger)count
 {
 	return self.credentialItems.count;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCustomerToken.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCustomerToken.h
@@ -1,5 +1,5 @@
 //
-//  BUYAuthenticatedResponse.m
+//  BUYCustomerToken.h
 //  Mobile Buy SDK
 //
 //  Created by Shopify.
@@ -24,28 +24,14 @@
 //  THE SOFTWARE.
 //
 
-#import "BUYAuthenticatedResponse.h"
-#import "NSDateFormatter+BUYAdditions.h"
+#import <Foundation/Foundation.h>
 
-@implementation BUYAuthenticatedResponse
+@interface BUYCustomerToken : NSObject
 
-+ (BUYAuthenticatedResponse *)responseWithJSON:(NSDictionary *)json
-{
-	return [[[self class] alloc] initWithJSON:json];
-}
+@property (nonatomic, copy, readonly) NSString *accessToken;
+@property (nonatomic, copy, readonly) NSDate *expiry;
+@property (nonatomic, copy, readonly) NSString *customerID;
 
-- (instancetype)initWithJSON:(NSDictionary *)json
-{
-	self = [super init];
-	if (self) {
-		NSDateFormatter *formatter = [NSDateFormatter dateFormatterForPublications];
-		NSDictionary *access       = json[@"customer_access_token"];
-		
-		_accessToken = access[@"access_token"];
-		_expiry      = [formatter dateFromString:access[@"expires_at"]];
-		_customerID  = [NSString stringWithFormat:@"%@", access[@"customer_id"]];
-	}
-	return self;
-}
++ (BUYCustomerToken *)responseWithJSON:(NSDictionary *)json;
 
 @end

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCustomerToken.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCustomerToken.h
@@ -31,7 +31,8 @@
 @property (nonatomic, copy, readonly) NSString *accessToken;
 @property (nonatomic, copy, readonly) NSDate *expiry;
 @property (nonatomic, copy, readonly) NSString *customerID;
+@property (nonatomic, copy, readonly) NSDictionary *JSONDictionary;
 
-+ (BUYCustomerToken *)responseWithJSON:(NSDictionary *)json;
++ (BUYCustomerToken *)customerTokenWithJSON:(NSDictionary *)json;
 
 @end

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCustomerToken.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCustomerToken.h
@@ -30,9 +30,11 @@
 
 @property (nonatomic, copy, readonly) NSString *accessToken;
 @property (nonatomic, copy, readonly) NSDate *expiry;
-@property (nonatomic, copy, readonly) NSString *customerID;
+@property (nonatomic, copy, readonly) NSNumber *customerID;
 @property (nonatomic, copy, readonly) NSDictionary *JSONDictionary;
 
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithCustomerID:(NSNumber *)customerID accessToken:(NSString *)accessToken expiry:(NSDate *)expiry;
 + (BUYCustomerToken *)customerTokenWithJSON:(NSDictionary *)json;
 
 @end

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCustomerToken.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCustomerToken.h
@@ -35,6 +35,6 @@
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithCustomerID:(NSNumber *)customerID accessToken:(NSString *)accessToken expiry:(NSDate *)expiry;
-+ (BUYCustomerToken *)customerTokenWithJSON:(NSDictionary *)json;
++ (BUYCustomerToken *)customerTokenWithJSONDictionary:(NSDictionary *)json;
 
 @end

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCustomerToken.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCustomerToken.m
@@ -34,23 +34,31 @@ static NSString * const customerIDKey = @"customer_id";
 
 @implementation BUYCustomerToken
 
+- (instancetype)initWithCustomerID:(NSNumber *)customerID accessToken:(NSString *)accessToken expiry:(NSDate *)expiry
+{
+	self = [super init];
+	if (self) {
+		_customerID  = customerID;
+		_accessToken = accessToken;
+		_expiry      = expiry;
+	}
+	return self;
+}
+
 + (BUYCustomerToken *)customerTokenWithJSON:(NSDictionary *)json
 {
-	return [[[self class] alloc] initWithJSON:json];
+	return [[self alloc] initWithJSON:json];
 }
 
 - (instancetype)initWithJSON:(NSDictionary *)json
 {
-	self = [super init];
-	if (self) {
-		NSDateFormatter *formatter = [NSDateFormatter dateFormatterForPublications];
-		NSDictionary *access       = json[customerAccessTokenKey];
-		
-		_accessToken = access[accessTokenKey];
-		_expiry      = [formatter dateFromString:access[expiresAtKey]];
-		_customerID  = [NSString stringWithFormat:@"%@", access[customerIDKey]];
-	}
-	return self;
+	NSDateFormatter *formatter = [NSDateFormatter dateFormatterForPublications];
+	NSDictionary *access       = json[customerAccessTokenKey];
+	
+	NSNumber *customerID  = access[customerIDKey];
+	NSString *accessToken = access[accessTokenKey];
+	NSDate *expiry = [formatter dateFromString:access[expiresAtKey]];
+	return [self initWithCustomerID:customerID accessToken:accessToken expiry:expiry];
 }
 
 - (NSDictionary *)JSONDictionary

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCustomerToken.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCustomerToken.m
@@ -1,5 +1,5 @@
 //
-//  BUYAuthenticatedResponse.h
+//  BUYCustomerToken.m
 //  Mobile Buy SDK
 //
 //  Created by Shopify.
@@ -24,14 +24,28 @@
 //  THE SOFTWARE.
 //
 
-#import <Foundation/Foundation.h>
+#import "BUYCustomerToken.h"
+#import "NSDateFormatter+BUYAdditions.h"
 
-@interface BUYAuthenticatedResponse : NSObject
+@implementation BUYCustomerToken
 
-@property (nonatomic, copy, readonly) NSString *accessToken;
-@property (nonatomic, copy, readonly) NSDate *expiry;
-@property (nonatomic, copy, readonly) NSString *customerID;
++ (BUYCustomerToken *)responseWithJSON:(NSDictionary *)json
+{
+	return [[[self class] alloc] initWithJSON:json];
+}
 
-+ (BUYAuthenticatedResponse *)responseWithJSON:(NSDictionary *)json;
+- (instancetype)initWithJSON:(NSDictionary *)json
+{
+	self = [super init];
+	if (self) {
+		NSDateFormatter *formatter = [NSDateFormatter dateFormatterForPublications];
+		NSDictionary *access       = json[@"customer_access_token"];
+		
+		_accessToken = access[@"access_token"];
+		_expiry      = [formatter dateFromString:access[@"expires_at"]];
+		_customerID  = [NSString stringWithFormat:@"%@", access[@"customer_id"]];
+	}
+	return self;
+}
 
 @end

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCustomerToken.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCustomerToken.m
@@ -27,9 +27,14 @@
 #import "BUYCustomerToken.h"
 #import "NSDateFormatter+BUYAdditions.h"
 
+static NSString * const customerAccessTokenKey = @"customer_access_token";
+static NSString * const accessTokenKey = @"access_token";
+static NSString * const expiresAtKey = @"expires_at";
+static NSString * const customerIDKey = @"customer_id";
+
 @implementation BUYCustomerToken
 
-+ (BUYCustomerToken *)responseWithJSON:(NSDictionary *)json
++ (BUYCustomerToken *)customerTokenWithJSON:(NSDictionary *)json
 {
 	return [[[self class] alloc] initWithJSON:json];
 }
@@ -39,13 +44,23 @@
 	self = [super init];
 	if (self) {
 		NSDateFormatter *formatter = [NSDateFormatter dateFormatterForPublications];
-		NSDictionary *access       = json[@"customer_access_token"];
+		NSDictionary *access       = json[customerAccessTokenKey];
 		
-		_accessToken = access[@"access_token"];
-		_expiry      = [formatter dateFromString:access[@"expires_at"]];
-		_customerID  = [NSString stringWithFormat:@"%@", access[@"customer_id"]];
+		_accessToken = access[accessTokenKey];
+		_expiry      = [formatter dateFromString:access[expiresAtKey]];
+		_customerID  = [NSString stringWithFormat:@"%@", access[customerIDKey]];
 	}
 	return self;
+}
+
+- (NSDictionary *)JSONDictionary
+{
+	NSDateFormatter *formatter = [NSDateFormatter dateFormatterForPublications];
+	return @{
+			 accessTokenKey : _accessToken,
+			 expiresAtKey : [formatter stringFromDate:_expiry],
+			 customerIDKey : _customerID
+			 };
 }
 
 @end

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCustomerToken.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCustomerToken.m
@@ -26,6 +26,7 @@
 
 #import "BUYCustomerToken.h"
 #import "NSDateFormatter+BUYAdditions.h"
+#import "NSDictionary+BUYAdditions.h"
 
 static NSString * const customerAccessTokenKey = @"customer_access_token";
 static NSString * const accessTokenKey = @"access_token";
@@ -36,6 +37,10 @@ static NSString * const customerIDKey = @"customer_id";
 
 - (instancetype)initWithCustomerID:(NSNumber *)customerID accessToken:(NSString *)accessToken expiry:(NSDate *)expiry
 {
+	NSParameterAssert(customerID);
+	NSParameterAssert(accessToken);
+	NSParameterAssert(expiry);
+	
 	self = [super init];
 	if (self) {
 		_customerID  = customerID;
@@ -45,7 +50,7 @@ static NSString * const customerIDKey = @"customer_id";
 	return self;
 }
 
-+ (BUYCustomerToken *)customerTokenWithJSON:(NSDictionary *)json
++ (BUYCustomerToken *)customerTokenWithJSONDictionary:(NSDictionary *)json
 {
 	return [[self alloc] initWithJSON:json];
 }
@@ -53,7 +58,7 @@ static NSString * const customerIDKey = @"customer_id";
 - (instancetype)initWithJSON:(NSDictionary *)json
 {
 	NSDateFormatter *formatter = [NSDateFormatter dateFormatterForPublications];
-	NSDictionary *access       = json[customerAccessTokenKey];
+	NSDictionary *access       = json[customerAccessTokenKey] ?: json;
 	
 	NSNumber *customerID  = access[customerIDKey];
 	NSString *accessToken = access[accessTokenKey];

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Mobile Buy SDK.xcdatamodeld/Mobile Buy SDK.xcdatamodel/contents
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Mobile Buy SDK.xcdatamodeld/Mobile Buy SDK.xcdatamodel/contents
@@ -983,25 +983,25 @@
         <memberEntity name="CheckoutAttribute"/>
     </configuration>
     <elements>
-        <element name="Address" positionX="126" positionY="521" width="128" height="255"/>
-        <element name="Cart" positionX="-576" positionY="558" width="128" height="60"/>
-        <element name="CartLineItem" positionX="-380" positionY="558" width="128" height="90"/>
-        <element name="Checkout" positionX="333" positionY="442" width="128" height="630"/>
-        <element name="CheckoutAttribute" positionX="-954" positionY="594" width="128" height="90"/>
-        <element name="Collection" positionX="-963" positionY="772" width="128" height="195"/>
-        <element name="Customer" positionX="106" positionY="1263" width="128" height="330"/>
-        <element name="Discount" positionX="126" positionY="877" width="128" height="105"/>
-        <element name="GiftCard" positionX="531" positionY="862" width="128" height="135"/>
-        <element name="ImageLink" positionX="-1161" positionY="832" width="128" height="165"/>
-        <element name="LineItem" positionX="-18" positionY="727" width="128" height="315"/>
-        <element name="MaskedCreditCard" positionX="531" positionY="693" width="128" height="150"/>
-        <element name="Option" positionX="-576" positionY="907" width="128" height="105"/>
-        <element name="OptionValue" positionX="-387" positionY="907" width="128" height="105"/>
-        <element name="Order" positionX="682" positionY="922" width="128" height="180"/>
-        <element name="Product" positionX="-765" positionY="712" width="128" height="285"/>
-        <element name="ProductVariant" positionX="-182" positionY="787" width="128" height="240"/>
-        <element name="ShippingRate" positionX="531" positionY="1035" width="128" height="135"/>
-        <element name="Shop" positionX="-279" positionY="450" width="128" height="255"/>
-        <element name="TaxLine" positionX="126" positionY="1026" width="128" height="133"/>
+        <element name="Address" positionX="-990" positionY="1444" width="128" height="255"/>
+        <element name="Cart" positionX="-1192" positionY="978" width="128" height="60"/>
+        <element name="CartLineItem" positionX="-987" positionY="1183" width="128" height="90"/>
+        <element name="Checkout" positionX="-765" positionY="1072" width="128" height="630"/>
+        <element name="CheckoutAttribute" positionX="-990" positionY="1332" width="128" height="90"/>
+        <element name="Collection" positionX="-1588" positionY="1063" width="128" height="195"/>
+        <element name="Customer" positionX="-1190" positionY="1359" width="128" height="330"/>
+        <element name="Discount" positionX="-551" positionY="1377" width="128" height="105"/>
+        <element name="GiftCard" positionX="-540" positionY="1492" width="128" height="135"/>
+        <element name="ImageLink" positionX="-1786" positionY="1108" width="128" height="165"/>
+        <element name="LineItem" positionX="-353" positionY="1342" width="128" height="315"/>
+        <element name="MaskedCreditCard" positionX="-567" positionY="1218" width="128" height="150"/>
+        <element name="Option" positionX="-1588" positionY="1287" width="128" height="105"/>
+        <element name="OptionValue" positionX="-1390" positionY="894" width="128" height="105"/>
+        <element name="Order" positionX="-549" positionY="1647" width="128" height="180"/>
+        <element name="Product" positionX="-1390" positionY="1018" width="128" height="300"/>
+        <element name="ProductVariant" positionX="-1192" positionY="1063" width="128" height="240"/>
+        <element name="ShippingRate" positionX="-569" positionY="1836" width="128" height="135"/>
+        <element name="Shop" positionX="-1786" positionY="843" width="128" height="255"/>
+        <element name="TaxLine" positionX="-990" positionY="1737" width="128" height="133"/>
     </elements>
 </model>

--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYWebCheckoutPaymentProvider.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYWebCheckoutPaymentProvider.m
@@ -27,6 +27,7 @@
 #import "BUYWebCheckoutPaymentProvider.h"
 #import "BUYCheckout.h"
 #import "BUYClient+Checkout.h"
+#import "BUYCustomerToken.h"
 #import "BUYAssert.h"
 
 @import SafariServices;
@@ -176,11 +177,11 @@ static NSString *const WebCheckoutCustomerAccessToken = @"customer_access_token"
 
 - (NSURL *)authenticatedWebCheckoutURL:(NSURL *)url
 {
-	NSString *customerToken = self.client.customerToken;
-	if (!customerToken.length) {
+	NSString *accessToken = self.client.customerToken.accessToken;
+	if (!accessToken.length) {
 		return url;
 	}
-	NSURLQueryItem *item = [NSURLQueryItem queryItemWithName:WebCheckoutCustomerAccessToken value:customerToken];
+	NSURLQueryItem *item = [NSURLQueryItem queryItemWithName:WebCheckoutCustomerAccessToken value:accessToken];
 	NSURLComponents *authenticatedComponents = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:YES];
 	authenticatedComponents.queryItems = authenticatedComponents.queryItems ? [authenticatedComponents.queryItems arrayByAddingObject:item] : @[item];
 	return authenticatedComponents.URL;


### PR DESCRIPTION
# Purpose

The customer authentication (token creation) endpoint provided by Shopify returns an access token (`customer_access_token`) object. This includes three attributes: `customer_id`, `expires_at` and `access_token`. Up until now, the buy client has been keeping a reference to the token string, using the customer ID to fetch the customer, and throwing away the expiry date.

On Android, in contrast, we keep a reference to the entire access token.

As a consequence, APIs that require a customer to be authenticated can use the `customerID` from the access token, instead of a needing a parameter.

# Approach

This PR updates the behaviour to match Android, keeping a reference to the entire access token.

We have renamed a private class to `BUYCustomerToken` and made it public. Callbacks now return this object, instead of the token string.

Simultaneously, we are updating customer APIs on both Android and iOS to remove the `customerID` parameter for those APIs that require authentication: getting and updating the customer, renewing the token, and all address access.

Fixes https://github.com/Shopify/mobile-buy-sdk-ios/issues/268

# Steps

- [ ] Unit tests
- [ ] Code Review
- [ ] Test