### PR TITLE
Stricter approach to many-to-many JSON encoding.

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Additions/NSEntityDescription+BUYAdditions.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Additions/NSEntityDescription+BUYAdditions.h
@@ -44,7 +44,7 @@
 /**
  * Signifies whether this entity is private to the app (not used by the endpoint).
  */
-- (BOOL)buy_isPrivate;
+@property (nonatomic, readonly, getter=buy_isPrivate) BOOL private;
 
 /**
  * Generate JSON, recursively, from the provided model object.

--- a/Mobile Buy SDK/Mobile Buy SDK/Additions/NSPropertyDescription+BUYAdditions.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Additions/NSPropertyDescription+BUYAdditions.h
@@ -87,8 +87,14 @@ extern NSString * const BUYJSONPropertyKeyUserInfoKey;      // = @"JSONPropertyK
 
 /**
  * YES if the delete rule is not Cascading and the entity is not private.
+ * Deprecated. Use ownsDestination on the source relationship when encoding.
  */
-@property (nonatomic, readonly, getter=buy_allowsInverseEncoding) BOOL allowsInverseEncoding;
+@property (nonatomic, readonly, getter=buy_allowsInverseEncoding) BOOL allowsInverseEncoding DEPRECATED_ATTRIBUTE;
+
+/**
+ * YES if the delete rule is Cascading and the destination entity is not private.
+ */
+@property (nonatomic, readonly, getter=buy_ownsDestination) BOOL ownsDestination;
 
 /**
  * YES if this relationship and its inverse are both toMany


### PR DESCRIPTION
The previous solution is simple, but more lenient in the case of inconsistent models. We should have automated verification to ensure every relationship is defined to prevent circular encoding or missing values.

The simple fix (targeting a bugfix release 2.0.1) checks whether the inverse relationship allows inverse encoding, but it is both convoluted and too lenient.

We have an implicit rule in our model that any relationship should specify ownership via implication of delete rules: if a relationship deletes its destination, then it owns it. If it owns it, the inverse should not encode itself, because it would be encoding its owner. But if a relationship's ownership cannot be inferred, then we also will encode from either direction, which could lead to a circular (recursive) encoding, as the same relationship is traversed back and forth.

There should not be any relationships without ownership in our model. Every relationship should have an owner. But we need to verify, and assert this assumption.

This PR includes a deprecation.
This PR also includes a change to convert a method into a read-only property.

Replacement for https://github.com/Shopify/mobile-buy-sdk-ios/pull/328

@davidmuzi @gabrieloc 