### PR TITLE
Check whether many-to-many relationship allows encoding.

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Additions/NSPropertyDescription+BUYAdditions.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Additions/NSPropertyDescription+BUYAdditions.m
@@ -287,7 +287,7 @@ static NSString *JSONValueTransformerNameForAttributeType(NSAttributeType type)
 	else if (!self.toMany) {
 		json = [self buy_JSONForObject:value];
 	}
-	else if (!self.manyToMany) {
+	else if (!self.manyToMany || self.inverseRelationship.allowsInverseEncoding) {
 		json = [self buy_JSONForCollection:value];
 	}
 	return json;


### PR DESCRIPTION
Fix issue where product variants did not encode their option values.

Fixes #326 

@davidmuzi @gabrieloc 