### PR TITLE
Encoding many-to-many relationships in JSON

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYCoreDataModelAdditionsTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYCoreDataModelAdditionsTests.m
@@ -235,9 +235,24 @@ static NSString * const RootEntity = @"Root";
 
 - (void)testManyToManyRelationship
 {
-	Researcher *researcher = [self.modelManager buy_objectWithEntityName:ResearchEntity JSONDictionary:nil];
+	NSDictionary *birdJSON = @{
+							   @"id" : @1,
+							   @"colour" : @"red"
+							   };
+	NSDictionary *researcherJSON = @{
+									 @"name" : @"Bob",
+									 @"birds" : @[ birdJSON ]
+									 };
+	Researcher *researcher = [self.modelManager buy_objectWithEntityName:ResearchEntity JSONDictionary:researcherJSON];
+	
+	XCTAssertNotNil(researcher.birds.anyObject.researchers.anyObject);
+	
 	NSRelationshipDescription *researchersRelationship = [self relationshipWithName:@"researchers" forEntity:BirdEntity];
-	XCTAssertNil([researchersRelationship buy_JSONForValue:[NSSet setWithObject:researcher]]);
+	NSArray *actual = [researchersRelationship buy_JSONForValue:[NSSet setWithObject:researcher]];
+	NSArray *expected = @[
+						  @{ @"name" : @"Bob" }
+						  ];
+	XCTAssertEqualObjects(actual, expected);
 }
 
 - (void)testEntityIsPrivate

--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYTestModel.xcdatamodeld/BUYTestModel.xcdatamodel/contents
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYTestModel.xcdatamodeld/BUYTestModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Xcode 7.0">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10174" systemVersion="15G1004" minimumToolsVersion="Xcode 7.0">
     <entity name="Bird" representedClassName="Bird" syncable="YES">
         <attribute name="colour" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="identifier" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
@@ -74,7 +74,7 @@
         <element name="Forest" positionX="-718" positionY="57" width="128" height="58"/>
         <element name="Leaf" positionX="-72" positionY="-18" width="128" height="90"/>
         <element name="Nest" positionX="-72" positionY="126" width="128" height="90"/>
+        <element name="Researcher" positionX="369" positionY="141" width="128" height="75"/>
         <element name="Root" positionX="-504" positionY="-18" width="128" height="133"/>
-        <element name="Researcher" positionX="-288" positionY="81" width="128" height="75"/>
     </elements>
 </model>

--- a/Mobile Buy SDK/Mobile Buy SDK/Additions/NSDictionary+BUYAdditions.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Additions/NSDictionary+BUYAdditions.h
@@ -48,6 +48,11 @@ typedef NSString * (^BUYStringMap) (NSString *);
 - (NSDictionary *)buy_dictionaryByMappingValuesWithBlock:(BUYObjectMap)map;
 
 /**
+ *  Return a new dictionary containing key/value pairs where the value matches the predicate.
+ */
+- (NSDictionary *)buy_dictionaryByFilteringValuesWithPredicate:(NSPredicate *)predicate;
+
+/**
  *  Alernative to objectForKey, where NSNull is replaced with nil
  *
  *  @param key The key for which to return the corresponding value.

--- a/Mobile Buy SDK/Mobile Buy SDK/Additions/NSDictionary+BUYAdditions.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Additions/NSDictionary+BUYAdditions.m
@@ -37,7 +37,7 @@
 - (NSDictionary *)buy_dictionaryByMappingKeysWithBlock:(BUYStringMap)map
 {
 	NSMutableDictionary *result = [NSMutableDictionary dictionary];
-	[self enumerateKeysAndObjectsUsingBlock:^(id  _Nonnull key, id  _Nonnull obj, BOOL * _Nonnull stop) {
+	[self enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
 		result[(map(key) ?: key)] = self[key];
 	}];
 	return result;
@@ -46,9 +46,20 @@
 - (NSDictionary *)buy_dictionaryByMappingValuesWithBlock:(BUYObjectMap)map
 {
 	NSMutableDictionary *result = [NSMutableDictionary dictionary];
-	[self enumerateKeysAndObjectsUsingBlock:^(id  _Nonnull key, id  _Nonnull obj, BOOL * _Nonnull stop) {
+	[self enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
 		id newValue = map(self[key]);
 		result[key] = newValue;
+	}];
+	return result;
+}
+
+- (NSDictionary *)buy_dictionaryByFilteringValuesWithPredicate:(NSPredicate *)predicate
+{
+	NSMutableDictionary *result = [NSMutableDictionary dictionary];
+	[self enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+		if ([predicate evaluateWithObject:obj]) {
+			result[key] = obj;
+		}
 	}];
 	return result;
 }

--- a/Mobile Buy SDK/Mobile Buy SDK/Additions/NSEntityDescription+BUYAdditions.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Additions/NSEntityDescription+BUYAdditions.h
@@ -49,12 +49,12 @@
 /**
  * Generate JSON, recursively, from the provided model object.
  */
-- (NSDictionary *)buy_JSONForObject:(id<BUYObject>)object;
+- (NSDictionary *)buy_JSONForObject:(id<BUYObject>)object inRelationship:(NSRelationshipDescription *)relationship;
 
 /**
  * Generate JSON, recursively, for each model in the provided array.
  */
-- (NSArray *)buy_JSONForArray:(NSArray<NSObject<BUYObject> *> *)array;
+- (NSArray *)buy_JSONForArray:(NSArray<NSObject<BUYObject> *> *)array inRelationship:(NSRelationshipDescription *)relationship;
 
 /**
  * Update the properties of the given model object, and child objects, using the given JSON dictionary.

--- a/Mobile Buy SDK/Mobile Buy SDK/Additions/NSEntityDescription+BUYAdditions.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Additions/NSEntityDescription+BUYAdditions.m
@@ -68,8 +68,9 @@
 
 - (NSDictionary *)buy_JSONEncodedProperties
 {
-	NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithDictionary:[self attributesByName]];
-	[properties addEntriesFromDictionary:[self relationshipsByName]];
+	NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithDictionary:self.attributesByName];
+	NSDictionary *relationships = [self.relationshipsByName buy_dictionaryByFilteringValuesWithPredicate:[NSPredicate predicateWithFormat:@"manyToMany == NO"]];
+	[properties addEntriesFromDictionary:relationships];
 	return properties;
 }
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Additions/NSEntityDescription+BUYAdditions.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Additions/NSEntityDescription+BUYAdditions.m
@@ -151,6 +151,22 @@
 	return results;
 }
 
+- (NSDictionary *)buy_JSONEncodedPropertiesForObject:(NSObject<BUYObject> *)object
+{
+	static NSMutableDictionary<NSString *, NSDictionary *> *cachedProperties;
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		cachedProperties = [NSMutableDictionary dictionary];
+	});
+	
+	NSDictionary *properties = cachedProperties[self.name];
+	if (nil == properties) {
+		properties = object.JSONEncodedProperties;
+		cachedProperties[self.name] = properties;
+	}
+	return properties;
+}
+
 - (NSArray *)buy_JSONForArray:(NSArray<NSObject<BUYObject> *> *)array
 {
 	return [array buy_map:^(NSObject<BUYObject> *object) {

--- a/Mobile Buy SDK/Mobile Buy SDK/Additions/NSPropertyDescription+BUYAdditions.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Additions/NSPropertyDescription+BUYAdditions.m
@@ -211,7 +211,7 @@ static NSString *JSONValueTransformerNameForAttributeType(NSAttributeType type)
 {
 	id json = nil;
 	if (!self.inverseRelationship || self.inverseRelationship.allowsInverseEncoding) {
-		json = [self.destinationEntity buy_JSONForObject:object];
+		json = [self.destinationEntity buy_JSONForObject:object inRelationship:self];
 	}
 	return json;
 }
@@ -247,7 +247,7 @@ static NSString *JSONValueTransformerNameForAttributeType(NSAttributeType type)
 // (ordered)set (of models) -> JSON
 - (NSArray *)buy_JSONForCollection:(id)collection
 {
-	return [self.destinationEntity buy_JSONForArray:[self buy_arrayForCollection:collection]];
+	return [self.destinationEntity buy_JSONForArray:[self buy_arrayForCollection:collection] inRelationship:self];
 }
 
 #pragma mark - Property Additions Overrides

--- a/Mobile Buy SDK/Mobile Buy SDK/Additions/NSPropertyDescription+BUYAdditions.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Additions/NSPropertyDescription+BUYAdditions.m
@@ -284,11 +284,11 @@ static NSString *JSONValueTransformerNameForAttributeType(NSAttributeType type)
 	if (self.encodesIdInJSON) {
 		json = [value valueForKey:NSStringFromSelector(@selector(identifier))];
 	}
-	else if (!self.toMany) {
-		json = [self buy_JSONForObject:value];
-	}
-	else if (!self.manyToMany) {
+	else if (self.toMany) {
 		json = [self buy_JSONForCollection:value];
+	}
+	else {
+		json = [self buy_JSONForObject:value];
 	}
 	return json;
 }

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYManagedObject.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYManagedObject.m
@@ -77,7 +77,7 @@ return self.entity.JSONEncodedProperties;
 {
 	// JSON generation starts in `-buy_JSONForObject`.
 	// Both persistent and transient objects go through this interface.
-	return [self.entity buy_JSONForObject:self];
+	return [self.entity buy_JSONForObject inRelationship:nil];
 }
 
 - (void)setJSONDictionary:(NSDictionary *)JSONDictionary

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/BUYObject.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/BUYObject.m
@@ -125,7 +125,7 @@
 {
 	// JSON generation starts in `-buy_JSONForObject`.
 	// Both persistent and transient objects go through this interface.
-	return [self.entity buy_JSONForObject:self];
+	return [self.entity buy_JSONForObject:self inRelationship:nil];
 }
 
 - (void)setJSONDictionary:(NSDictionary *)JSONDictionary

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Mobile Buy SDK.xcdatamodeld/Mobile Buy SDK.xcdatamodel/contents
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Mobile Buy SDK.xcdatamodeld/Mobile Buy SDK.xcdatamodel/contents
@@ -360,6 +360,7 @@
         <relationship name="products" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Product" inverseName="collections" inverseEntity="Product" syncable="YES">
             <userInfo>
                 <entry key="documentation" value="Inverse of Product.collections."/>
+                <entry key="JSONPropertyKey" value="product_ids"/>
             </userInfo>
         </relationship>
         <userInfo>

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Mobile Buy SDK.xcdatamodeld/Mobile Buy SDK.xcdatamodel/contents
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Mobile Buy SDK.xcdatamodeld/Mobile Buy SDK.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10174" systemVersion="15F34" minimumToolsVersion="Xcode 7.0">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10174" systemVersion="15G1004" minimumToolsVersion="Xcode 7.0">
     <entity name="Address" representedClassName="BUYAddress" syncable="YES">
         <attribute name="address1" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
@@ -1006,7 +1006,7 @@
         <element name="OptionValue" positionX="-1390" positionY="894" width="128" height="105"/>
         <element name="Order" positionX="-549" positionY="1647" width="128" height="180"/>
         <element name="Product" positionX="-1390" positionY="1018" width="128" height="300"/>
-        <element name="ProductVariant" positionX="-1192" positionY="1063" width="128" height="240"/>
+        <element name="ProductVariant" positionX="-1192" positionY="1063" width="128" height="238"/>
         <element name="ShippingRate" positionX="-569" positionY="1836" width="128" height="135"/>
         <element name="Shop" positionX="-1786" positionY="843" width="128" height="255"/>
         <element name="TaxLine" positionX="-990" positionY="1737" width="128" height="133"/>


### PR DESCRIPTION
Originally, we designed the JSON encoding to ignore many-to-many relationships, because we did not have a way to specify ownership in such a relationship. Many-to-many relationships involve sharing of objects in both directions.

Any object on either side of a many-to-many may be related to multiple others. They are effectively collaborators, not parent/child. They can exist independently.

As a result, encoding a Product graph (including variants etc.) would not include the option values on the variants.

However, for the purpose of JSON encoding, some duplication may be tolerable. (Of course, if there is such duplication, then it would up to the decoder to detect it.)

One approach to avoid duplication would be to only encode the identifier. Unfortunately, in the particular case of encoding `OptionValue` (contained in `ProductVariant.options`), there _is_ no `identifier`, or any single property that can act like one. (The primary key, as such, would require two fields: `optionId` and `value`. Which is too complex a special case to address for this model.)

We never send shop catalog data across the wire back to Shopify. The only use of encoding catalog objects as JSON is for local caching. So we don't have to worry about creating duplicates in Shopify. But any clients that use this will have to be careful.

This could have had awkward consequences for the `Collection` <-> `Product` relationship, but this relationship is not described in any content returned from the listings API (which is used by the SDK to retrieve collections and products). Forming this relationship is the responsibility of client objects, determined by specifying the collection ID when requesting products. In any case, both properties have had a `JSONPropertyKey` added to their `userInfo` in the data model, so they will only encode the IDs, and then only if the relationship actually has content. 

This PR includes updates to the tests to verify this new behaviour.

@davidmuzi @gabrieloc 
