### PR TITLE
Add "Address.isDefault" boolean <-> "default"

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClient+CustomerTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClient+CustomerTests.m
@@ -232,6 +232,9 @@
 		XCTAssertTrue([addresses.firstObject isKindOfClass:[BUYAddress class]]);
 		XCTAssertNil(error);
 		
+		NSArray *defaultAddresses = [addresses filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"isDefault == 1"]];
+		XCTAssertEqual(1, defaultAddresses.count);
+		
 		[expectation fulfill];
 	}];
 	

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Mobile Buy SDK.xcdatamodeld/Mobile Buy SDK.xcdatamodel/contents
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Mobile Buy SDK.xcdatamodeld/Mobile Buy SDK.xcdatamodel/contents
@@ -41,6 +41,13 @@
                 <entry key="documentation" value="Unique identifier for the address"/>
             </userInfo>
         </attribute>
+        <attribute name="isDefault" optional="YES" attributeType="Boolean" syncable="YES">
+            <userInfo>
+                <entry key="discussion" value="Maps to &quot;default&quot; key in JSON."/>
+                <entry key="documentation" value="Whether the address is the owning customer's default address."/>
+                <entry key="JSONPropertyKey" value="default"/>
+            </userInfo>
+        </attribute>
         <attribute name="lastName" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
                 <entry key="documentation" value="The last name of the person associated with the payment method."/>
@@ -983,7 +990,7 @@
         <memberEntity name="CheckoutAttribute"/>
     </configuration>
     <elements>
-        <element name="Address" positionX="-990" positionY="1444" width="128" height="255"/>
+        <element name="Address" positionX="-990" positionY="1444" width="128" height="270"/>
         <element name="Cart" positionX="-1192" positionY="978" width="128" height="60"/>
         <element name="CartLineItem" positionX="-987" positionY="1183" width="128" height="90"/>
         <element name="Checkout" positionX="-765" positionY="1072" width="128" height="630"/>

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYAddress.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYAddress.h
@@ -39,6 +39,7 @@ extern const struct BUYAddressAttributes {
 	__unsafe_unretained NSString *countryCode;
 	__unsafe_unretained NSString *firstName;
 	__unsafe_unretained NSString *identifier;
+	__unsafe_unretained NSString *isDefault;
 	__unsafe_unretained NSString *lastName;
 	__unsafe_unretained NSString *phone;
 	__unsafe_unretained NSString *province;
@@ -115,6 +116,17 @@ extern const struct BUYAddressUserInfo {
 - (void)setIdentifierValue:(int64_t)value_;
 
 /**
+ * Whether the address is the owning customer's default address.
+ *
+ * Maps to "default" key in JSON.
+ */
+@property (nonatomic, strong) NSNumber* isDefault;
+
+@property (atomic) BOOL isDefaultValue;
+- (BOOL)isDefaultValue;
+- (void)setIsDefaultValue:(BOOL)value_;
+
+/**
  * The last name of the person associated with the payment method.
  */
 @property (nonatomic, strong) NSString* lastName;
@@ -168,6 +180,9 @@ extern const struct BUYAddressUserInfo {
 
 - (NSNumber*)primitiveIdentifier;
 - (void)setPrimitiveIdentifier:(NSNumber*)value;
+
+- (NSNumber*)primitiveIsDefault;
+- (void)setPrimitiveIsDefault:(NSNumber*)value;
 
 - (NSString*)primitiveLastName;
 - (void)setPrimitiveLastName:(NSString*)value;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYAddress.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYAddress.m
@@ -37,6 +37,7 @@ const struct BUYAddressAttributes BUYAddressAttributes = {
 	.countryCode = @"countryCode",
 	.firstName = @"firstName",
 	.identifier = @"identifier",
+	.isDefault = @"isDefault",
 	.lastName = @"lastName",
 	.phone = @"phone",
 	.province = @"province",
@@ -66,6 +67,11 @@ const struct BUYAddressUserInfo BUYAddressUserInfo = {
 		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
 		return keyPaths;
 	}
+	if ([key isEqualToString:@"isDefaultValue"]) {
+		NSSet *affectingKey = [NSSet setWithObject:@"isDefault"];
+		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+		return keyPaths;
+	}
 
 	return keyPaths;
 }
@@ -79,6 +85,7 @@ const struct BUYAddressUserInfo BUYAddressUserInfo = {
 @dynamic countryCode;
 @dynamic firstName;
 @dynamic identifier;
+@dynamic isDefault;
 @dynamic lastName;
 @dynamic phone;
 @dynamic province;
@@ -93,6 +100,15 @@ const struct BUYAddressUserInfo BUYAddressUserInfo = {
 
 - (void)setIdentifierValue:(int64_t)value_ {
 	[self setIdentifier:@(value_)];
+}
+
+- (BOOL)isDefaultValue {
+	NSNumber *result = [self isDefault];
+	return [result boolValue];
+}
+
+- (void)setIsDefaultValue:(BOOL)value_ {
+	[self setIsDefault:@(value_)];
 }
 
 #if defined CORE_DATA_PERSISTENCE


### PR DESCRIPTION
# What

Add `isDefault` attribute to `Address` entity.

We will add additional conveniences for making sure that setting the default address on a customer behaves nicely. For now, change the value directly on the correct address, and ensure any other addresses are no longer marked as default.

Fixes #277 

@gabrieloc @krisorr 