### PR TITLE
Removed Swift sample app link in README, and replaced broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,11 +187,11 @@ The Mobile Buy SDK includes a number of targets and schemes:
 
 ### Sample Apps
 
-The repo includes 3 sample apps. Each sample apps embeds the dynamic framework and includes readme files with more information:
+The repo includes 2 sample apps. Each sample apps embeds the dynamic framework and includes readme files with more information:
 
-* [Advanced Sample App](https://github.com/Shopify/mobile-buy-sdk-ios/tree/master/Mobile Buy SDK Sample Apps/Sample App Advanced/README.md)
-* [Swift Sample App](https://github.com/Shopify/mobile-buy-sdk-ios/tree/master/Mobile Buy SDK Sample Apps/Sample App Swift/README.md)
-* [Customers Sample App](https://github.com/Shopify/mobile-buy-sdk-ios/tree/master/Mobile Buy SDK Sample Apps/Sample App Customers/README.md)
+* [Advanced Sample App - Objective C](https://github.com/Shopify/mobile-buy-sdk-ios/tree/develop/Mobile%20Buy%20SDK%20Sample%20Apps/Advanced%20App%20-%20ObjC)
+* [Customers Sample App - Swift](https://github.com/Shopify/mobile-buy-sdk-ios/tree/develop/Mobile%20Buy%20SDK%20Sample%20Apps/Customers%20App%20-%20Swift)
+
 
 We suggest you take a look at the **Advanced Sample App** and test your shop with the sample app before you begin. If you run into any issues, the **Advanced Sample App** is also a great resource for debugging integration issues and checkout.
 


### PR DESCRIPTION
Removed Swift sample app link in README, and replaced broken links.

The new sample app links to their respective folders instead of README.md which the old links linked too, since their respective folders display the README.md anyways

@bgulanowski @gabrieloc 