### PR TITLE
Args are in wrong order.

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.m
@@ -137,7 +137,7 @@ static NSString * const BUYCollectionsKey = @"collection_listings";
 		if (json && !error) {
 			tags = [json[@"tags"] valueForKey:@"title"];
 		}
-		block(tags, [self hasReachedEndOfPage:tags], page, error);
+		block(tags, page, [self hasReachedEndOfPage:tags], error);
 	}];
 }
 


### PR DESCRIPTION
This puts arguments in the correct order when invoking the completion block.

This causes a compiler error when built for device:

```
mobile-buy-sdk-ios/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.m:140:48: error: implicit conversion loses integer precision: 'const NSUInteger' (aka 'const unsigned int') to 'BOOL' (aka 'signed char') [-Werror,-Wconversion]
                block(tags, [self hasReachedEndOfPage:tags], page, error);
                ~~~~~                                        ^~~~
```
But this issue is not caught when building for simulator.

@gabrieloc @davidmuzi 