### PR TITLE
Update test to remove delay and add explicit expectation

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYRequestOperationTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYRequestOperationTests.m
@@ -265,7 +265,7 @@
 
 - (void)testCancellationDuringExecution
 {
-	[self stubRequestsWithDelay:2.0];
+	[self stubRequestsWithDelay:0.01];
 	
 	BUYRequestOperation *operation = [self operationFulfillingExpectation:nil completion:^{
 		XCTAssert(NO, @"Operation should not call completion if cancelled.");
@@ -273,7 +273,7 @@
 	
 	[self.queue addOperation:operation];
 	XCTestExpectation *expectation = [self expectationWithDescription:@"Should stop polling at 2 iterations"];
-	[self after:1.0 block:^{
+	[self after:0.001 block:^{
 		XCTAssertFalse(operation.finished);
 		XCTAssertFalse(operation.cancelled);
 		[operation cancel];

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYRequestOperationTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYRequestOperationTests.m
@@ -271,13 +271,17 @@
 		XCTAssert(NO, @"Operation should not call completion if cancelled.");
 	}];
 	
-	[self createExpectationDelay:3.0];
 	[self.queue addOperation:operation];
+	XCTestExpectation *expectation = [self expectationWithDescription:@"Should stop polling at 2 iterations"];
 	[self after:1.0 block:^{
+		XCTAssertFalse(operation.finished);
+		XCTAssertFalse(operation.cancelled);
 		[operation cancel];
+		[expectation fulfill];
+		XCTAssertTrue(operation.cancelled);
 	}];
 	
-	[self waitForExpectationsWithTimeout:10.0 handler:^(NSError *error) {}];
+	[self waitForExpectationsWithTimeout:5.0 handler:^(NSError *error) {}];
 }
 
 - (void)testCancellationWithoutQueue


### PR DESCRIPTION
The test to cancel an operation after it has already started (and before it completes) has been crashing sporadically with a memory access exception. Cause not really known.

This simplifies the test somewhat to create and fulfill an expectation the more common way. Very much a shot in the dark.

Also add some more assertions.

@gabrieloc @dbart01 