### PR TITLE
ApplePay: Handle incomplete shipping address

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayAuthorizationDelegate.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYApplePayAuthorizationDelegate.m
@@ -123,6 +123,9 @@ typedef void (^BUYShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArra
 	self.checkout.shippingAddress = [self buyAddressWithABRecord:address];
 	if ([self.checkout.shippingAddress isValidAddressForShippingRates]) {
 		[self updateCheckoutWithAddressCompletion:completion];
+	} else {
+		self.lastError = [NSError errorWithDomain:BUYShopifyError code:BUYShopifyError_InvalidShippingAddress userInfo:nil];
+		completion(PKPaymentAuthorizationStatusInvalidShippingPostalAddress, @[], [self.checkout buy_summaryItemsWithShopName:self.shopName]);
 	}
 }
 
@@ -206,6 +209,9 @@ typedef void (^BUYShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArra
 	self.checkout.shippingAddress = [self buyAddressWithContact:contact];
 	if ([self.checkout.shippingAddress isValidAddressForShippingRates]) {
 		[self updateCheckoutWithAddressCompletion:completion];
+	} else {
+		self.lastError = [NSError errorWithDomain:BUYShopifyError code:BUYShopifyError_InvalidShippingAddress userInfo:nil];
+		completion(PKPaymentAuthorizationStatusInvalidShippingPostalAddress, @[], [self.checkout buy_summaryItemsWithShopName:self.shopName]);
 	}
 }
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYShopifyErrorCodes.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYShopifyErrorCodes.h
@@ -38,6 +38,10 @@ typedef NS_ENUM(NSUInteger, BUYCheckoutError){
 	 */
 	BUYShopifyError_CartFetchError,
 	/**
+	 *  Shipping address is not valid address for shipping rates
+	 */
+	BUYShopifyError_InvalidShippingAddress,
+	/**
 	 *  No shipping rates are available for the selected address
 	 */
 	BUYShopifyError_NoShippingMethodsToAddress,


### PR DESCRIPTION
If the user enters incomplete shipping address (i.e. without city/zip/province/country), apple pay just hangs on "Processing..." state infinitely, because `completion` callback is never called.