### PR TITLE
[#448] Make product image view square and aspect fit

### DIFF
--- a/Mobile Buy SDK Sample Apps/Mobile Buy SDK tvOS Sample/Mobile Buy SDK tvOS Sample/Base.lproj/Main.storyboard
+++ b/Mobile Buy SDK Sample Apps/Mobile Buy SDK tvOS Sample/Mobile Buy SDK tvOS Sample/Base.lproj/Main.storyboard
@@ -50,7 +50,7 @@
                                                     <rect key="frame" x="0.0" y="74" width="1920" height="426"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="50" minimumInteritemSpacing="0.0" id="0JC-65-5u7">
-                                                        <size key="itemSize" width="200" height="410"/>
+                                                        <size key="itemSize" width="300" height="410"/>
                                                         <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                                         <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                                         <inset key="sectionInset" minX="50" minY="0.0" maxX="50" maxY="0.0"/>
@@ -64,26 +64,26 @@
                                                     </label>
                                                     <cells>
                                                         <collectionViewCell opaque="NO" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ProductCollectionViewCell" id="smx-ww-K6h" customClass="ProductCollectionViewCell" customModule="Mobile_Buy_SDK_tvOS_Sample_App" customModuleProvider="target">
-                                                            <rect key="frame" x="50" y="8" width="200" height="410"/>
+                                                            <rect key="frame" x="50" y="8" width="300" height="410"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                                                                <rect key="frame" x="0.0" y="0.0" width="200" height="410"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="300" height="410"/>
                                                                 <autoresizingMask key="autoresizingMask"/>
                                                                 <subviews>
-                                                                    <imageView opaque="NO" multipleTouchEnabled="YES" contentMode="scaleAspectFill" fixedFrame="YES" adjustsImageWhenAncestorFocused="YES" translatesAutoresizingMaskIntoConstraints="NO" id="g4J-FO-cjw" customClass="AsyncImageView">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="200" height="298"/>
+                                                                    <imageView opaque="NO" multipleTouchEnabled="YES" contentMode="scaleAspectFit" fixedFrame="YES" adjustsImageWhenAncestorFocused="YES" translatesAutoresizingMaskIntoConstraints="NO" id="g4J-FO-cjw" customClass="AsyncImageView">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="300" height="300"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                                     </imageView>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DbE-i5-3Us">
-                                                                        <rect key="frame" x="0.0" y="329" width="200" height="61"/>
+                                                                        <rect key="frame" x="0.0" y="329" width="300" height="61"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                                                         <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LtS-M0-0dF">
-                                                                        <rect key="frame" x="0.0" y="390" width="200" height="21"/>
+                                                                        <rect key="frame" x="0.0" y="390" width="300" height="21"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="22"/>
                                                                         <color key="textColor" red="0.7533692917212782" green="0.97393804365003167" blue="0.38649725183213457" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
Make product image views square with a content mode of aspect fill so that product images look good in all orientations and dimensions.

Resolves #448 

@davidmuzi @bgulanowski 