### PR TITLE
[#245] Support PKPaymentAuthorizationController for iOS 10.0+

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK Tests/BUYPaymentProviderTests.m
+++ b/Mobile Buy SDK/Mobile Buy SDK Tests/BUYPaymentProviderTests.m
@@ -264,6 +264,11 @@ extern Class SafariViewControllerClass;
 	[self.expectations[@"presentController"] fulfill];
 }
 
+- (void)paymentProvider:(id<BUYPaymentProvider>)provider wantsPaymentControllerPresented:(PKPaymentAuthorizationController *)controller
+{
+	[self.expectations[@"presentController"] fulfill];
+}
+
 - (void)paymentProviderWantsControllerDismissed:(id <BUYPaymentProvider>)provider
 {
 	

--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYApplePayPaymentProvider.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYApplePayPaymentProvider.m
@@ -207,6 +207,7 @@ typedef void (^ShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArray<P
 		PKPaymentAuthorizationController *controller = [[PKPaymentAuthorizationController alloc] initWithPaymentRequest:request];
 		if (controller) {
 			controller.delegate = self;
+			[self.delegate paymentProvider:self wantsPaymentControllerPresented:controller];
 		}
 		else {
 			if ([self.delegate respondsToSelector:@selector(paymentProvider:didFailWithError:)]) {

--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYApplePayPaymentProvider.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYApplePayPaymentProvider.m
@@ -36,8 +36,8 @@
 
 NSString *const BUYApplePayPaymentProviderId = @"BUYApplePayPaymentProviderId";
 
-typedef void (^AddressUpdateCompletion)(PKPaymentAuthorizationStatus, NSArray<PKShippingMethod *> * _Nonnull, NSArray<PKPaymentSummaryItem *> * _Nonnull);
-typedef void (^ShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArray<PKPaymentSummaryItem *> * _Nonnull);
+typedef void (^BUYAddressUpdateCompletion)(PKPaymentAuthorizationStatus, NSArray<PKShippingMethod *> * _Nonnull, NSArray<PKPaymentSummaryItem *> * _Nonnull);
+typedef void (^BUYShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArray<PKPaymentSummaryItem *> * _Nonnull);
 
 @interface BUYApplePayPaymentProvider () <PKPaymentAuthorizationViewControllerDelegate, PKPaymentAuthorizationControllerDelegate>
 
@@ -301,7 +301,7 @@ typedef void (^ShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArray<P
 	[self paymentAuthorizationDidFinish];
 }
 
-- (void)paymentAuthorizationController:(PKPaymentAuthorizationController *)controller didSelectShippingMethod:(PKShippingMethod *)shippingMethod completion:(ShippingMethodCompletion)completion
+- (void)paymentAuthorizationController:(PKPaymentAuthorizationController *)controller didSelectShippingMethod:(PKShippingMethod *)shippingMethod completion:(BUYShippingMethodCompletion)completion
 {
 	[self.applePayAuthorizationDelegate paymentAuthorizationController:controller didSelectShippingMethod:shippingMethod completion:^(PKPaymentAuthorizationStatus status, NSArray<PKPaymentSummaryItem *> * _Nonnull summaryItems) {
 		if (status == PKPaymentAuthorizationStatusInvalidShippingPostalAddress) {
@@ -314,7 +314,7 @@ typedef void (^ShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArray<P
 	}];
 }
 
-- (void)paymentAuthorizationController:(PKPaymentAuthorizationController *)controller didSelectShippingContact:(PKContact *)contact completion:(AddressUpdateCompletion)completion
+- (void)paymentAuthorizationController:(PKPaymentAuthorizationController *)controller didSelectShippingContact:(PKContact *)contact completion:(BUYAddressUpdateCompletion)completion
 {
 	[self.applePayAuthorizationDelegate paymentAuthorizationController:controller didSelectShippingContact:contact completion:^(PKPaymentAuthorizationStatus status, NSArray<PKShippingMethod *> * _Nonnull shippingMethods, NSArray<PKPaymentSummaryItem *> * _Nonnull summaryItems) {
 		[self paymentAuthorizationDidUpdateAddressWithStatus:status];
@@ -337,7 +337,7 @@ typedef void (^ShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArray<P
 	[self paymentAuthorizationDidFinish];
 }
 
-- (void)paymentAuthorizationViewController:(PKPaymentAuthorizationViewController *)controller didSelectShippingMethod:(nonnull PKShippingMethod *)shippingMethod completion:(ShippingMethodCompletion)completion
+- (void)paymentAuthorizationViewController:(PKPaymentAuthorizationViewController *)controller didSelectShippingMethod:(nonnull PKShippingMethod *)shippingMethod completion:(BUYShippingMethodCompletion)completion
 {
 	[self.applePayAuthorizationDelegate paymentAuthorizationViewController:controller didSelectShippingMethod:shippingMethod completion:^(PKPaymentAuthorizationStatus status, NSArray<PKPaymentSummaryItem *> * _Nonnull summaryItems) {
 		[self paymentAuthorizationDidUpdateAddressWithStatus:status];
@@ -345,7 +345,7 @@ typedef void (^ShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArray<P
 	}];
 }
 
--(void)paymentAuthorizationViewController:(PKPaymentAuthorizationViewController *)controller didSelectShippingAddress:(ABRecordRef)address completion:(AddressUpdateCompletion)completion
+-(void)paymentAuthorizationViewController:(PKPaymentAuthorizationViewController *)controller didSelectShippingAddress:(ABRecordRef)address completion:(BUYAddressUpdateCompletion)completion
 {
 	[self.applePayAuthorizationDelegate paymentAuthorizationViewController:controller didSelectShippingAddress:address completion:^(PKPaymentAuthorizationStatus status, NSArray<PKShippingMethod *> * _Nonnull shippingMethods, NSArray<PKPaymentSummaryItem *> * _Nonnull summaryItems) {
 		[self paymentAuthorizationDidUpdateAddressWithStatus:status];
@@ -353,7 +353,7 @@ typedef void (^ShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArray<P
 	}];
 }
 
-- (void)paymentAuthorizationViewController:(PKPaymentAuthorizationViewController *)controller didSelectShippingContact:(PKContact *)contact completion:(AddressUpdateCompletion)completion
+- (void)paymentAuthorizationViewController:(PKPaymentAuthorizationViewController *)controller didSelectShippingContact:(PKContact *)contact completion:(BUYAddressUpdateCompletion)completion
 {
 	[self.applePayAuthorizationDelegate paymentAuthorizationViewController:controller didSelectShippingContact:contact completion:^(PKPaymentAuthorizationStatus status, NSArray<PKShippingMethod *> * _Nonnull shippingMethods, NSArray<PKPaymentSummaryItem *> * _Nonnull summaryItems) {
 		[self paymentAuthorizationDidUpdateAddressWithStatus:status];

--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYApplePayPaymentProvider.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYApplePayPaymentProvider.m
@@ -155,7 +155,7 @@ typedef void (^BUYShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArra
 	// checks if device hardware is capable of using Apple Pay
 	// checks if the device has a payment card setup
 	
-	Class PaymentClass = [self applePayController];
+	Class PaymentClass = [self applePayControllerClass];
 	return (self.merchantID.length &&
 			[PaymentClass canMakePayments] &&
 			[PaymentClass canMakePaymentsUsingNetworks:self.supportedNetworks]);
@@ -167,7 +167,7 @@ typedef void (^BUYShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArra
 	if ([passLibrary respondsToSelector:@selector(canAddPaymentPassWithPrimaryAccountIdentifier:)] &&
 		// Check if the device can add a payment pass
 		[self.merchantID length]) {
-		Class PaymentClass = [self applePayController];
+		Class PaymentClass = [self applePayControllerClass];
 		return [PaymentClass canMakePayments];
 	} else {
 		return NO;
@@ -181,7 +181,7 @@ typedef void (^BUYShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArra
 	PKPaymentRequest *request = [self paymentRequest];
 	request.paymentSummaryItems = [self.checkout buy_summaryItemsWithShopName:self.shop.name];
 	
-	Class PaymentClass = [self applePayController];
+	Class PaymentClass = [self applePayControllerClass];
 	id controller = [[PaymentClass alloc] initWithPaymentRequest:request];
 	[self presentPaymentController:controller withApplePayControllerClass:PaymentClass];
 }
@@ -215,7 +215,7 @@ typedef void (^BUYShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArra
 	return _supportedNetworks;
 }
 
-- (Class)applePayController
+- (Class)applePayControllerClass
 {
 	return ([PKPaymentAuthorizationController class]) ?: [PKPaymentAuthorizationViewController class];
 }

--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYApplePayPaymentProvider.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYApplePayPaymentProvider.m
@@ -183,24 +183,7 @@ typedef void (^BUYShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArra
 	
 	Class PaymentClass = [self applePayController];
 	id controller = [[PaymentClass alloc] initWithPaymentRequest:request];
-	if (controller) {
-		[controller setDelegate:self];
-		if ([PaymentClass isSubclassOfClass:[PKPaymentAuthorizationController class]]) {
-			if ([self.delegate respondsToSelector:@selector(paymentProvider:wantsPaymentControllerPresented:)]) {
-				[self.delegate paymentProvider:self wantsPaymentControllerPresented:controller];
-			} else {
-				[controller presentWithCompletion:nil];
-			}
-		} else {
-			[self.delegate paymentProvider:self wantsControllerPresented:controller];
-		}
-	}
-	else {
-		if ([self.delegate respondsToSelector:@selector(paymentProvider:didFailWithError:)]) {
-			[self.delegate paymentProvider:self didFailWithError:nil];
-		}
-		[[NSNotificationCenter defaultCenter] postNotificationName:BUYPaymentProviderDidFailCheckoutNotificationKey object:self];
-	}
+	[self presentPaymentController:controller withApplePayControllerClass:PaymentClass];
 }
 
 - (PKPaymentRequest *)paymentRequest
@@ -283,6 +266,27 @@ typedef void (^BUYShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArra
 			[self.delegate paymentProvider:self didFailWithError:self.applePayAuthorizationDelegate.lastError];
 		}
 		[[NSNotificationCenter defaultCenter] postNotificationName:BUYPaymentProviderDidFailToUpdateCheckoutNotificationKey object:self];
+	}
+}
+
+- (void)presentPaymentController:(id)controller withApplePayControllerClass:(Class)applePayControllerClass {
+	if (controller) {
+		[controller setDelegate:self];
+		if ([applePayControllerClass isSubclassOfClass:[PKPaymentAuthorizationController class]]) {
+			if ([self.delegate respondsToSelector:@selector(paymentProvider:wantsPaymentControllerPresented:)]) {
+				[self.delegate paymentProvider:self wantsPaymentControllerPresented:controller];
+			} else {
+				[controller presentWithCompletion:nil];
+			}
+		} else {
+			[self.delegate paymentProvider:self wantsControllerPresented:controller];
+		}
+	}
+	else {
+		if ([self.delegate respondsToSelector:@selector(paymentProvider:didFailWithError:)]) {
+			[self.delegate paymentProvider:self didFailWithError:nil];
+		}
+		[[NSNotificationCenter defaultCenter] postNotificationName:BUYPaymentProviderDidFailCheckoutNotificationKey object:self];
 	}
 }
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYPaymentProvider.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYPaymentProvider.h
@@ -25,6 +25,7 @@
 //
 
 @import UIKit;
+@import PassKit;
 
 #import "BUYClient.h"
 
@@ -50,6 +51,14 @@ extern NSString *const BUYPaymentProviderDidCompleteCheckoutNotificationKey;
  *  @param controller the `UIViewController` to be presented
  */
 - (void)paymentProvider:(id <BUYPaymentProvider>)provider wantsControllerPresented:(UIViewController *)controller;
+
+/**
+ *  Called when a controller needs to be presented
+ *
+ *  @param provider   the `BUYPaymentProvider`
+ *  @param controller the `PKPaymentAuthorizationController` to be presented
+ */
+- (void)paymentProvider:(id <BUYPaymentProvider>)provider wantsPaymentControllerPresented:(PKPaymentAuthorizationController *)controller;
 
 /**
  *  Called when the view controller

--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYPaymentProvider.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYPaymentProvider.h
@@ -53,14 +53,6 @@ extern NSString *const BUYPaymentProviderDidCompleteCheckoutNotificationKey;
 - (void)paymentProvider:(id <BUYPaymentProvider>)provider wantsControllerPresented:(UIViewController *)controller;
 
 /**
- *  Called when a controller needs to be presented
- *
- *  @param provider   the `BUYPaymentProvider`
- *  @param controller the `PKPaymentAuthorizationController` to be presented
- */
-- (void)paymentProvider:(id <BUYPaymentProvider>)provider wantsPaymentControllerPresented:(PKPaymentAuthorizationController *)controller;
-
-/**
  *  Called when the view controller
  *
  *  @param provider   the `BUYPaymentProvider`
@@ -68,6 +60,14 @@ extern NSString *const BUYPaymentProviderDidCompleteCheckoutNotificationKey;
 - (void)paymentProviderWantsControllerDismissed:(id <BUYPaymentProvider>)provider;
 
 @optional
+
+/**
+ *  Called when a controller needs to be presented
+ *
+ *  @param provider   the `BUYPaymentProvider`
+ *  @param controller the `PKPaymentAuthorizationController` to be presented
+ */
+- (void)paymentProvider:(id <BUYPaymentProvider>)provider wantsPaymentControllerPresented:(PKPaymentAuthorizationController *)controller NS_AVAILABLE_IOS(10_0);
 
 /**
  *  Called when the checkout process has started

--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYPaymentProvider.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYPaymentProvider.h
@@ -62,7 +62,10 @@ extern NSString *const BUYPaymentProviderDidCompleteCheckoutNotificationKey;
 @optional
 
 /**
- *  Called when a controller needs to be presented
+ *  Called when a PKPaymentAuthorizationController needs to be presented. If this method is implemented, also
+ *  call `presentWithCompletion:` on the controller and specify completion.
+ *
+ *  PKPaymentAuthorizationController is only available in iOS 10.0+. For older versions, use PKPaymentAuthorizationViewController.
  *
  *  @param provider   the `BUYPaymentProvider`
  *  @param controller the `PKPaymentAuthorizationController` to be presented

--- a/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayAuthorizationDelegate.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayAuthorizationDelegate.h
@@ -33,7 +33,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface BUYApplePayAuthorizationDelegate : NSObject <PKPaymentAuthorizationViewControllerDelegate>
+@interface BUYApplePayAuthorizationDelegate : NSObject <PKPaymentAuthorizationViewControllerDelegate, PKPaymentAuthorizationControllerDelegate>
 
 /**
  *  Initializes a helper to support Apple Pay

--- a/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayAuthorizationDelegate.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayAuthorizationDelegate.m
@@ -38,8 +38,8 @@
 
 const NSTimeInterval PollDelay = 0.5;
 
-typedef void (^AddressUpdateCompletion)(PKPaymentAuthorizationStatus, NSArray<PKShippingMethod *> * _Nonnull, NSArray<PKPaymentSummaryItem *> * _Nonnull);
-typedef void (^ShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArray<PKPaymentSummaryItem *> * _Nonnull);
+typedef void (^BUYAddressUpdateCompletion)(PKPaymentAuthorizationStatus, NSArray<PKShippingMethod *> * _Nonnull, NSArray<PKPaymentSummaryItem *> * _Nonnull);
+typedef void (^BUYShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArray<PKPaymentSummaryItem *> * _Nonnull);
 
 @interface BUYApplePayAuthorizationDelegate ()
 
@@ -84,14 +84,14 @@ typedef void (^ShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArray<P
 
 - (void)paymentAuthorizationController:(PKPaymentAuthorizationController *)controller
 			  didSelectShippingContact:(PKContact *)contact
-							completion:(AddressUpdateCompletion)completion
+							completion:(BUYAddressUpdateCompletion)completion
 {
 	[self paymentAuthorizationDidSelectShippingContact:contact completion:completion];
 }
 
 - (void)paymentAuthorizationController:(PKPaymentAuthorizationController *)controller
 			   didSelectShippingMethod:(PKShippingMethod *)shippingMethod
-							completion:(ShippingMethodCompletion)completion
+							completion:(BUYShippingMethodCompletion)completion
 {
 	[self paymentAuthorizationDidSelectShippingMethod:shippingMethod completion:completion];
 }
@@ -123,7 +123,7 @@ typedef void (^ShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArray<P
 
 -(void)paymentAuthorizationViewController:(PKPaymentAuthorizationViewController *)controller
 				 didSelectShippingAddress:(ABRecordRef)address
-							   completion:(AddressUpdateCompletion)completion
+							   completion:(BUYAddressUpdateCompletion)completion
 {
 	self.checkout.shippingAddress = [self buyAddressWithABRecord:address];
 	if ([self.checkout.shippingAddress isValidAddressForShippingRates]) {
@@ -133,14 +133,14 @@ typedef void (^ShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArray<P
 
 -(void)paymentAuthorizationViewController:(PKPaymentAuthorizationViewController *)controller
 				 didSelectShippingContact:(PKContact *)contact
-							   completion:(AddressUpdateCompletion)completion
+							   completion:(BUYAddressUpdateCompletion)completion
 {
 	[self paymentAuthorizationDidSelectShippingContact:contact completion:completion];
 }
 
 -(void)paymentAuthorizationViewController:(PKPaymentAuthorizationViewController *)controller
 				  didSelectShippingMethod:(PKShippingMethod *)shippingMethod
-							   completion:(ShippingMethodCompletion)completion
+							   completion:(BUYShippingMethodCompletion)completion
 {
 	[self paymentAuthorizationDidSelectShippingMethod:shippingMethod completion:completion];
 }
@@ -195,7 +195,7 @@ typedef void (^ShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArray<P
 }
 
 - (void)paymentAuthorizationDidSelectShippingContact:(PKContact *)contact
-										  completion:(AddressUpdateCompletion)completion
+										  completion:(BUYAddressUpdateCompletion)completion
 {
 	self.checkout.shippingAddress = [self buyAddressWithContact:contact];
 	if ([self.checkout.shippingAddress isValidAddressForShippingRates]) {
@@ -204,7 +204,7 @@ typedef void (^ShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArray<P
 }
 
 - (void)paymentAuthorizationDidSelectShippingMethod:(PKShippingMethod *)shippingMethod
-										 completion:(ShippingMethodCompletion)completion
+										 completion:(BUYShippingMethodCompletion)completion
 {
 	BUYShippingRate *shippingRate = [self rateForShippingMethod:shippingMethod];
 	self.checkout.shippingRate = shippingRate;
@@ -220,7 +220,7 @@ typedef void (^ShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArray<P
 	}];
 }
 
-- (void)updateCheckoutWithAddressCompletion:(AddressUpdateCompletion)completion
+- (void)updateCheckoutWithAddressCompletion:(BUYAddressUpdateCompletion)completion
 {
 	// This method call is internal to selection of shipping address that are returned as partial from PKPaymentAuthorizationViewController
 	// However, to ensure we never set partialAddresses to NO, we want to guard the setter. Should PKPaymentAuthorizationViewController ever
@@ -246,7 +246,7 @@ typedef void (^ShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArray<P
 	}];
 }
 
-- (void)updateShippingRatesCompletion:(AddressUpdateCompletion)completion
+- (void)updateShippingRatesCompletion:(BUYAddressUpdateCompletion)completion
 {
 	[self.client getShippingRatesForCheckoutWithToken:self.checkout.token completion:^(NSArray *shippingRates, BUYStatus status, NSError *error) {
 		


### PR DESCRIPTION
Adopt `PKPaymentAuthorizationControllerDelegate` for Apple Pay specific classes and use system version checking to use `PKPaymentAuthorizationController` instead of `PKPaymentAuthorizationViewController`.

This will allow us to use the current Apple Pay classes for watchOS.

Resolves #245 

@davidmuzi @bgulanowski 