### PR TITLE
[#397] Fix ternary operator assignment for Apple Pay Shipping Address Required Fields 

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYApplePayPaymentProvider.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYApplePayPaymentProvider.m
@@ -195,7 +195,7 @@ NSString *const BUYApplePayPaymentProviderId = @"BUYApplePayPaymentProviderId";
 	
 	[paymentRequest setMerchantIdentifier:self.merchantID];
 	[paymentRequest setRequiredBillingAddressFields:PKAddressFieldAll];
-	[paymentRequest setRequiredShippingAddressFields:[self.checkout.requiresShipping integerValue] ? PKAddressFieldAll : PKAddressFieldEmail|PKAddressFieldPhone];
+	[paymentRequest setRequiredShippingAddressFields:self.checkout.requiresShippingValue ? PKAddressFieldAll : PKAddressFieldEmail|PKAddressFieldPhone];
 	[paymentRequest setSupportedNetworks:self.supportedNetworks];
 	[paymentRequest setMerchantCapabilities:PKMerchantCapability3DS];
 	[paymentRequest setCountryCode:self.shop.country];

--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYApplePayPaymentProvider.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYApplePayPaymentProvider.m
@@ -195,7 +195,7 @@ NSString *const BUYApplePayPaymentProviderId = @"BUYApplePayPaymentProviderId";
 	
 	[paymentRequest setMerchantIdentifier:self.merchantID];
 	[paymentRequest setRequiredBillingAddressFields:PKAddressFieldAll];
-	[paymentRequest setRequiredShippingAddressFields:self.checkout.requiresShipping ? PKAddressFieldAll : PKAddressFieldEmail|PKAddressFieldPhone];
+	[paymentRequest setRequiredShippingAddressFields:[self.checkout.requiresShipping integerValue] ? PKAddressFieldAll : PKAddressFieldEmail|PKAddressFieldPhone];
 	[paymentRequest setSupportedNetworks:self.supportedNetworks];
 	[paymentRequest setMerchantCapabilities:PKMerchantCapability3DS];
 	[paymentRequest setCountryCode:self.shop.country];


### PR DESCRIPTION
Check integer value instead of NSNumber pointer when assigning required fields

Resolves #397 

@davidmuzi @bgulanowski 