### PR TITLE
Fix Apple Pay button logic in PaymentViewController

### DIFF
--- a/Mobile Buy SDK Sample Apps/Advanced App - ObjC/Mobile Buy SDK Advanced Sample/Product View/ProductView.h
+++ b/Mobile Buy SDK Sample Apps/Advanced App - ObjC/Mobile Buy SDK Advanced Sample/Product View/ProductView.h
@@ -87,11 +87,10 @@
  *  @param rect              The rect is needed for the UICollectionView in the ProductViewHeader to setup the cell's bounds
  *  @param product           The product to display in the product view. Only used in the initializer to
  *  @param theme             The theme for the product view
- *  @param showApplePaySetup Show Apple Pay button with 'Set Up Apple Pay' text as determined by the presenter
  *
  *  @return An instance of the ProductView
  */
-- (instancetype)initWithFrame:(CGRect)rect product:(BUYProduct*)product shouldShowApplePaySetup:(BOOL)showApplePaySetup;
+- (instancetype)initWithFrame:(CGRect)rect product:(BUYProduct*)product;
 
 /**
  *  The BUYProductViewController is the UITableViewDelegate, so it receives the UIScrollView delegate method calls. 

--- a/Mobile Buy SDK Sample Apps/Advanced App - ObjC/Mobile Buy SDK Advanced Sample/Product View/ProductView.m
+++ b/Mobile Buy SDK Sample Apps/Advanced App - ObjC/Mobile Buy SDK Advanced Sample/Product View/ProductView.m
@@ -45,7 +45,7 @@
 
 @implementation ProductView
 
-- (instancetype)initWithFrame:(CGRect)rect product:(BUYProduct*)product shouldShowApplePaySetup:(BOOL)showApplePaySetup
+- (instancetype)initWithFrame:(CGRect)rect product:(BUYProduct*)product
 {
 	self = [super initWithFrame:rect];
 	if (self) {

--- a/Mobile Buy SDK Sample Apps/Advanced App - ObjC/Mobile Buy SDK Advanced Sample/Product View/ProductViewController.m
+++ b/Mobile Buy SDK Sample Apps/Advanced App - ObjC/Mobile Buy SDK Advanced Sample/Product View/ProductViewController.m
@@ -286,7 +286,7 @@ CGFloat const BUYMaxProductViewHeight = 640.0;
 
 - (void)createProductView
 {
-    _productView = [[ProductView alloc] initWithFrame:CGRectMake(0, 0, self.preferredContentSize.width, self.preferredContentSize.height) product:self.product shouldShowApplePaySetup:self.shouldShowApplePaySetup];
+    _productView = [[ProductView alloc] initWithFrame:CGRectMake(0, 0, self.preferredContentSize.width, self.preferredContentSize.height) product:self.product];
     _productView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.view addSubview:_productView];
     [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_productView]|" options:0 metrics:nil views:NSDictionaryOfVariableBindings(_productView)]];
@@ -310,7 +310,7 @@ CGFloat const BUYMaxProductViewHeight = 640.0;
     _productView.productViewHeader.collectionView.dataSource = self;
     
     _productView.layoutMargins = UIEdgeInsetsMake(self.productView.layoutMargins.top, self.productView.layoutMargins.left, self.bottomLayoutGuide.length, self.productView.layoutMargins.right);
-    [_productView.productViewFooter setApplePayAvailable:self.shouldShowApplePaySetup requiresSetup:self.shouldShowApplePaySetup];
+
     [_productView.tableView reloadSections:[NSIndexSet indexSetWithIndex:0] withRowAnimation:UITableViewRowAnimationNone];
 
     self.navigationItem.title = _product.title;

--- a/Mobile Buy SDK Sample Apps/Advanced App - ObjC/Mobile Buy SDK Advanced Sample/Product View/View Controllers/PaymentViewController.m
+++ b/Mobile Buy SDK Sample Apps/Advanced App - ObjC/Mobile Buy SDK Advanced Sample/Product View/View Controllers/PaymentViewController.m
@@ -67,12 +67,12 @@
 }
 
 - (BOOL)shouldShowApplePayButton {
-	return self.applePayPaymentProvider.available || [self canShowApplePaySetup];
+	return [self isApplePayAvailable] || [self canShowApplePaySetup];
 }
 
 - (BOOL)shouldShowApplePaySetup
 {
-	return self.applePayPaymentProvider.available == NO && [self canShowApplePaySetup];
+	return [self isApplePayAvailable] == NO && [self canShowApplePaySetup];
 }
 
 #pragma mark - Payment


### PR DESCRIPTION
Fix: #304 

### What

This fixes a bug in the sample app that prevents the Apple Pay button from appearing

### How

Removes a duplicate call to setup the button, which was using the wrong boolean value.

@bgulanowski 