### PR TITLE
Add support to get collection with handle

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClient+StorefrontTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClient+StorefrontTests.m
@@ -253,6 +253,26 @@
 	}];
 }
 
+- (void)testCollectionHandle
+{
+	[OHHTTPStubs stubUsingResponseWithKey:@"testGetCollection_0" useMocks:[self shouldUseMocks]];
+	
+    XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
+    [self.client getCollectionByHandle:@"frontpage" completion:^(BUYCollection * _Nullable collection, NSError * _Nullable error) {
+        
+        XCTAssertNotNil(collection);
+        XCTAssertEqualObjects(@"Frontpage", collection.title);
+		XCTAssertEqualObjects(@109931075, collection.identifier);
+        XCTAssertNil(error);
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:10 handler:^(NSError *error) {
+        XCTAssertNil(error);
+    }];
+}
+
 - (void)testProductsInCollection
 {
 	if (self.collection == nil) {

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.h
@@ -78,6 +78,14 @@ typedef NS_ENUM(NSUInteger, BUYCollectionSort) {
 typedef void (^BUYDataShopBlock)(BUYShop * _Nullable shop, NSError * _Nullable error);
 
 /**
+ *  Return block containing a BUYCollection object and/or an NSError
+ *
+ *  @param collection  A BUYCollection object.
+ *  @param error       Optional NSError
+ */
+typedef void (^BUYDataCollectionBlock)(BUYCollection* _Nullable collection, NSError * _Nullable error);
+
+/**
  *  Return block containing a list of BUYCollection objects and/or an NSError
  *
  *  @param collections An array of BUYCollection objects
@@ -189,6 +197,16 @@ typedef void (^BUYDataTagsListBlock)(NSArray <NSString *> * _Nullable tags, NSUI
  *  @return The associated NSOperation
  */
 - (NSOperation *)getProductTagsPage:(NSUInteger)page completion:(BUYDataTagsListBlock)block;
+
+/**
+ *  Fetch a single collection by the handle of the collection.
+ *
+ *  @param handle Collection handle
+ *  @param block  (^BUYDataCollectionBlock)(BUYCollection* _Nullable collection, NSError * _Nullable error)
+ *
+ *  @return The associated operation.
+ */
+- (NSOperation *)getCollectionByHandle:(NSString *)handle completion:(BUYDataCollectionBlock)block;
 
 /**
  *  Fetches collections based off page

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.h
@@ -144,7 +144,7 @@ typedef void (^BUYDataTagsListBlock)(NSArray <NSString *> * _Nullable tags, NSUI
  *
  *  @param block (^BUYDataShopBlock)(BUYShop *shop, NSError *error);
  *
- *  @return The associated BUYRequestOperation
+ *  @return The associated operation
  */
 - (NSOperation *)getShop:(BUYDataShopBlock)block;
 
@@ -154,7 +154,7 @@ typedef void (^BUYDataTagsListBlock)(NSArray <NSString *> * _Nullable tags, NSUI
  *  @param page  Page to request. Pages start at 1.
  *  @param block (^BUYDataProductListBlock)(NSArray *products, NSUInteger page, BOOL reachedEnd, NSError *error);
  *
- *  @return The associated BUYRequestOperation
+ *  @return The associated operation
  */
 - (NSOperation *)getProductsPage:(NSUInteger)page completion:(BUYDataProductListBlock)block;
 
@@ -164,7 +164,7 @@ typedef void (^BUYDataTagsListBlock)(NSArray <NSString *> * _Nullable tags, NSUI
  *  @param handle  Product handle
  *  @param block   (^BUYDataProductBlock)(BUYProduct *product, NSError *error);
  *
- *  @return The associated BUYRequestOperation
+ *  @return The associated operation
  */
 - (NSOperation *)getProductByHandle:(NSString *)handle completion:(BUYDataProductBlock)block;
 
@@ -174,7 +174,7 @@ typedef void (^BUYDataTagsListBlock)(NSArray <NSString *> * _Nullable tags, NSUI
  *  @param productId Product ID
  *  @param block     (^BUYDataProductBlock)(BUYProduct *product, NSError *error);
  *
- *  @return The associated BUYRequestOperation
+ *  @return The associated operation
  */
 - (NSOperation *)getProductById:(NSNumber *)productId completion:(BUYDataProductBlock)block;
 
@@ -184,7 +184,7 @@ typedef void (^BUYDataTagsListBlock)(NSArray <NSString *> * _Nullable tags, NSUI
  *  @param productIds An array of `NSString` objects with Product IDs to fetch
  *  @param block      (^BUYDataProductsBlock)(NSArray *products, NSError *error);
  *
- *  @return The associated BUYRequestOperation
+ *  @return The associated operation
  */
 - (NSOperation *)getProductsByIds:(NSArray<NSNumber *> *)productIds completion:(BUYDataProductsBlock)block;
 
@@ -214,7 +214,7 @@ typedef void (^BUYDataTagsListBlock)(NSArray <NSString *> * _Nullable tags, NSUI
  *  @param page  Index of the page requested
  *  @param block (^BUYDataCollectionsBlock)(NSArray *collections, NSError *error)
  *
- *  @return The associated BUYRequestOperation
+ *  @return The associated operation
  */
 - (NSOperation *)getCollectionsPage:(NSUInteger)page completion:(BUYDataCollectionsListBlock)block;
 
@@ -226,7 +226,7 @@ typedef void (^BUYDataTagsListBlock)(NSArray <NSString *> * _Nullable tags, NSUI
  *  @param collectionId The `collectionId` found in the BUYCollection object to fetch the products from
  *  @param block        (NSArray *products, NSUInteger page, BOOL reachedEnd, NSError *error)
  *
- *  @return the associated BUYRequestOperation
+ *  @return the associated operation
  */
 - (NSOperation *)getProductsPage:(NSUInteger)page inCollection:(NSNumber *)collectionId completion:(BUYDataProductListBlock)block;
 
@@ -239,7 +239,7 @@ typedef void (^BUYDataTagsListBlock)(NSArray <NSString *> * _Nullable tags, NSUI
  *  @param sortOrder    The sort order that overrides the default collection sort order
  *  @param block        (NSArray *products, NSUInteger page, BOOL reachedEnd, NSError *error)
  *
- *  @return the associated BUYRequestOperation
+ *  @return the associated operation
  */
 - (NSOperation *)getProductsPage:(NSUInteger)page inCollection:(nullable NSNumber *)collectionId withTags:(nullable NSArray <NSString *> *)tags sortOrder:(BUYCollectionSort)sortOrder completion:(BUYDataProductListBlock)block;
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.m
@@ -141,6 +141,21 @@ static NSString * const BUYCollectionsKey = @"collection_listings";
 	}];
 }
 
+- (NSOperation *)getCollectionByHandle:(NSString *)handle completion:(BUYDataCollectionBlock)block
+{
+	NSURL *url = [self urlForCollectionListingsWithParameters:@{
+																@"handle" : handle
+																}];
+	
+	return [self getRequestForURL:url completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
+		BUYCollection *collection = nil;
+		if (json && !error) {
+			collection = [self.modelManager buy_objectWithEntityName:[BUYCollection entityName] JSONDictionary:json];
+		}
+		block(collection, error);
+	}];
+}
+
 - (NSOperation *)getCollectionsPage:(NSUInteger)page completion:(BUYDataCollectionsListBlock)block
 {
 	NSURL *url  = [self urlForCollectionListingsWithParameters:@{

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.m
@@ -150,7 +150,7 @@ static NSString * const BUYCollectionsKey = @"collection_listings";
 	return [self getRequestForURL:url completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
 		BUYCollection *collection = nil;
 		if (json && !error) {
-			collection = [self.modelManager buy_objectWithEntityName:[BUYCollection entityName] JSONDictionary:json];
+			collection = [self.modelManager buy_objectWithEntityName:[BUYCollection entityName] JSONDictionary:json[BUYCollectionsKey][0]];
 		}
 		block(collection, error);
 	}];


### PR DESCRIPTION
# Why

To support shared links from the web for collections, we must be able to fetch a collection by the handle used in the link. Parity with Android.

# How

New storefront API method that accepts a handle as a string, returns a collection.

- [x] Code Review
- [ ] Test

@gabrieloc @krisorr 