### PR TITLE
change completeCheckout: return value from BUYOperation to NSOperation

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClientTest.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClientTest.m
@@ -140,7 +140,7 @@
 
 - (void)testCheckoutPaymentWithOnlyGiftCard
 {
-	BUYOperation *task = [self.client completeCheckoutWithToken:@"abcdef" paymentToken:nil completion:^(BUYCheckout *checkout, NSError *error) {}];
+	NSOperation *task = [self.client completeCheckoutWithToken:@"abcdef" paymentToken:nil completion:^(BUYCheckout *checkout, NSError *error) {}];
 	XCTAssertNotNil(task);
 }
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Checkout.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Checkout.h
@@ -142,7 +142,7 @@ typedef void (^BUYDataGiftCardBlock)(BUYGiftCard * _Nullable giftCard, NSError *
  *
  *  @return The associated BUYOperation
  */
-- (BUYOperation *)completeCheckoutWithToken:(nullable NSString *)checkoutToken paymentToken:(_Nullable id<BUYPaymentToken>)paymentToken completion:(BUYDataCheckoutBlock)block;
+- (NSOperation *)completeCheckoutWithToken:(nullable NSString *)checkoutToken paymentToken:(_Nullable id<BUYPaymentToken>)paymentToken completion:(BUYDataCheckoutBlock)block;
 
 /**
  *  Retrieve the status of a checkout with token. This checks the status of the current payment processing job for the provided checkout.

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Checkout.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Checkout.m
@@ -103,7 +103,7 @@
 	}];
 }
 
-- (BUYOperation *)completeCheckoutWithToken:(NSString *)checkoutToken paymentToken:(id<BUYPaymentToken>)paymentToken completion:(BUYDataCheckoutBlock)block
+- (NSOperation *)completeCheckoutWithToken:(NSString *)checkoutToken paymentToken:(id<BUYPaymentToken>)paymentToken completion:(BUYDataCheckoutBlock)block
 {
 	BUYCheckoutOperation *operation = [BUYCheckoutOperation operationWithClient:self checkoutToken:checkoutToken token:paymentToken completion:block];
 	[self startOperation:operation];


### PR DESCRIPTION
completeCheckout: was returning a private class BUYOperation.  When using the Buy framework in Swift the completeCheckout: method was not available because of the private class return type.  I changed the return value for the method to NSOperation which lets the method be available.  Alternatively you could make BUYOperation public.  