### PR TITLE
Revert "Dismiss PKPaymentAuthorizationController after completion"

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYApplePayPaymentProvider.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Payment Providers/BUYApplePayPaymentProvider.m
@@ -321,7 +321,6 @@ typedef void (^BUYShippingMethodCompletion)(PKPaymentAuthorizationStatus, NSArra
 
 - (void)paymentAuthorizationControllerDidFinish:(PKPaymentAuthorizationController *)controller
 {
-	[controller dismissWithCompletion:nil];
 	[self paymentAuthorizationDidFinish];
 }
 


### PR DESCRIPTION
This reverts commit 1a146891e007902afbe3de6b43b5b1fff4500322.
Looks like controller must be dismissed by delegate inside `paymentProviderWantsControllerDismissed:` method
See: https://help.shopify.com/api/sdks/custom-storefront/mobile-buy-sdk/ios/integration-guide/checkout

Fixes #517