### PR TITLE
Add customer update endpoint

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClient+CustomerTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClient+CustomerTests.m
@@ -197,6 +197,23 @@
 	[self waitForExpectationsWithTimeout:10.0 handler:^(NSError *error) {}];
 }
 
+- (void)testCustomerUpdate
+{
+	[OHHTTPStubs stubUsingResponseWithKey:@"testCustomerLogin" useMocks:[self shouldUseMocks]];
+
+	XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
+
+	[self.client updateCustomer:_customer callback:^(BUYCustomer * _Nullable customer, NSError * _Nullable error) {
+
+		XCTAssertNil(error);
+		XCTAssertNotNil(customer);
+ 
+		[expectation fulfill];
+ 	}];
+
+	[self waitForExpectationsWithTimeout:10 handler:^(NSError *error) {}];
+}
+
 #pragma mark - Address -
 
 - (void)testGetAddresses

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClient+CustomerTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClient+CustomerTests.m
@@ -197,29 +197,6 @@
 	[self waitForExpectationsWithTimeout:10.0 handler:^(NSError *error) {}];
 }
 
-#pragma mark - Update -
-
-- (void)testCustomerUpdate
-{
-	[OHHTTPStubs stubUsingResponseWithKey:@"testCustomerLogin" useMocks:[self shouldUseMocks]];
-
-	XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
-	
-	BUYAccountCredentialItem *email    = [BUYAccountCredentialItem itemWithEmail:self.customerEmail];
-	BUYAccountCredentials *credentials = [BUYAccountCredentials credentialsWithItems:@[email]];
-	
-	[self.client updateCustomerWithCredentials:credentials callback:^(BUYCustomer *customer, NSError *error) {
-		
-		XCTAssertNil(error);
-		XCTAssertNotNil(customer);
-		XCTAssertEqualObjects(customer.email, self.customerEmail);
-		
-		[expectation fulfill];
-	}];
-	
-	[self waitForExpectationsWithTimeout:10 handler:^(NSError *error) {}];
-}
-
 #pragma mark - Address -
 
 - (void)testGetAddresses

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.h
@@ -119,14 +119,13 @@ typedef void (^BUYDataOrderBlock)(BUYOrder * _Nullable order, NSError * _Nullabl
 
 /**
  *  PUT /api/customers/:customer_id
- *  Update customer credentials represented by BUYAccountCredentials object
  *
- *  @param credentials   Credentials containing a password
- *  @param block         (BUYCustomer *customer, NSError *error)
+ *  @param customer		the customer object to update
+ *  @param block        (BUYCustomer *customer, NSError *error)
  *
  *  @return The associated BUYRequestOperation
  */
-- (NSOperation *)updateCustomerWithCredentials:(BUYAccountCredentials *)credentials callback:(BUYDataCustomerBlock)block;
+- (NSOperation *)updateCustomer:(BUYCustomer *)customer callback:(BUYDataCustomerBlock)block;
 
 /**
  *  PUT /api/customers/:customer_id/reset

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.m
@@ -82,10 +82,10 @@
 	}];
 }
 
-- (NSOperation *)updateCustomerWithCredentials:(BUYAccountCredentials *)credentials callback:(BUYDataCustomerBlock)block
+- (NSOperation *)updateCustomer:(BUYCustomer *)customer callback:(BUYDataCustomerBlock)block
 {
-	NSURL *url = [self urlForLoggedInCustomer];
-	return [self putRequestForURL:url object:credentials.JSONRepresentation completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
+	NSURL *url = [self urlForCustomersWithID:customer.identifier.stringValue];
+	return [self putRequestForURL:url object:@{@"customer": customer.JSONDictionary} completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
 		BUYCustomer *customer = nil;
 		if (json && !error) {
 			customer = [self.modelManager customerWithJSONDictionary:json];


### PR DESCRIPTION
### What is this

Fix: #272 

Adds support for the update customer endpoint.  Removes pointless customer update unit test.

@bgulanowski 