### PR TITLE
Fix the build for non-POSIX compliant shells (ie. fish)

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK.xcodeproj/project.pbxproj
+++ b/Mobile Buy SDK/Mobile Buy SDK.xcodeproj/project.pbxproj
@@ -1913,7 +1913,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "$SHELL \"${PROJECT_DIR}/../Scripts/generate_models.sh\"";
+			shellScript = "/bin/sh \"${PROJECT_DIR}/../Scripts/generate_models.sh\"";
 		};
 		904FB61F1AE03DCF00EA1758 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Scripts/run_tests.sh
+++ b/Scripts/run_tests.sh
@@ -14,4 +14,4 @@ fi
 xcodebuild test -project "Mobile Buy SDK/Mobile Buy SDK.xcodeproj" \
 -scheme "Mobile Buy SDK Tests" \
 -sdk iphonesimulator \
--destination 'platform=iOS Simulator,name=iPhone 6s,OS=10.1'
+-destination 'platform=iOS Simulator,name=iPhone 6s,OS=10.2'


### PR DESCRIPTION
Don't pull the shell from $SHELL because $SHELL could be anything, but
what is really desired is a POSIX-compliant shell (ie. /bin/sh)