### PR TITLE
Xcode version noise

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK.xcodeproj/xcshareddata/xcschemes/Buy.xcscheme
+++ b/Mobile Buy SDK/Mobile Buy SDK.xcodeproj/xcshareddata/xcschemes/Buy.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0810"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Mobile Buy SDK/Mobile Buy SDK.xcodeproj/xcshareddata/xcschemes/Documentation.xcscheme
+++ b/Mobile Buy SDK/Mobile Buy SDK.xcodeproj/xcshareddata/xcschemes/Documentation.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0810"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Mobile Buy SDK/Mobile Buy SDK.xcodeproj/xcshareddata/xcschemes/Mobile Buy SDK Tests.xcscheme
+++ b/Mobile Buy SDK/Mobile Buy SDK.xcodeproj/xcshareddata/xcschemes/Mobile Buy SDK Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0810"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Mobile Buy SDK/Mobile Buy SDK.xcodeproj/xcshareddata/xcschemes/Static Universal Framework.xcscheme
+++ b/Mobile Buy SDK/Mobile Buy SDK.xcodeproj/xcshareddata/xcschemes/Static Universal Framework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0810"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Xcode 8.2 came out a while ago. Xcode randomly decided to change the version marker in these files. If we don't commit them, it will just keep making this changes.