### PR TITLE
Remove `identifier` property from `ShippingRate` entity

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Mobile Buy SDK.xcdatamodeld/Mobile Buy SDK.xcdatamodel/contents
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Mobile Buy SDK.xcdatamodeld/Mobile Buy SDK.xcdatamodel/contents
@@ -844,7 +844,6 @@
                 <entry key="JSONValueTransformer" value="BUYDeliveryRange"/>
             </userInfo>
         </attribute>
-        <attribute name="identifier" optional="YES" attributeType="Integer 64" defaultValueString="0" indexed="YES" syncable="YES"/>
         <attribute name="price" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES">
             <userInfo>
                 <entry key="documentation" value="The price of this shipping method."/>
@@ -990,7 +989,7 @@
         <memberEntity name="CheckoutAttribute"/>
     </configuration>
     <elements>
-        <element name="Address" positionX="-990" positionY="1444" width="128" height="270"/>
+        <element name="Address" positionX="-990" positionY="1437" width="128" height="270"/>
         <element name="Cart" positionX="-1192" positionY="978" width="128" height="60"/>
         <element name="CartLineItem" positionX="-987" positionY="1183" width="128" height="90"/>
         <element name="Checkout" positionX="-765" positionY="1072" width="128" height="630"/>
@@ -1007,7 +1006,7 @@
         <element name="Order" positionX="-549" positionY="1647" width="128" height="180"/>
         <element name="Product" positionX="-1390" positionY="1018" width="128" height="300"/>
         <element name="ProductVariant" positionX="-1192" positionY="1063" width="128" height="240"/>
-        <element name="ShippingRate" positionX="-569" positionY="1836" width="128" height="135"/>
+        <element name="ShippingRate" positionX="-569" positionY="1836" width="128" height="120"/>
         <element name="Shop" positionX="-1786" positionY="843" width="128" height="255"/>
         <element name="TaxLine" positionX="-990" positionY="1737" width="128" height="133"/>
     </elements>

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/_BUYShippingRate.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/_BUYShippingRate.h
@@ -32,7 +32,6 @@
 
 extern const struct BUYShippingRateAttributes {
 	__unsafe_unretained NSString *deliveryRange;
-	__unsafe_unretained NSString *identifier;
 	__unsafe_unretained NSString *price;
 	__unsafe_unretained NSString *shippingRateIdentifier;
 	__unsafe_unretained NSString *title;
@@ -70,12 +69,6 @@ extern const struct BUYShippingRateUserInfo {
  * One or two NSDate objects of the potential delivery dates.
  */
 @property (nonatomic, strong) NSArray* deliveryRange;
-
-@property (nonatomic, strong) NSNumber* identifier;
-
-@property (atomic) int64_t identifierValue;
-- (int64_t)identifierValue;
-- (void)setIdentifierValue:(int64_t)value_;
 
 /**
  * The price of this shipping method.

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/_BUYShippingRate.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Transient/_BUYShippingRate.m
@@ -30,7 +30,6 @@
 
 const struct BUYShippingRateAttributes BUYShippingRateAttributes = {
 	.deliveryRange = @"deliveryRange",
-	.identifier = @"identifier",
 	.price = @"price",
 	.shippingRateIdentifier = @"shippingRateIdentifier",
 	.title = @"title",
@@ -54,22 +53,7 @@ const struct BUYShippingRateUserInfo BUYShippingRateUserInfo = {
 + (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key {
 	NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
 
-	if ([key isEqualToString:@"identifierValue"]) {
-		NSSet *affectingKey = [NSSet setWithObject:@"identifier"];
-		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
-		return keyPaths;
-	}
-
 	return keyPaths;
-}
-
-- (int64_t)identifierValue {
-	NSNumber *result = [self identifier];
-	return [result longLongValue];
-}
-
-- (void)setIdentifierValue:(int64_t)value_ {
-	[self setIdentifier:@(value_)];
 }
 
 @end


### PR DESCRIPTION
`ShippingRate` was incorrectly given an `identifier` property when the model was converted for SDK version 2. `identifier` may have been intended to replace `shippingRateIdentifier`, but that would have been inappropriate in any case, as the `shippingRateIdentifier` is a string, not a number.

Fixes https://github.com/Shopify/mobile-buy-sdk-ios/issues/313

cd @davidmuzi @gabrieloc for review