### PR TITLE
Remove unused fields from Customer

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Mobile Buy SDK.xcdatamodeld/Mobile Buy SDK.xcdatamodel/contents
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Mobile Buy SDK.xcdatamodeld/Mobile Buy SDK.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10174" systemVersion="15F34" minimumToolsVersion="Xcode 7.0">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10174" systemVersion="15G1004" minimumToolsVersion="Xcode 7.0">
     <entity name="Address" representedClassName="BUYAddress" syncable="YES">
         <attribute name="address1" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
@@ -377,9 +377,7 @@
         <attribute name="lastOrderID" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
         <attribute name="lastOrderName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="multipassIdentifier" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="note" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="ordersCount" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
-        <attribute name="tags" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="taxExempt" optional="YES" attributeType="Boolean" syncable="YES"/>
         <attribute name="totalSpent" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
@@ -996,7 +994,7 @@
         <element name="Checkout" positionX="-765" positionY="1072" width="128" height="630"/>
         <element name="CheckoutAttribute" positionX="-990" positionY="1332" width="128" height="90"/>
         <element name="Collection" positionX="-1588" positionY="1063" width="128" height="195"/>
-        <element name="Customer" positionX="-1190" positionY="1359" width="128" height="330"/>
+        <element name="Customer" positionX="-1190" positionY="1359" width="128" height="300"/>
         <element name="Discount" positionX="-551" positionY="1377" width="128" height="105"/>
         <element name="GiftCard" positionX="-540" positionY="1492" width="128" height="135"/>
         <element name="ImageLink" positionX="-1786" positionY="1108" width="128" height="165"/>

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYCustomer.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYCustomer.h
@@ -41,9 +41,7 @@ extern const struct BUYCustomerAttributes {
 	__unsafe_unretained NSString *lastOrderID;
 	__unsafe_unretained NSString *lastOrderName;
 	__unsafe_unretained NSString *multipassIdentifier;
-	__unsafe_unretained NSString *note;
 	__unsafe_unretained NSString *ordersCount;
-	__unsafe_unretained NSString *tags;
 	__unsafe_unretained NSString *taxExempt;
 	__unsafe_unretained NSString *totalSpent;
 	__unsafe_unretained NSString *updatedAt;
@@ -105,15 +103,11 @@ extern const struct BUYCustomerRelationships {
 
 @property (nonatomic, strong) NSString* multipassIdentifier;
 
-@property (nonatomic, strong) NSString* note;
-
 @property (nonatomic, strong) NSNumber* ordersCount;
 
 @property (atomic) int16_t ordersCountValue;
 - (int16_t)ordersCountValue;
 - (void)setOrdersCountValue:(int16_t)value_;
-
-@property (nonatomic, strong) NSString* tags;
 
 @property (nonatomic, strong) NSNumber* taxExempt;
 
@@ -174,14 +168,8 @@ extern const struct BUYCustomerRelationships {
 - (NSString*)primitiveMultipassIdentifier;
 - (void)setPrimitiveMultipassIdentifier:(NSString*)value;
 
-- (NSString*)primitiveNote;
-- (void)setPrimitiveNote:(NSString*)value;
-
 - (NSNumber*)primitiveOrdersCount;
 - (void)setPrimitiveOrdersCount:(NSNumber*)value;
-
-- (NSString*)primitiveTags;
-- (void)setPrimitiveTags:(NSString*)value;
 
 - (NSNumber*)primitiveTaxExempt;
 - (void)setPrimitiveTaxExempt:(NSNumber*)value;

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYCustomer.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/_BUYCustomer.m
@@ -39,9 +39,7 @@ const struct BUYCustomerAttributes BUYCustomerAttributes = {
 	.lastOrderID = @"lastOrderID",
 	.lastOrderName = @"lastOrderName",
 	.multipassIdentifier = @"multipassIdentifier",
-	.note = @"note",
 	.ordersCount = @"ordersCount",
-	.tags = @"tags",
 	.taxExempt = @"taxExempt",
 	.totalSpent = @"totalSpent",
 	.updatedAt = @"updatedAt",
@@ -112,9 +110,7 @@ const struct BUYCustomerRelationships BUYCustomerRelationships = {
 @dynamic lastOrderID;
 @dynamic lastOrderName;
 @dynamic multipassIdentifier;
-@dynamic note;
 @dynamic ordersCount;
-@dynamic tags;
 @dynamic taxExempt;
 @dynamic totalSpent;
 @dynamic updatedAt;


### PR DESCRIPTION
This removes the `tags` and `note` fields from the `Customer` entity, which have never been available from the endpoint, and were added in error.

This does not address the apparent writability of other fields that are in fact read-only. Marking properties are read-only can be accomplished via the mogenerator template by including the key `mogenerator.readonly` in the property's `userInfo` in the managed object model definition file.

Fixes #308 

@davidmuzi 