### PR TITLE
Convert all #import declarations to use user/quoted style.

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYAccountCredentialsTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYAccountCredentialsTests.m
@@ -24,8 +24,8 @@
 //  THE SOFTWARE.
 //
 
-#import <XCTest/XCTest.h>
-#import <Buy/Buy.h>
+@import XCTest;
+@import Buy;
 
 @interface BUYAccountCredentialsTests : XCTestCase
 

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYApplePayAdditionsTest.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYApplePayAdditionsTest.m
@@ -28,8 +28,7 @@
 @import PassKit;
 @import UIKit;
 @import XCTest;
-
-#import <Buy/Buy.h>
+@import Buy;
 
 #import "BUYPKContact.h"
 #import "BUYNSPersonNameComponents.h"

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYApplePayTokenTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYApplePayTokenTests.m
@@ -24,8 +24,10 @@
 //  THE SOFTWARE.
 //
 
-#import <XCTest/XCTest.h>
-#import <PassKit/PassKit.h>
+@import PassKit;
+@import XCTest;
+@import Buy;
+
 #import "BUYApplePayToken.h"
 #import "BUYApplePayTestToken.h"
 

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYArrayAdditionsTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYArrayAdditionsTests.m
@@ -24,7 +24,8 @@
 //  THE SOFTWARE.
 //
 
-#import <XCTest/XCTest.h>
+@import XCTest;
+
 #import "NSArray+BUYAdditions.h"
 
 @interface BUYArrayAdditionsTests : XCTestCase

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYCartTest.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYCartTest.m
@@ -26,7 +26,7 @@
 
 @import UIKit;
 @import XCTest;
-#import <Buy/Buy.h>
+@import Buy;
 
 @interface BUYCartTest : XCTestCase
 @end

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYCheckoutTest.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYCheckoutTest.m
@@ -26,8 +26,8 @@
 
 @import UIKit;
 @import XCTest;
+@import Buy;
 
-#import <Buy/Buy.h>
 #import "BUYCheckout.h"
 
 @interface BUYCheckoutTest : XCTestCase

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClient+CustomerTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClient+CustomerTests.m
@@ -25,10 +25,10 @@
 //
 
 @import XCTest;
+@import Buy;
+
 #import "BUYClientTestBase.h"
-#import "BUYClient+Customers.h"
-#import "BUYAccountCredentials.h"
-#import "BUYError+BUYAdditions.h"
+
 #import <OHHTTPStubs/OHHTTPStubs.h>
 #import "OHHTTPStubsResponse+Helpers.h"
 

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClient+RoutingTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClient+RoutingTests.m
@@ -24,9 +24,10 @@
 //  THE SOFTWARE.
 //
 
-#import <XCTest/XCTest.h>
+@import XCTest;
+@import Buy;
+
 #import "BUYClient+Routing.h"
-#import "BUYCustomerToken.h"
 
 @interface BUYClient_RoutingTests : XCTestCase
 

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClient+StorefrontTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClient+StorefrontTests.m
@@ -26,13 +26,13 @@
 
 @import UIKit;
 @import XCTest;
-#import <Buy/Buy.h>
-#import "BUYTestConstants.h"
-#import "BUYCollection.h"
+@import Buy;
+
 #import "BUYClientTestBase.h"
+#import "BUYTestConstants.h"
+
 #import <OHHTTPStubs/OHHTTPStubs.h>
 #import "OHHTTPStubsResponse+Helpers.h"
-#import "BUYShopifyErrorCodes.h"
 
 @interface BUYClientTest_Storefront : BUYClientTestBase
 @property (nonatomic, strong) BUYCollection *collection;

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClientTest.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClientTest.m
@@ -26,17 +26,15 @@
 
 @import UIKit;
 @import XCTest;
+@import Buy;
 
-#import <Buy/Buy.h>
+#import "BUYApplePayToken.h"
+#import "BUYClient+Internal.h"
+#import "BUYRequestOperation.h"
+
 #import "BUYTestConstants.h"
 #import "BUYClientTestBase.h"
-#import "BUYShopifyErrorCodes.h"
-#import "BUYAccountCredentials.h"
-#import "BUYClient+Customers.h"
-#import "BUYClient+Internal.h"
-#import "BUYApplePayToken.h"
 #import "BUYApplePayTestToken.h"
-#import "BUYRequestOperation.h"
 
 @interface BUYClient_Test : BUYClient
 

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClientTestBase.h
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYClientTestBase.h
@@ -25,7 +25,7 @@
 //
 
 @import XCTest;
-#import <Buy/Buy.h>
+@import Buy;
 
 extern NSString * const BUYShopDomain_Placeholder;
 extern NSString * const BUYAPIKey_Placeholder;

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYCollectionTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYCollectionTests.m
@@ -24,9 +24,8 @@
 //  THE SOFTWARE.
 //
 
-#import <XCTest/XCTest.h>
-#import "BUYCollection.h"
-#import "BUYModelManager.h"
+@import XCTest;
+@import Buy;
 
 @interface BUYCollectionTests : XCTestCase
 @end

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYCoreDataModelAdditionsTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYCoreDataModelAdditionsTests.m
@@ -24,14 +24,14 @@
 //  THE SOFTWARE.
 //
 
-#import <XCTest/XCTest.h>
-#import <CoreData/CoreData.h>
+@import XCTest;
+@import CoreData;
+@import Buy;
 
-#import "BUYFlatCollectionTransformer.h"
 #import "BUYDateTransformer.h"
+#import "BUYFlatCollectionTransformer.h"
 #import "BUYIdentityTransformer.h"
-#import "NSEntityDescription+BUYAdditions.h"
-#import "NSPropertyDescription+BUYAdditions.h"
+
 #import "TestModel.h"
 
 static NSString * const BirdEntity = @"Bird";

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYCreditCardTokenTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYCreditCardTokenTests.m
@@ -24,7 +24,9 @@
 //  THE SOFTWARE.
 //
 
-#import <XCTest/XCTest.h>
+@import XCTest;
+@import Buy;
+
 #import "BUYCreditCardToken.h"
 
 @interface BUYCreditCardTokenTests : XCTestCase

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYCustomerTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYCustomerTests.m
@@ -24,9 +24,8 @@
 //  THE SOFTWARE.
 //
 
-
-#import <XCTest/XCTest.h>
-#import "BUYCustomer.h"
+@import XCTest;
+@import Buy;
 
 @interface BUYCustomerTests : XCTestCase
 

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYDictionaryAdditionsTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYDictionaryAdditionsTests.m
@@ -24,8 +24,8 @@
 //  THE SOFTWARE.
 //
 
-#import <XCTest/XCTest.h>
-#import "NSDictionary+BUYAdditions.h"
+@import XCTest;
+@import Buy;
 
 @interface BUYDictionaryAdditionsTests : XCTestCase
 

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYErrorTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYErrorTests.m
@@ -24,8 +24,8 @@
 //  THE SOFTWARE.
 //
 
-#import <XCTest/XCTest.h>
-#import "BUYError.h"
+@import XCTest;
+@import Buy;
 
 @interface BUYErrorTests : XCTestCase
 

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYExceptionAdditionsTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYExceptionAdditionsTests.m
@@ -24,8 +24,8 @@
 //  THE SOFTWARE.
 //
 
-#import <XCTest/XCTest.h>
-#import "NSException+BUYAdditions.h"
+@import XCTest;
+@import Buy;
 
 @interface BUYExceptionAdditionsTests : XCTestCase
 

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYIntegrationTest.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYIntegrationTest.m
@@ -26,12 +26,13 @@
 
 @import UIKit;
 @import XCTest;
+@import Buy;
 
-#import <Buy/Buy.h>
-#import "BUYTestConstants.h"
-#import "BUYCheckout.h"
-#import "BUYClientTestBase.h"
 #import "BUYClient+Routing.h"
+
+#import "BUYTestConstants.h"
+#import "BUYClientTestBase.h"
+
 #import <OHHTTPStubs/OHHTTPStubs.h>
 #import "OHHTTPStubsResponse+Helpers.h"
 

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYLineItemTest.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYLineItemTest.m
@@ -26,7 +26,7 @@
 
 @import UIKit;
 @import XCTest;
-#import <Buy/Buy.h>
+@import Buy;
 
 @interface BUYLineItemTest : XCTestCase
 @end

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYModelManagerTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYModelManagerTests.m
@@ -24,23 +24,9 @@
 //  THE SOFTWARE.
 //
 
-#import <XCTest/XCTest.h>
-
-#import "BUYManagedObject.h"
-
-#import "BUYCollection.h"
-//#import "BUYCustomer.h"
-#import "BUYProduct.h"
-#import "BUYProductVariant.h"
-#import "BUYShop.h"
-
-#import "BUYAddress.h"
-#import "BUYCheckout.h"
-#import "BUYLineItem.h"
-
-#import "BUYModelManager.h"
-
-#import <CoreData/CoreData.h>
+@import CoreData;
+@import XCTest;
+@import Buy;
 
 @interface BUYModelManager (buymodel_tests)
 - (BUYCollection *)newTestCollection;

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYObjectTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYObjectTests.m
@@ -26,8 +26,7 @@
 
 @import UIKit;
 @import XCTest;
-
-#import <Buy/Buy.h>
+@import Buy;
 
 @interface BUYDirtyTracked : BUYObject
 

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYObserverTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYObserverTests.m
@@ -24,7 +24,8 @@
 //  THE SOFTWARE.
 //
 
-#import <XCTest/XCTest.h>
+@import XCTest;
+
 #import "BUYObserver.h"
 
 @interface Target : NSObject

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYOperationTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYOperationTests.m
@@ -24,7 +24,8 @@
 //  THE SOFTWARE.
 //
 
-#import <XCTest/XCTest.h>
+@import XCTest;
+
 #import "BUYOperation.h"
 
 @interface BUYOperationTests : XCTestCase

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYOptionValueTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYOptionValueTests.m
@@ -24,8 +24,8 @@
 //  THE SOFTWARE.
 //
 
-#import <XCTest/XCTest.h>
-#import "BUYOptionValue.h"
+@import XCTest;
+@import Buy;
 
 @interface BUYOptionValueTests : XCTestCase
 

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYOrderTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYOrderTests.m
@@ -24,8 +24,8 @@
 //  THE SOFTWARE.
 //
 
-#import <XCTest/XCTest.h>
-#import "BUYOrder.h"
+@import XCTest;
+@import Buy;
 
 @interface BUYOrderTests : XCTestCase
 @property (nonatomic, readonly) NSArray<BUYOrder *> *orders;

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYPaymentProviderTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYPaymentProviderTests.m
@@ -25,14 +25,11 @@
 //
 
 @import XCTest;
+@import Buy;
 
-#import <Buy/Buy.h>
-
-#import "BUYApplePayPaymentProvider.h"
-#import "BUYWebCheckoutPaymentProvider.h"
 #import "BUYClientTestBase.h"
-#import "BUYPaymentController.h"
 #import "BUYFakeSafariController.h"
+
 #import <OHHTTPStubs/OHHTTPStubs.h>
 
 extern Class SafariViewControllerClass;

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYRegularExpressionAdditionsTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYRegularExpressionAdditionsTests.m
@@ -24,8 +24,8 @@
 //  THE SOFTWARE.
 //
 
-#import <XCTest/XCTest.h>
-#import "NSRegularExpression+BUYAdditions.h"
+@import XCTest;
+@import Buy;
 
 @interface BUYRegularExpressionAdditionsTests : XCTestCase
 

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYRequestOperationTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYRequestOperationTests.m
@@ -24,10 +24,12 @@
 //  THE SOFTWARE.
 //
 
-#import <XCTest/XCTest.h>
-#import <OHHTTPStubs/OHHTTPStubs.h>
+@import XCTest;
+@import Buy;
+
 #import "BUYRequestOperation.h"
-#import "BUYClient.h"
+
+#import <OHHTTPStubs/OHHTTPStubs.h>
 
 @interface BUYRequestOperationTests : XCTestCase
 

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYStringAdditionsTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYStringAdditionsTests.m
@@ -24,8 +24,8 @@
 //  THE SOFTWARE.
 //
 
-#import <XCTest/XCTest.h>
-#import "NSString+BUYAdditions.h"
+@import XCTest;
+@import Buy;
 
 @interface BUYStringAdditionsTests : XCTestCase
 

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYTransformerTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYTransformerTests.m
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <XCTest/XCTest.h>
+@import XCTest;
 
 #import "BUYDateTransformer.h"
 #import "BUYDecimalNumberTransformer.h"

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYURLAdditionsTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYURLAdditionsTests.m
@@ -24,8 +24,8 @@
 //  THE SOFTWARE.
 //
 
-#import <XCTest/XCTest.h>
-#import "NSURL+BUYAdditions.h"
+@import XCTest;
+@import Buy;
 
 @interface BUYURLAdditionsTests : XCTestCase
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Additions/NSDictionary+BUYAdditions.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Additions/NSDictionary+BUYAdditions.h
@@ -25,8 +25,8 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Buy/BUYSerializable.h>
-#import <Buy/NSArray+BUYAdditions.h>
+#import "BUYSerializable.h"
+#import "NSArray+BUYAdditions.h"
 
 typedef NSString * (^BUYStringMap) (NSString *);
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Buy.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Buy.h
@@ -27,68 +27,68 @@
 #import <UIKit/UIKit.h>
 
 // Model types
-#import <Buy/BUYAccountCredentials.h>
-#import <Buy/BUYAddress.h>
-#import <Buy/BUYCart.h>
-#import <Buy/BUYCartLineItem.h>
-#import <Buy/BUYCheckout.h>
-#import <Buy/BUYCheckoutAttribute.h>
-#import <Buy/BUYCollection.h>
-#import <Buy/BUYCreditCard.h>
-#import <Buy/BUYCustomer.h>
-#import <Buy/BUYCustomerToken.h>
-#import <Buy/BUYDiscount.h>
-#import <Buy/BUYGiftCard.h>
-#import <Buy/BUYImageLink.h>
-#import <Buy/BUYLineItem.h>
-#import <Buy/BUYMaskedCreditCard.h>
-#import <Buy/BUYOption.h>
-#import <Buy/BUYOptionValue.h>
-#import <Buy/BUYOrder.h>
-#import <Buy/BUYPaymentToken.h>
-#import <Buy/BUYProduct.h>
-#import <Buy/BUYProductVariant.h>
-#import <Buy/BUYShippingRate.h>
-#import <Buy/BUYShop.h>
-#import <Buy/BUYTaxLine.h>
+#import "BUYAccountCredentials.h"
+#import "BUYAddress.h"
+#import "BUYCart.h"
+#import "BUYCartLineItem.h"
+#import "BUYCheckout.h"
+#import "BUYCheckoutAttribute.h"
+#import "BUYCollection.h"
+#import "BUYCreditCard.h"
+#import "BUYCustomer.h"
+#import "BUYCustomerToken.h"
+#import "BUYDiscount.h"
+#import "BUYGiftCard.h"
+#import "BUYImageLink.h"
+#import "BUYLineItem.h"
+#import "BUYMaskedCreditCard.h"
+#import "BUYOption.h"
+#import "BUYOptionValue.h"
+#import "BUYOrder.h"
+#import "BUYPaymentToken.h"
+#import "BUYProduct.h"
+#import "BUYProductVariant.h"
+#import "BUYShippingRate.h"
+#import "BUYShop.h"
+#import "BUYTaxLine.h"
 
 // Model support
-#import <Buy/BUYError.h>
-#import <Buy/BUYError+BUYAdditions.h>
-#import <Buy/BUYManagedObject.h>
-#import <Buy/BUYModelManager.h>
-#import <Buy/BUYModelManagerProtocol.h>
-#import <Buy/BUYObject.h>
-#import <Buy/BUYObjectProtocol.h>
-#import <Buy/BUYShopifyErrorCodes.h>
+#import "BUYError.h"
+#import "BUYError+BUYAdditions.h"
+#import "BUYManagedObject.h"
+#import "BUYModelManager.h"
+#import "BUYModelManagerProtocol.h"
+#import "BUYObject.h"
+#import "BUYObjectProtocol.h"
+#import "BUYShopifyErrorCodes.h"
 
 // Checkout support
-#import <Buy/BUYApplePayAdditions.h>
-#import <Buy/BUYApplePayAuthorizationDelegate.h>
-#import <Buy/BUYApplePayPaymentProvider.h>
-#import <Buy/BUYPaymentController.h>
-#import <Buy/BUYPaymentProvider.h>
-#import <Buy/BUYWebCheckoutPaymentProvider.h>
+#import "BUYApplePayAdditions.h"
+#import "BUYApplePayAuthorizationDelegate.h"
+#import "BUYApplePayPaymentProvider.h"
+#import "BUYPaymentController.h"
+#import "BUYPaymentProvider.h"
+#import "BUYWebCheckoutPaymentProvider.h"
 
 // Client API
-#import <Buy/BUYClientTypes.h>
-#import <Buy/BUYClient.h>
-#import <Buy/BUYClient+Address.h>
-#import <Buy/BUYClient+Customers.h>
-#import <Buy/BUYClient+Checkout.h>
-#import <Buy/BUYClient+Storefront.h>
+#import "BUYClientTypes.h"
+#import "BUYClient.h"
+#import "BUYClient+Address.h"
+#import "BUYClient+Customers.h"
+#import "BUYClient+Checkout.h"
+#import "BUYClient+Storefront.h"
 
 // Foundation extensions
-#import <Buy/NSArray+BUYAdditions.h>
-#import <Buy/NSDate+BUYAdditions.h>
-#import <Buy/NSDateFormatter+BUYAdditions.h>
-#import <Buy/NSDecimalNumber+BUYAdditions.h>
-#import <Buy/NSDictionary+BUYAdditions.h>
-#import <Buy/NSException+BUYAdditions.h>
-#import <Buy/NSString+BUYAdditions.h>
-#import <Buy/NSURL+BUYAdditions.h>
+#import "NSArray+BUYAdditions.h"
+#import "NSDate+BUYAdditions.h"
+#import "NSDateFormatter+BUYAdditions.h"
+#import "NSDecimalNumber+BUYAdditions.h"
+#import "NSDictionary+BUYAdditions.h"
+#import "NSException+BUYAdditions.h"
+#import "NSString+BUYAdditions.h"
+#import "NSURL+BUYAdditions.h"
 
 // Core Data extensions
-#import <Buy/NSEntityDescription+BUYAdditions.h>
-#import <Buy/NSPropertyDescription+BUYAdditions.h>
-#import <Buy/NSRegularExpression+BUYAdditions.h>
+#import "NSEntityDescription+BUYAdditions.h"
+#import "NSPropertyDescription+BUYAdditions.h"
+#import "NSRegularExpression+BUYAdditions.h"

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Address.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Address.h
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/BUYClient+Customers.h>
+#import "BUYClient+Customers.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @class BUYAddress;

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Checkout.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Checkout.h
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/BUYClient.h>
+#import "BUYClient.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @class BUYCheckout;

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Customers.h
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/BUYClient.h>
+#import "BUYClient.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @class BUYAccountCredentials;

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Internal.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Internal.h
@@ -24,9 +24,9 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/BUYClient.h>
-#import <Buy/BUYClient+Checkout.h>
-#import <Buy/BUYSerializable.h>
+#import "BUYClient.h"
+#import "BUYClient+Checkout.h"
+#import "BUYSerializable.h"
 
 static NSString * const BUYShopifyErrorDomain = @"BUYShopifyErrorDomain";
 static NSString * const BUYClientCustomerAccessToken = @"X-Shopify-Customer-Access-Token";

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Routing.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Routing.h
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/BUYClient.h>
+#import "BUYClient.h"
 
 @interface BUYClient (Routing)
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.h
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/BUYClient.h>
+#import "BUYClient.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @class BUYShop;

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient.h
@@ -25,7 +25,7 @@
 //
 
 @import Foundation;
-#import <Buy/BUYClientTypes.h>
+#import "BUYClientTypes.h"
 
 @class BUYCustomerToken;
 @class BUYModelManager;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYApplePayToken.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYApplePayToken.h
@@ -25,7 +25,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Buy/BUYPaymentToken.h>
+#import "BUYPaymentToken.h"
 
 @class PKPaymentToken;
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCreditCard.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCreditCard.h
@@ -25,7 +25,7 @@
 //
 
 @import Foundation;
-#import <Buy/BUYSerializable.h>
+#import "BUYSerializable.h"
 NS_ASSUME_NONNULL_BEGIN
 
 /**

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCreditCardToken.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYCreditCardToken.h
@@ -25,7 +25,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Buy/BUYPaymentToken.h>
+#import "BUYPaymentToken.h"
 
 @interface BUYCreditCardToken : NSObject <BUYPaymentToken>
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYManagedObject.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYManagedObject.h
@@ -25,7 +25,7 @@
 //
 
 #import <CoreData/CoreData.h>
-#import <Buy/BUYObject.h>
+#import "BUYObject.h"
 NS_ASSUME_NONNULL_BEGIN
 
 #if defined CORE_DATA_PERSISTENCE

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYModelManager.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYModelManager.h
@@ -25,8 +25,8 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Buy/BUYObject.h>
-#import <Buy/BUYModelManagerProtocol.h>
+#import "BUYObject.h"
+#import "BUYModelManagerProtocol.h"
 NS_ASSUME_NONNULL_BEGIN
 
 /**

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYObject.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYObject.h
@@ -25,8 +25,8 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Buy/BUYObjectProtocol.h>
-#import <Buy/BUYModelManagerProtocol.h>
+#import "BUYObjectProtocol.h"
+#import "BUYModelManagerProtocol.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BUYObject : NSObject<BUYObject>

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYObjectProtocol.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYObjectProtocol.h
@@ -25,7 +25,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Buy/BUYSerializable.h>
+#import "BUYSerializable.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @class NSEntityDescription;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYAddress.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYAddress.h
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/_BUYAddress.h>
+#import "_BUYAddress.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BUYAddress : _BUYAddress {}

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYCart.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYCart.h
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/_BUYCart.h>
+#import "_BUYCart.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @class BUYProductVariant;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYCartLineItem.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYCartLineItem.h
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/_BUYCartLineItem.h>
+#import "_BUYCartLineItem.h"
 NS_ASSUME_NONNULL_BEGIN
 
 /**

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYCollection.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYCollection.h
@@ -24,8 +24,8 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/_BUYCollection.h>
-#import <Buy/BUYClient+Storefront.h>
+#import "_BUYCollection.h"
+#import "BUYClient+Storefront.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BUYCollection : _BUYCollection {}

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYCustomer.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYCustomer.h
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/_BUYCustomer.h>
+#import "_BUYCustomer.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BUYCustomer : _BUYCustomer {}

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYImageLink.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYImageLink.h
@@ -25,7 +25,7 @@
 //
 
 @import UIKit;
-#import <Buy/_BUYImageLink.h>
+#import "_BUYImageLink.h"
 NS_ASSUME_NONNULL_BEGIN
 
 // Defines for common maximum image sizes

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYLineItem.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYLineItem.h
@@ -24,8 +24,8 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/_BUYLineItem.h>
-#import <Buy/BUYModelManager.h>
+#import "_BUYLineItem.h"
+#import "BUYModelManager.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @class BUYCartLineItem;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYOption.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYOption.h
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/_BUYOption.h>
+#import "_BUYOption.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BUYOption : _BUYOption {}

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYOptionValue.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYOptionValue.h
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/_BUYOptionValue.h>
+#import "_BUYOptionValue.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BUYOptionValue : _BUYOptionValue {}

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYOrder.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYOrder.h
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/_BUYOrder.h>
+#import "_BUYOrder.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BUYOrder : _BUYOrder {}

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYProduct.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYProduct.h
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/_BUYProduct.h>
+#import "_BUYProduct.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BUYProduct : _BUYProduct {}

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYProductVariant.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYProductVariant.h
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/_BUYProductVariant.h>
+#import "_BUYProductVariant.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @class BUYOptionValue;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYShop.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYShop.h
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/_BUYShop.h>
+#import "_BUYShop.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BUYShop : _BUYShop {}

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYAddress.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYAddress.h
@@ -26,9 +26,9 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to BUYAddress.h instead.
 
-#import <Buy/BUYManagedObject.h>
+#import "BUYManagedObject.h"
 
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 extern const struct BUYAddressAttributes {
 	__unsafe_unretained NSString *address1;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYCart.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYCart.h
@@ -26,9 +26,9 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to BUYCart.h instead.
 
-#import <Buy/BUYManagedObject.h>
+#import "BUYManagedObject.h"
 
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 extern const struct BUYCartRelationships {
 	__unsafe_unretained NSString *lineItems;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYCartLineItem.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYCartLineItem.h
@@ -26,9 +26,9 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to BUYCartLineItem.h instead.
 
-#import <Buy/BUYManagedObject.h>
+#import "BUYManagedObject.h"
 
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 extern const struct BUYCartLineItemAttributes {
 	__unsafe_unretained NSString *quantity;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYCollection.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYCollection.h
@@ -26,9 +26,9 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to BUYCollection.h instead.
 
-#import <Buy/BUYManagedObject.h>
+#import "BUYManagedObject.h"
 
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 extern const struct BUYCollectionAttributes {
 	__unsafe_unretained NSString *createdAt;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYCustomer.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYCustomer.h
@@ -26,9 +26,9 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to BUYCustomer.h instead.
 
-#import <Buy/BUYManagedObject.h>
+#import "BUYManagedObject.h"
 
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 extern const struct BUYCustomerAttributes {
 	__unsafe_unretained NSString *acceptsMarketing;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYImageLink.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYImageLink.h
@@ -26,9 +26,9 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to BUYImageLink.h instead.
 
-#import <Buy/BUYManagedObject.h>
+#import "BUYManagedObject.h"
 
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 extern const struct BUYImageLinkAttributes {
 	__unsafe_unretained NSString *createdAt;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYLineItem.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYLineItem.h
@@ -26,9 +26,9 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to BUYLineItem.h instead.
 
-#import <Buy/BUYManagedObject.h>
+#import "BUYManagedObject.h"
 
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 extern const struct BUYLineItemAttributes {
 	__unsafe_unretained NSString *compareAtPrice;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYOption.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYOption.h
@@ -26,9 +26,9 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to BUYOption.h instead.
 
-#import <Buy/BUYManagedObject.h>
+#import "BUYManagedObject.h"
 
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 extern const struct BUYOptionAttributes {
 	__unsafe_unretained NSString *identifier;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYOptionValue.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYOptionValue.h
@@ -26,9 +26,9 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to BUYOptionValue.h instead.
 
-#import <Buy/BUYManagedObject.h>
+#import "BUYManagedObject.h"
 
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 extern const struct BUYOptionValueAttributes {
 	__unsafe_unretained NSString *name;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYOrder.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYOrder.h
@@ -26,9 +26,9 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to BUYOrder.h instead.
 
-#import <Buy/BUYManagedObject.h>
+#import "BUYManagedObject.h"
 
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 extern const struct BUYOrderAttributes {
 	__unsafe_unretained NSString *identifier;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYProduct.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYProduct.h
@@ -26,9 +26,9 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to BUYProduct.h instead.
 
-#import <Buy/BUYManagedObject.h>
+#import "BUYManagedObject.h"
 
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 extern const struct BUYProductAttributes {
 	__unsafe_unretained NSString *available;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYProductVariant.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYProductVariant.h
@@ -26,9 +26,9 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to BUYProductVariant.h instead.
 
-#import <Buy/BUYManagedObject.h>
+#import "BUYManagedObject.h"
 
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 extern const struct BUYProductVariantAttributes {
 	__unsafe_unretained NSString *available;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYShop.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYShop.h
@@ -26,9 +26,9 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to BUYShop.h instead.
 
-#import <Buy/BUYManagedObject.h>
+#import "BUYManagedObject.h"
 
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 extern const struct BUYShopAttributes {
 	__unsafe_unretained NSString *city;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Templates/Persistent/human.h.motemplate
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Templates/Persistent/human.h.motemplate
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/_<$managedObjectClassName$>.h>
+#import "_<$managedObjectClassName$>.h"
 
 @interface <$managedObjectClassName$> : _<$managedObjectClassName$> {}
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Templates/Persistent/machine.h.motemplate
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Templates/Persistent/machine.h.motemplate
@@ -26,12 +26,12 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to <$managedObjectClassName$>.h instead.
 
-#import <Buy/BUYManagedObject.h>
+#import "BUYManagedObject.h"
 
 <$if hasAdditionalHeaderFile$>
-#import <Buy/<$additionalHeaderFileName$>>
+#import "<$additionalHeaderFileName$>"
 <$endif$>
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 <$if noninheritedAttributes.@count > 0$>
 extern const struct <$managedObjectClassName$>Attributes {<$foreach Attribute noninheritedAttributes do$>

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Templates/Transient/human.h.motemplate
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Templates/Transient/human.h.motemplate
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/_<$managedObjectClassName$>.h>
+#import "_<$managedObjectClassName$>.h"
 
 @interface <$managedObjectClassName$> : _<$managedObjectClassName$> {}
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Templates/Transient/machine.h.motemplate
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Templates/Transient/machine.h.motemplate
@@ -26,13 +26,13 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to <$managedObjectClassName$>.h instead.
 
-<$if hasCustomSuperentity$><$if hasSuperentity$>#import <Buy/<$customSuperentity$>.h>
-<$else$><$if hasCustomBaseCaseImport$>#import <$baseClassImport$><$else$>#import <Buy/<$customSuperentity$>.h><$endif$><$endif$><$endif$>
+<$if hasCustomSuperentity$><$if hasSuperentity$>#import "<$customSuperentity$>.h"
+<$else$><$if hasCustomBaseCaseImport$>#import <$baseClassImport$><$else$>#import "<$customSuperentity$>.h"<$endif$><$endif$><$endif$>
 
 <$if hasAdditionalHeaderFile$>
-#import <Buy/<$additionalHeaderFileName$>>
+#import "$additionalHeaderFileName$>"
 <$endif$>
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 <$if noninheritedAttributes.@count > 0$>
 extern const struct <$managedObjectClassName$>Attributes {<$foreach Attribute noninheritedAttributes do$>

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYCheckout.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYCheckout.h
@@ -24,9 +24,9 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/_BUYCheckout.h>
-#import <Buy/_BUYProductVariant.h>
-#import <Buy/BUYModelManager.h>
+#import "_BUYCheckout.h"
+#import "_BUYProductVariant.h"
+#import "BUYModelManager.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @class BUYCart, BUYCartLineItem, BUYAddress, BUYGiftCard;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYCheckoutAttribute.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYCheckoutAttribute.h
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/_BUYCheckoutAttribute.h>
+#import "_BUYCheckoutAttribute.h"
 NS_ASSUME_NONNULL_BEGIN
 
 /**

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYDiscount.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYDiscount.h
@@ -24,8 +24,8 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/_BUYDiscount.h>
-#import <Buy/BUYModelManager.h>
+#import "_BUYDiscount.h"
+#import "BUYModelManager.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BUYDiscount : _BUYDiscount {}

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYGiftCard.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYGiftCard.h
@@ -24,8 +24,8 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/_BUYGiftCard.h>
-#import <Buy/BUYModelManager.h>
+#import "_BUYGiftCard.h"
+#import "BUYModelManager.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BUYGiftCard : _BUYGiftCard {}

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYMaskedCreditCard.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYMaskedCreditCard.h
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/_BUYMaskedCreditCard.h>
+#import "_BUYMaskedCreditCard.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BUYMaskedCreditCard : _BUYMaskedCreditCard {}

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYShippingRate.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYShippingRate.h
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/_BUYShippingRate.h>
+#import "_BUYShippingRate.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BUYShippingRate : _BUYShippingRate {}

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYTaxLine.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/BUYTaxLine.h
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/_BUYTaxLine.h>
+#import "_BUYTaxLine.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BUYTaxLine : _BUYTaxLine {}

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/_BUYCheckout.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/_BUYCheckout.h
@@ -26,9 +26,9 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to BUYCheckout.h instead.
 
-#import <Buy/BUYObject.h>
+#import "BUYObject.h"
 
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 extern const struct BUYCheckoutAttributes {
 	__unsafe_unretained NSString *cartToken;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/_BUYCheckoutAttribute.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/_BUYCheckoutAttribute.h
@@ -26,9 +26,9 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to BUYCheckoutAttribute.h instead.
 
-#import <Buy/BUYObject.h>
+#import "BUYObject.h"
 
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 extern const struct BUYCheckoutAttributeAttributes {
 	__unsafe_unretained NSString *name;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/_BUYDiscount.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/_BUYDiscount.h
@@ -26,9 +26,9 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to BUYDiscount.h instead.
 
-#import <Buy/BUYObject.h>
+#import "BUYObject.h"
 
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 extern const struct BUYDiscountAttributes {
 	__unsafe_unretained NSString *amount;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/_BUYGiftCard.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/_BUYGiftCard.h
@@ -26,9 +26,9 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to BUYGiftCard.h instead.
 
-#import <Buy/BUYObject.h>
+#import "BUYObject.h"
 
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 extern const struct BUYGiftCardAttributes {
 	__unsafe_unretained NSString *amountUsed;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/_BUYMaskedCreditCard.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/_BUYMaskedCreditCard.h
@@ -26,9 +26,9 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to BUYMaskedCreditCard.h instead.
 
-#import <Buy/BUYObject.h>
+#import "BUYObject.h"
 
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 extern const struct BUYMaskedCreditCardAttributes {
 	__unsafe_unretained NSString *expiryMonth;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/_BUYShippingRate.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/_BUYShippingRate.h
@@ -26,9 +26,9 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to BUYShippingRate.h instead.
 
-#import <Buy/BUYObject.h>
+#import "BUYObject.h"
 
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 extern const struct BUYShippingRateAttributes {
 	__unsafe_unretained NSString *deliveryRange;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/_BUYTaxLine.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/_BUYTaxLine.h
@@ -26,9 +26,9 @@
 // DO NOT EDIT. This file is machine-generated and constantly overwritten.
 // Make changes to BUYTaxLine.h instead.
 
-#import <Buy/BUYObject.h>
+#import "BUYObject.h"
 
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 
 extern const struct BUYTaxLineAttributes {
 	__unsafe_unretained NSString *createdAt;

--- a/Mobile Buy SDK/Mobile Buy SDK/Operations/BUYCheckoutOperation.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Operations/BUYCheckoutOperation.h
@@ -24,9 +24,9 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/BUYGroupOperation.h>
-#import <Buy/BUYStatusOperation.h>
-#import <Buy/BUYClientTypes.h>
+#import "BUYGroupOperation.h"
+#import "BUYStatusOperation.h"
+#import "BUYClientTypes.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @class BUYClient;

--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYApplePayPaymentProvider.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYApplePayPaymentProvider.h
@@ -25,7 +25,7 @@
 //
 
 @import UIKit;
-#import <Buy/BUYPaymentProvider.h>
+#import "BUYPaymentProvider.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYPaymentController.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYPaymentController.h
@@ -25,7 +25,7 @@
 //
 
 @import Foundation;
-#import <Buy/BUYPaymentProvider.h>
+#import "BUYPaymentProvider.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYPaymentProvider.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYPaymentProvider.h
@@ -26,7 +26,7 @@
 
 @import UIKit;
 
-#import <Buy/BUYClient.h>
+#import "BUYClient.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYWebCheckoutPaymentProvider.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYWebCheckoutPaymentProvider.h
@@ -25,7 +25,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Buy/BUYPaymentProvider.h>
+#import "BUYPaymentProvider.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayAdditions.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayAdditions.h
@@ -27,9 +27,9 @@
 @import Foundation;
 @import PassKit;
 
-#import <Buy/BUYCheckout.h>
-#import <Buy/BUYShippingRate.h>
-#import <Buy/BUYAddress.h>
+#import "BUYCheckout.h"
+#import "BUYShippingRate.h"
+#import "BUYAddress.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BUYCheckout (ApplePay)

--- a/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYError+BUYAdditions.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYError+BUYAdditions.h
@@ -24,7 +24,7 @@
 //  THE SOFTWARE.
 //
 
-#import <Buy/BUYError.h>
+#import "BUYError.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BUYError (Checkout)

--- a/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYModelManager+ApplePay.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYModelManager+ApplePay.h
@@ -25,7 +25,7 @@
 //
 
 @import PassKit;
-#import <Buy/BUYModelManager.h>
+#import "BUYModelManager.h"
 NS_ASSUME_NONNULL_BEGIN
 
 @class BUYAddress;


### PR DESCRIPTION
The correct way to declare dependencies in public headers of public frameworks is to use framework style: `<Framework/File.h>`. This is to ensure compatibility with projects not using modules, although, these days, Xcode probably works around that some other way.

However, either because of a bug in lldb, or because of community members voting with their feet, the standard now is to use the user-style `#import` directives (with quotation marks). Perhaps as a result of this, lldb does not work with framework-style import directives.

This converts to using user-style, to accommodate implicit expectations of lldb.

Fixes https://github.com/Shopify/mobile-buy-sdk-ios/issues/315

@gabrieloc @davidmuzi @dbart01 