### PR TITLE
Collections hybrid view

### DIFF
--- a/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
+++ b/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9AAFAB7E1E60BE6500864A17 /* ViewModeling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB7D1E60BE6500864A17 /* ViewModeling.swift */; };
+		9AAFAB801E60BE9800864A17 /* ViewModelConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB7F1E60BE9800864A17 /* ViewModelConfigurable.swift */; };
+		9AAFAB8C1E60C3C700864A17 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB8B1E60C3C700864A17 /* ViewModel.swift */; };
 		9ADAD46B1E563091008AC561 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADAD46A1E563091008AC561 /* AppDelegate.swift */; };
 		9ADAD46D1E563091008AC561 /* CollectionsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADAD46C1E563091008AC561 /* CollectionsController.swift */; };
 		9ADAD4701E563091008AC561 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9ADAD46E1E563091008AC561 /* Main.storyboard */; };
@@ -53,6 +56,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		9AAFAB7D1E60BE6500864A17 /* ViewModeling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModeling.swift; sourceTree = "<group>"; };
+		9AAFAB7F1E60BE9800864A17 /* ViewModelConfigurable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModelConfigurable.swift; sourceTree = "<group>"; };
+		9AAFAB8B1E60C3C700864A17 /* ViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		9ADAD4671E563091008AC561 /* Storefront.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Storefront.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9ADAD46A1E563091008AC561 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9ADAD46C1E563091008AC561 /* CollectionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionsController.swift; sourceTree = "<group>"; };
@@ -80,6 +86,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9AAFAB7C1E60BE3700864A17 /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				9AAFAB8B1E60C3C700864A17 /* ViewModel.swift */,
+				9AAFAB7D1E60BE6500864A17 /* ViewModeling.swift */,
+				9AAFAB7F1E60BE9800864A17 /* ViewModelConfigurable.swift */,
+			);
+			name = Protocols;
+			sourceTree = "<group>";
+		};
 		9ADAD45E1E563091008AC561 = {
 			isa = PBXGroup;
 			children = (
@@ -103,6 +119,7 @@
 				9AEF61CA1E606EEB0067FA90 /* Fragments */,
 				9ADAD46A1E563091008AC561 /* AppDelegate.swift */,
 				9ADAD46C1E563091008AC561 /* CollectionsController.swift */,
+				9AAFAB7C1E60BE3700864A17 /* Protocols */,
 				9ADAD46E1E563091008AC561 /* Main.storyboard */,
 				9ADAD47C1E5630CB008AC561 /* Supporting Files */,
 			);
@@ -255,9 +272,12 @@
 			files = (
 				9AEF61D71E6070F40067FA90 /* Fragment+Shop.swift in Sources */,
 				9AEF61D11E606F930067FA90 /* Fragment+Product.swift in Sources */,
+				9AAFAB7E1E60BE6500864A17 /* ViewModeling.swift in Sources */,
 				9AEF61D51E6070880067FA90 /* Fragment+Collection.swift in Sources */,
+				9AAFAB8C1E60C3C700864A17 /* ViewModel.swift in Sources */,
 				9AEF61CC1E606EFE0067FA90 /* Fragment+ProductConnectionQuery.swift in Sources */,
 				9ADAD46D1E563091008AC561 /* CollectionsController.swift in Sources */,
+				9AAFAB801E60BE9800864A17 /* ViewModelConfigurable.swift in Sources */,
 				9AEF61CE1E606F100067FA90 /* Fragment+ImageConnectionQuery.swift in Sources */,
 				9ADAD46B1E563091008AC561 /* AppDelegate.swift in Sources */,
 			);

--- a/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
+++ b/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 		9AAFAB941E60D2D000864A17 /* NSObject+Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB931E60D2D000864A17 /* NSObject+Name.swift */; };
 		9AAFAB961E60D83600864A17 /* Fragment+CollectionQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB951E60D83600864A17 /* Fragment+CollectionQuery.swift */; };
 		9ADAD46B1E563091008AC561 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADAD46A1E563091008AC561 /* AppDelegate.swift */; };
-		9ADAD46D1E563091008AC561 /* CollectionsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADAD46C1E563091008AC561 /* CollectionsController.swift */; };
+		9ADAD46D1E563091008AC561 /* CollectionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADAD46C1E563091008AC561 /* CollectionsViewController.swift */; };
 		9ADAD4701E563091008AC561 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9ADAD46E1E563091008AC561 /* Main.storyboard */; };
 		9ADAD4721E563091008AC561 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9ADAD4711E563091008AC561 /* Assets.xcassets */; };
 		9ADAD4751E563091008AC561 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9ADAD4731E563091008AC561 /* LaunchScreen.storyboard */; };
@@ -81,7 +81,7 @@
 		9AAFAB951E60D83600864A17 /* Fragment+CollectionQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Fragment+CollectionQuery.swift"; sourceTree = "<group>"; };
 		9ADAD4671E563091008AC561 /* Storefront.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Storefront.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9ADAD46A1E563091008AC561 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		9ADAD46C1E563091008AC561 /* CollectionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionsController.swift; sourceTree = "<group>"; };
+		9ADAD46C1E563091008AC561 /* CollectionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionsViewController.swift; sourceTree = "<group>"; };
 		9ADAD46F1E563091008AC561 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		9ADAD4711E563091008AC561 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9ADAD4741E563091008AC561 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -123,6 +123,7 @@
 				9AAFAB7A1E60BDF900864A17 /* CollectionCell.swift */,
 				9AAFAB831E60BF4400864A17 /* CollectionCell.xib */,
 				9AAFAB811E60BEE000864A17 /* CollectionViewModel.swift */,
+				9ADAD46C1E563091008AC561 /* CollectionsViewController.swift */,
 			);
 			name = Collections;
 			sourceTree = "<group>";
@@ -175,7 +176,6 @@
 			isa = PBXGroup;
 			children = (
 				9ADAD46A1E563091008AC561 /* AppDelegate.swift */,
-				9ADAD46C1E563091008AC561 /* CollectionsController.swift */,
 				9AAFAB901E60D0F900864A17 /* UI */,
 				9AAFAB8D1E60C69C00864A17 /* Extensions */,
 				9AAFAB7C1E60BE3700864A17 /* Protocols */,
@@ -346,8 +346,8 @@
 				9AAFAB7B1E60BDF900864A17 /* CollectionCell.swift in Sources */,
 				9AAFAB941E60D2D000864A17 /* NSObject+Name.swift in Sources */,
 				9AEF61CC1E606EFE0067FA90 /* Fragment+ProductConnectionQuery.swift in Sources */,
-				9ADAD46D1E563091008AC561 /* CollectionsController.swift in Sources */,
 				9AAFAB8F1E60C6AC00864A17 /* UIImageView+Remote.swift in Sources */,
+				9ADAD46D1E563091008AC561 /* CollectionsViewController.swift in Sources */,
 				9AAFAB821E60BEE000864A17 /* CollectionViewModel.swift in Sources */,
 				9AAFAB801E60BE9800864A17 /* ViewModelConfigurable.swift in Sources */,
 				9AEF61CE1E606F100067FA90 /* Fragment+ImageConnectionQuery.swift in Sources */,

--- a/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
+++ b/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		9AAFAB891E60C17100864A17 /* ProductCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB871E60C17100864A17 /* ProductCell.swift */; };
 		9AAFAB8A1E60C17100864A17 /* ProductCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9AAFAB881E60C17100864A17 /* ProductCell.xib */; };
 		9AAFAB8C1E60C3C700864A17 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB8B1E60C3C700864A17 /* ViewModel.swift */; };
+		9AAFAB8F1E60C6AC00864A17 /* UIImageView+Remote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB8E1E60C6AC00864A17 /* UIImageView+Remote.swift */; };
 		9AAFAB921E60D11000864A17 /* StorefrontCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB911E60D11000864A17 /* StorefrontCollectionView.swift */; };
 		9AAFAB941E60D2D000864A17 /* NSObject+Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB931E60D2D000864A17 /* NSObject+Name.swift */; };
 		9ADAD46B1E563091008AC561 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADAD46A1E563091008AC561 /* AppDelegate.swift */; };
@@ -73,6 +74,7 @@
 		9AAFAB871E60C17100864A17 /* ProductCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductCell.swift; sourceTree = "<group>"; };
 		9AAFAB881E60C17100864A17 /* ProductCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ProductCell.xib; sourceTree = "<group>"; };
 		9AAFAB8B1E60C3C700864A17 /* ViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
+		9AAFAB8E1E60C6AC00864A17 /* UIImageView+Remote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImageView+Remote.swift"; sourceTree = "<group>"; };
 		9AAFAB911E60D11000864A17 /* StorefrontCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorefrontCollectionView.swift; sourceTree = "<group>"; };
 		9AAFAB931E60D2D000864A17 /* NSObject+Name.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+Name.swift"; sourceTree = "<group>"; };
 		9ADAD4671E563091008AC561 /* Storefront.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Storefront.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -136,6 +138,7 @@
 		9AAFAB8D1E60C69C00864A17 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				9AAFAB8E1E60C6AC00864A17 /* UIImageView+Remote.swift */,
 				9AAFAB931E60D2D000864A17 /* NSObject+Name.swift */,
 			);
 			name = Extensions;
@@ -340,6 +343,7 @@
 				9AAFAB941E60D2D000864A17 /* NSObject+Name.swift in Sources */,
 				9AEF61CC1E606EFE0067FA90 /* Fragment+ProductConnectionQuery.swift in Sources */,
 				9ADAD46D1E563091008AC561 /* CollectionsController.swift in Sources */,
+				9AAFAB8F1E60C6AC00864A17 /* UIImageView+Remote.swift in Sources */,
 				9AAFAB821E60BEE000864A17 /* CollectionViewModel.swift in Sources */,
 				9AAFAB801E60BE9800864A17 /* ViewModelConfigurable.swift in Sources */,
 				9AEF61CE1E606F100067FA90 /* Fragment+ImageConnectionQuery.swift in Sources */,

--- a/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
+++ b/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		9AAFAB8A1E60C17100864A17 /* ProductCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9AAFAB881E60C17100864A17 /* ProductCell.xib */; };
 		9AAFAB8C1E60C3C700864A17 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB8B1E60C3C700864A17 /* ViewModel.swift */; };
 		9AAFAB921E60D11000864A17 /* StorefrontCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB911E60D11000864A17 /* StorefrontCollectionView.swift */; };
+		9AAFAB941E60D2D000864A17 /* NSObject+Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB931E60D2D000864A17 /* NSObject+Name.swift */; };
 		9ADAD46B1E563091008AC561 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADAD46A1E563091008AC561 /* AppDelegate.swift */; };
 		9ADAD46D1E563091008AC561 /* CollectionsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADAD46C1E563091008AC561 /* CollectionsController.swift */; };
 		9ADAD4701E563091008AC561 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9ADAD46E1E563091008AC561 /* Main.storyboard */; };
@@ -73,6 +74,7 @@
 		9AAFAB881E60C17100864A17 /* ProductCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ProductCell.xib; sourceTree = "<group>"; };
 		9AAFAB8B1E60C3C700864A17 /* ViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		9AAFAB911E60D11000864A17 /* StorefrontCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorefrontCollectionView.swift; sourceTree = "<group>"; };
+		9AAFAB931E60D2D000864A17 /* NSObject+Name.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+Name.swift"; sourceTree = "<group>"; };
 		9ADAD4671E563091008AC561 /* Storefront.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Storefront.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9ADAD46A1E563091008AC561 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9ADAD46C1E563091008AC561 /* CollectionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionsController.swift; sourceTree = "<group>"; };
@@ -131,6 +133,14 @@
 			name = Protocols;
 			sourceTree = "<group>";
 		};
+		9AAFAB8D1E60C69C00864A17 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				9AAFAB931E60D2D000864A17 /* NSObject+Name.swift */,
+			);
+			name = Extensions;
+			sourceTree = "<group>";
+		};
 		9AAFAB901E60D0F900864A17 /* UI */ = {
 			isa = PBXGroup;
 			children = (
@@ -163,6 +173,7 @@
 				9ADAD46A1E563091008AC561 /* AppDelegate.swift */,
 				9ADAD46C1E563091008AC561 /* CollectionsController.swift */,
 				9AAFAB901E60D0F900864A17 /* UI */,
+				9AAFAB8D1E60C69C00864A17 /* Extensions */,
 				9AAFAB7C1E60BE3700864A17 /* Protocols */,
 				9AAFAB781E60BD5800864A17 /* View Controllers */,
 				9ADAD46E1E563091008AC561 /* Main.storyboard */,
@@ -326,6 +337,7 @@
 				9AAFAB921E60D11000864A17 /* StorefrontCollectionView.swift in Sources */,
 				9AAFAB8C1E60C3C700864A17 /* ViewModel.swift in Sources */,
 				9AAFAB7B1E60BDF900864A17 /* CollectionCell.swift in Sources */,
+				9AAFAB941E60D2D000864A17 /* NSObject+Name.swift in Sources */,
 				9AEF61CC1E606EFE0067FA90 /* Fragment+ProductConnectionQuery.swift in Sources */,
 				9ADAD46D1E563091008AC561 /* CollectionsController.swift in Sources */,
 				9AAFAB821E60BEE000864A17 /* CollectionViewModel.swift in Sources */,

--- a/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
+++ b/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		9AAFAB7E1E60BE6500864A17 /* ViewModeling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB7D1E60BE6500864A17 /* ViewModeling.swift */; };
 		9AAFAB801E60BE9800864A17 /* ViewModelConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB7F1E60BE9800864A17 /* ViewModelConfigurable.swift */; };
+		9AAFAB861E60C15300864A17 /* ProductViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB851E60C15300864A17 /* ProductViewModel.swift */; };
+		9AAFAB891E60C17100864A17 /* ProductCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB871E60C17100864A17 /* ProductCell.swift */; };
+		9AAFAB8A1E60C17100864A17 /* ProductCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9AAFAB881E60C17100864A17 /* ProductCell.xib */; };
 		9AAFAB8C1E60C3C700864A17 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB8B1E60C3C700864A17 /* ViewModel.swift */; };
 		9AAFAB921E60D11000864A17 /* StorefrontCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB911E60D11000864A17 /* StorefrontCollectionView.swift */; };
 		9ADAD46B1E563091008AC561 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADAD46A1E563091008AC561 /* AppDelegate.swift */; };
@@ -59,6 +62,9 @@
 /* Begin PBXFileReference section */
 		9AAFAB7D1E60BE6500864A17 /* ViewModeling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModeling.swift; sourceTree = "<group>"; };
 		9AAFAB7F1E60BE9800864A17 /* ViewModelConfigurable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModelConfigurable.swift; sourceTree = "<group>"; };
+		9AAFAB851E60C15300864A17 /* ProductViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductViewModel.swift; sourceTree = "<group>"; };
+		9AAFAB871E60C17100864A17 /* ProductCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductCell.swift; sourceTree = "<group>"; };
+		9AAFAB881E60C17100864A17 /* ProductCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ProductCell.xib; sourceTree = "<group>"; };
 		9AAFAB8B1E60C3C700864A17 /* ViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		9AAFAB911E60D11000864A17 /* StorefrontCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorefrontCollectionView.swift; sourceTree = "<group>"; };
 		9ADAD4671E563091008AC561 /* Storefront.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Storefront.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -88,6 +94,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9AAFAB781E60BD5800864A17 /* View Controllers */ = {
+			isa = PBXGroup;
+			children = (
+				9AAFAB791E60BDED00864A17 /* Collections */,
+			);
+			name = "View Controllers";
+			sourceTree = "<group>";
+		};
+		9AAFAB791E60BDED00864A17 /* Collections */ = {
+			isa = PBXGroup;
+			children = (
+				9AAFAB871E60C17100864A17 /* ProductCell.swift */,
+				9AAFAB881E60C17100864A17 /* ProductCell.xib */,
+				9AAFAB851E60C15300864A17 /* ProductViewModel.swift */,
+			);
+			name = Collections;
+			sourceTree = "<group>";
+		};
 		9AAFAB7C1E60BE3700864A17 /* Protocols */ = {
 			isa = PBXGroup;
 			children = (
@@ -131,6 +155,7 @@
 				9ADAD46C1E563091008AC561 /* CollectionsController.swift */,
 				9AAFAB901E60D0F900864A17 /* UI */,
 				9AAFAB7C1E60BE3700864A17 /* Protocols */,
+				9AAFAB781E60BD5800864A17 /* View Controllers */,
 				9ADAD46E1E563091008AC561 /* Main.storyboard */,
 				9ADAD47C1E5630CB008AC561 /* Supporting Files */,
 			);
@@ -270,6 +295,7 @@
 			files = (
 				9ADAD4751E563091008AC561 /* LaunchScreen.storyboard in Resources */,
 				9ADAD4721E563091008AC561 /* Assets.xcassets in Resources */,
+				9AAFAB8A1E60C17100864A17 /* ProductCell.xib in Resources */,
 				9ADAD4701E563091008AC561 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -283,7 +309,9 @@
 			files = (
 				9AEF61D71E6070F40067FA90 /* Fragment+Shop.swift in Sources */,
 				9AEF61D11E606F930067FA90 /* Fragment+Product.swift in Sources */,
+				9AAFAB861E60C15300864A17 /* ProductViewModel.swift in Sources */,
 				9AAFAB7E1E60BE6500864A17 /* ViewModeling.swift in Sources */,
+				9AAFAB891E60C17100864A17 /* ProductCell.swift in Sources */,
 				9AEF61D51E6070880067FA90 /* Fragment+Collection.swift in Sources */,
 				9AAFAB921E60D11000864A17 /* StorefrontCollectionView.swift in Sources */,
 				9AAFAB8C1E60C3C700864A17 /* ViewModel.swift in Sources */,

--- a/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
+++ b/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
@@ -7,8 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9AAFAB7B1E60BDF900864A17 /* CollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB7A1E60BDF900864A17 /* CollectionCell.swift */; };
 		9AAFAB7E1E60BE6500864A17 /* ViewModeling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB7D1E60BE6500864A17 /* ViewModeling.swift */; };
 		9AAFAB801E60BE9800864A17 /* ViewModelConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB7F1E60BE9800864A17 /* ViewModelConfigurable.swift */; };
+		9AAFAB821E60BEE000864A17 /* CollectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB811E60BEE000864A17 /* CollectionViewModel.swift */; };
+		9AAFAB841E60BF4400864A17 /* CollectionCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9AAFAB831E60BF4400864A17 /* CollectionCell.xib */; };
 		9AAFAB861E60C15300864A17 /* ProductViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB851E60C15300864A17 /* ProductViewModel.swift */; };
 		9AAFAB891E60C17100864A17 /* ProductCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB871E60C17100864A17 /* ProductCell.swift */; };
 		9AAFAB8A1E60C17100864A17 /* ProductCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9AAFAB881E60C17100864A17 /* ProductCell.xib */; };
@@ -60,8 +63,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		9AAFAB7A1E60BDF900864A17 /* CollectionCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionCell.swift; sourceTree = "<group>"; };
 		9AAFAB7D1E60BE6500864A17 /* ViewModeling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModeling.swift; sourceTree = "<group>"; };
 		9AAFAB7F1E60BE9800864A17 /* ViewModelConfigurable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModelConfigurable.swift; sourceTree = "<group>"; };
+		9AAFAB811E60BEE000864A17 /* CollectionViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewModel.swift; sourceTree = "<group>"; };
+		9AAFAB831E60BF4400864A17 /* CollectionCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CollectionCell.xib; sourceTree = "<group>"; };
 		9AAFAB851E60C15300864A17 /* ProductViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductViewModel.swift; sourceTree = "<group>"; };
 		9AAFAB871E60C17100864A17 /* ProductCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductCell.swift; sourceTree = "<group>"; };
 		9AAFAB881E60C17100864A17 /* ProductCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ProductCell.xib; sourceTree = "<group>"; };
@@ -108,6 +114,9 @@
 				9AAFAB871E60C17100864A17 /* ProductCell.swift */,
 				9AAFAB881E60C17100864A17 /* ProductCell.xib */,
 				9AAFAB851E60C15300864A17 /* ProductViewModel.swift */,
+				9AAFAB7A1E60BDF900864A17 /* CollectionCell.swift */,
+				9AAFAB831E60BF4400864A17 /* CollectionCell.xib */,
+				9AAFAB811E60BEE000864A17 /* CollectionViewModel.swift */,
 			);
 			name = Collections;
 			sourceTree = "<group>";
@@ -297,6 +306,7 @@
 				9ADAD4721E563091008AC561 /* Assets.xcassets in Resources */,
 				9AAFAB8A1E60C17100864A17 /* ProductCell.xib in Resources */,
 				9ADAD4701E563091008AC561 /* Main.storyboard in Resources */,
+				9AAFAB841E60BF4400864A17 /* CollectionCell.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -315,8 +325,10 @@
 				9AEF61D51E6070880067FA90 /* Fragment+Collection.swift in Sources */,
 				9AAFAB921E60D11000864A17 /* StorefrontCollectionView.swift in Sources */,
 				9AAFAB8C1E60C3C700864A17 /* ViewModel.swift in Sources */,
+				9AAFAB7B1E60BDF900864A17 /* CollectionCell.swift in Sources */,
 				9AEF61CC1E606EFE0067FA90 /* Fragment+ProductConnectionQuery.swift in Sources */,
 				9ADAD46D1E563091008AC561 /* CollectionsController.swift in Sources */,
+				9AAFAB821E60BEE000864A17 /* CollectionViewModel.swift in Sources */,
 				9AAFAB801E60BE9800864A17 /* ViewModelConfigurable.swift in Sources */,
 				9AEF61CE1E606F100067FA90 /* Fragment+ImageConnectionQuery.swift in Sources */,
 				9ADAD46B1E563091008AC561 /* AppDelegate.swift in Sources */,

--- a/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
+++ b/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		9AAFAB7E1E60BE6500864A17 /* ViewModeling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB7D1E60BE6500864A17 /* ViewModeling.swift */; };
 		9AAFAB801E60BE9800864A17 /* ViewModelConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB7F1E60BE9800864A17 /* ViewModelConfigurable.swift */; };
 		9AAFAB8C1E60C3C700864A17 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB8B1E60C3C700864A17 /* ViewModel.swift */; };
+		9AAFAB921E60D11000864A17 /* StorefrontCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB911E60D11000864A17 /* StorefrontCollectionView.swift */; };
 		9ADAD46B1E563091008AC561 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADAD46A1E563091008AC561 /* AppDelegate.swift */; };
 		9ADAD46D1E563091008AC561 /* CollectionsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADAD46C1E563091008AC561 /* CollectionsController.swift */; };
 		9ADAD4701E563091008AC561 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9ADAD46E1E563091008AC561 /* Main.storyboard */; };
@@ -59,6 +60,7 @@
 		9AAFAB7D1E60BE6500864A17 /* ViewModeling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModeling.swift; sourceTree = "<group>"; };
 		9AAFAB7F1E60BE9800864A17 /* ViewModelConfigurable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModelConfigurable.swift; sourceTree = "<group>"; };
 		9AAFAB8B1E60C3C700864A17 /* ViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
+		9AAFAB911E60D11000864A17 /* StorefrontCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorefrontCollectionView.swift; sourceTree = "<group>"; };
 		9ADAD4671E563091008AC561 /* Storefront.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Storefront.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9ADAD46A1E563091008AC561 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9ADAD46C1E563091008AC561 /* CollectionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionsController.swift; sourceTree = "<group>"; };
@@ -96,6 +98,14 @@
 			name = Protocols;
 			sourceTree = "<group>";
 		};
+		9AAFAB901E60D0F900864A17 /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				9AAFAB911E60D11000864A17 /* StorefrontCollectionView.swift */,
+			);
+			name = UI;
+			sourceTree = "<group>";
+		};
 		9ADAD45E1E563091008AC561 = {
 			isa = PBXGroup;
 			children = (
@@ -119,6 +129,7 @@
 				9AEF61CA1E606EEB0067FA90 /* Fragments */,
 				9ADAD46A1E563091008AC561 /* AppDelegate.swift */,
 				9ADAD46C1E563091008AC561 /* CollectionsController.swift */,
+				9AAFAB901E60D0F900864A17 /* UI */,
 				9AAFAB7C1E60BE3700864A17 /* Protocols */,
 				9ADAD46E1E563091008AC561 /* Main.storyboard */,
 				9ADAD47C1E5630CB008AC561 /* Supporting Files */,
@@ -274,6 +285,7 @@
 				9AEF61D11E606F930067FA90 /* Fragment+Product.swift in Sources */,
 				9AAFAB7E1E60BE6500864A17 /* ViewModeling.swift in Sources */,
 				9AEF61D51E6070880067FA90 /* Fragment+Collection.swift in Sources */,
+				9AAFAB921E60D11000864A17 /* StorefrontCollectionView.swift in Sources */,
 				9AAFAB8C1E60C3C700864A17 /* ViewModel.swift in Sources */,
 				9AEF61CC1E606EFE0067FA90 /* Fragment+ProductConnectionQuery.swift in Sources */,
 				9ADAD46D1E563091008AC561 /* CollectionsController.swift in Sources */,

--- a/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
+++ b/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		9AAFAB8F1E60C6AC00864A17 /* UIImageView+Remote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB8E1E60C6AC00864A17 /* UIImageView+Remote.swift */; };
 		9AAFAB921E60D11000864A17 /* StorefrontCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB911E60D11000864A17 /* StorefrontCollectionView.swift */; };
 		9AAFAB941E60D2D000864A17 /* NSObject+Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB931E60D2D000864A17 /* NSObject+Name.swift */; };
+		9AAFAB961E60D83600864A17 /* Fragment+CollectionQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB951E60D83600864A17 /* Fragment+CollectionQuery.swift */; };
 		9ADAD46B1E563091008AC561 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADAD46A1E563091008AC561 /* AppDelegate.swift */; };
 		9ADAD46D1E563091008AC561 /* CollectionsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADAD46C1E563091008AC561 /* CollectionsController.swift */; };
 		9ADAD4701E563091008AC561 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9ADAD46E1E563091008AC561 /* Main.storyboard */; };
@@ -77,6 +78,7 @@
 		9AAFAB8E1E60C6AC00864A17 /* UIImageView+Remote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImageView+Remote.swift"; sourceTree = "<group>"; };
 		9AAFAB911E60D11000864A17 /* StorefrontCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorefrontCollectionView.swift; sourceTree = "<group>"; };
 		9AAFAB931E60D2D000864A17 /* NSObject+Name.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+Name.swift"; sourceTree = "<group>"; };
+		9AAFAB951E60D83600864A17 /* Fragment+CollectionQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Fragment+CollectionQuery.swift"; sourceTree = "<group>"; };
 		9ADAD4671E563091008AC561 /* Storefront.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Storefront.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9ADAD46A1E563091008AC561 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9ADAD46C1E563091008AC561 /* CollectionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionsController.swift; sourceTree = "<group>"; };
@@ -172,12 +174,12 @@
 		9ADAD4691E563091008AC561 /* Storefront */ = {
 			isa = PBXGroup;
 			children = (
-				9AEF61CA1E606EEB0067FA90 /* Fragments */,
 				9ADAD46A1E563091008AC561 /* AppDelegate.swift */,
 				9ADAD46C1E563091008AC561 /* CollectionsController.swift */,
 				9AAFAB901E60D0F900864A17 /* UI */,
 				9AAFAB8D1E60C69C00864A17 /* Extensions */,
 				9AAFAB7C1E60BE3700864A17 /* Protocols */,
+				9AEF61CA1E606EEB0067FA90 /* Fragments */,
 				9AAFAB781E60BD5800864A17 /* View Controllers */,
 				9ADAD46E1E563091008AC561 /* Main.storyboard */,
 				9ADAD47C1E5630CB008AC561 /* Supporting Files */,
@@ -235,6 +237,7 @@
 			children = (
 				9AEF61CB1E606EFE0067FA90 /* Fragment+ProductConnectionQuery.swift */,
 				9AEF61CD1E606F100067FA90 /* Fragment+ImageConnectionQuery.swift */,
+				9AAFAB951E60D83600864A17 /* Fragment+CollectionQuery.swift */,
 			);
 			name = Queries;
 			sourceTree = "<group>";
@@ -332,6 +335,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9AEF61D71E6070F40067FA90 /* Fragment+Shop.swift in Sources */,
+				9AAFAB961E60D83600864A17 /* Fragment+CollectionQuery.swift in Sources */,
 				9AEF61D11E606F930067FA90 /* Fragment+Product.swift in Sources */,
 				9AAFAB861E60C15300864A17 /* ProductViewModel.swift in Sources */,
 				9AAFAB7E1E60BE6500864A17 /* ViewModeling.swift in Sources */,

--- a/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
+++ b/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9A15B73A1E64627A0078E7C5 /* StorefrontTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A15B7391E64627A0078E7C5 /* StorefrontTableView.swift */; };
 		9AAFAB7B1E60BDF900864A17 /* CollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB7A1E60BDF900864A17 /* CollectionCell.swift */; };
 		9AAFAB7E1E60BE6500864A17 /* ViewModeling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB7D1E60BE6500864A17 /* ViewModeling.swift */; };
 		9AAFAB801E60BE9800864A17 /* ViewModelConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB7F1E60BE9800864A17 /* ViewModelConfigurable.swift */; };
@@ -66,6 +67,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		9A15B7391E64627A0078E7C5 /* StorefrontTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorefrontTableView.swift; sourceTree = "<group>"; };
 		9AAFAB7A1E60BDF900864A17 /* CollectionCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionCell.swift; sourceTree = "<group>"; };
 		9AAFAB7D1E60BE6500864A17 /* ViewModeling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModeling.swift; sourceTree = "<group>"; };
 		9AAFAB7F1E60BE9800864A17 /* ViewModelConfigurable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModelConfigurable.swift; sourceTree = "<group>"; };
@@ -151,6 +153,7 @@
 			isa = PBXGroup;
 			children = (
 				9AAFAB911E60D11000864A17 /* StorefrontCollectionView.swift */,
+				9A15B7391E64627A0078E7C5 /* StorefrontTableView.swift */,
 			);
 			name = UI;
 			sourceTree = "<group>";
@@ -276,6 +279,7 @@
 				TargetAttributes = {
 					9ADAD4661E563091008AC561 = {
 						CreatedOnToolsVersion = 8.2.1;
+						DevelopmentTeam = 6ZYNJZSY2C;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -342,6 +346,7 @@
 				9AAFAB891E60C17100864A17 /* ProductCell.swift in Sources */,
 				9AEF61D51E6070880067FA90 /* Fragment+Collection.swift in Sources */,
 				9AAFAB921E60D11000864A17 /* StorefrontCollectionView.swift in Sources */,
+				9A15B73A1E64627A0078E7C5 /* StorefrontTableView.swift in Sources */,
 				9AAFAB8C1E60C3C700864A17 /* ViewModel.swift in Sources */,
 				9AAFAB7B1E60BDF900864A17 /* CollectionCell.swift in Sources */,
 				9AAFAB941E60D2D000864A17 /* NSObject+Name.swift in Sources */,
@@ -480,6 +485,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = 6ZYNJZSY2C;
 				INFOPLIST_FILE = Storefront/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.shopify.Storefront;
@@ -492,6 +498,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = 6ZYNJZSY2C;
 				INFOPLIST_FILE = Storefront/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.shopify.Storefront;

--- a/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
+++ b/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
@@ -12,7 +12,45 @@
 		9ADAD4701E563091008AC561 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9ADAD46E1E563091008AC561 /* Main.storyboard */; };
 		9ADAD4721E563091008AC561 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9ADAD4711E563091008AC561 /* Assets.xcassets */; };
 		9ADAD4751E563091008AC561 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9ADAD4731E563091008AC561 /* LaunchScreen.storyboard */; };
+		9AEF61C71E606C7C0067FA90 /* Buy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AEF61C41E606C710067FA90 /* Buy.framework */; };
+		9AEF61C91E606C8B0067FA90 /* Buy.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 9AEF61C41E606C710067FA90 /* Buy.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9AEF61CC1E606EFE0067FA90 /* Fragment+ProductConnectionQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AEF61CB1E606EFE0067FA90 /* Fragment+ProductConnectionQuery.swift */; };
+		9AEF61CE1E606F100067FA90 /* Fragment+ImageConnectionQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AEF61CD1E606F100067FA90 /* Fragment+ImageConnectionQuery.swift */; };
+		9AEF61D11E606F930067FA90 /* Fragment+Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AEF61D01E606F930067FA90 /* Fragment+Product.swift */; };
+		9AEF61D51E6070880067FA90 /* Fragment+Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AEF61D41E6070880067FA90 /* Fragment+Collection.swift */; };
+		9AEF61D71E6070F40067FA90 /* Fragment+Shop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AEF61D61E6070F40067FA90 /* Fragment+Shop.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		9AEF61C31E606C710067FA90 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9AEF61BF1E606C710067FA90 /* Buy.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 9AEF60F31E5F42D90067FA90;
+			remoteInfo = Buy;
+		};
+		9AEF61C51E606C780067FA90 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9AEF61BF1E606C710067FA90 /* Buy.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 9AEF60F21E5F42D90067FA90;
+			remoteInfo = Buy;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		9AEF61C81E606C800067FA90 /* Copy Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				9AEF61C91E606C8B0067FA90 /* Buy.framework in Copy Frameworks */,
+			);
+			name = "Copy Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		9ADAD4671E563091008AC561 /* Storefront.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Storefront.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -22,6 +60,12 @@
 		9ADAD4711E563091008AC561 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9ADAD4741E563091008AC561 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		9ADAD4761E563091008AC561 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9AEF61BF1E606C710067FA90 /* Buy.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Buy.xcodeproj; path = ../../Buy.xcodeproj; sourceTree = "<group>"; };
+		9AEF61CB1E606EFE0067FA90 /* Fragment+ProductConnectionQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Fragment+ProductConnectionQuery.swift"; sourceTree = "<group>"; };
+		9AEF61CD1E606F100067FA90 /* Fragment+ImageConnectionQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Fragment+ImageConnectionQuery.swift"; sourceTree = "<group>"; };
+		9AEF61D01E606F930067FA90 /* Fragment+Product.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Fragment+Product.swift"; sourceTree = "<group>"; };
+		9AEF61D41E6070880067FA90 /* Fragment+Collection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Fragment+Collection.swift"; sourceTree = "<group>"; };
+		9AEF61D61E6070F40067FA90 /* Fragment+Shop.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Fragment+Shop.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -29,6 +73,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9AEF61C71E606C7C0067FA90 /* Buy.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -38,6 +83,7 @@
 		9ADAD45E1E563091008AC561 = {
 			isa = PBXGroup;
 			children = (
+				9AEF61BE1E606C5F0067FA90 /* Buy */,
 				9ADAD4691E563091008AC561 /* Storefront */,
 				9ADAD4681E563091008AC561 /* Products */,
 			);
@@ -54,6 +100,7 @@
 		9ADAD4691E563091008AC561 /* Storefront */ = {
 			isa = PBXGroup;
 			children = (
+				9AEF61CA1E606EEB0067FA90 /* Fragments */,
 				9ADAD46A1E563091008AC561 /* AppDelegate.swift */,
 				9ADAD46C1E563091008AC561 /* CollectionsController.swift */,
 				9ADAD46E1E563091008AC561 /* Main.storyboard */,
@@ -72,6 +119,50 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		9AEF61BE1E606C5F0067FA90 /* Buy */ = {
+			isa = PBXGroup;
+			children = (
+				9AEF61BF1E606C710067FA90 /* Buy.xcodeproj */,
+			);
+			name = Buy;
+			sourceTree = "<group>";
+		};
+		9AEF61C01E606C710067FA90 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				9AEF61C41E606C710067FA90 /* Buy.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9AEF61CA1E606EEB0067FA90 /* Fragments */ = {
+			isa = PBXGroup;
+			children = (
+				9AEF61D31E606F9B0067FA90 /* Queries */,
+				9AEF61D21E606F970067FA90 /* Models */,
+			);
+			name = Fragments;
+			sourceTree = "<group>";
+		};
+		9AEF61D21E606F970067FA90 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				9AEF61D61E6070F40067FA90 /* Fragment+Shop.swift */,
+				9AEF61D41E6070880067FA90 /* Fragment+Collection.swift */,
+				9AEF61D01E606F930067FA90 /* Fragment+Product.swift */,
+			);
+			name = Models;
+			sourceTree = "<group>";
+		};
+		9AEF61D31E606F9B0067FA90 /* Queries */ = {
+			isa = PBXGroup;
+			children = (
+				9AEF61CB1E606EFE0067FA90 /* Fragment+ProductConnectionQuery.swift */,
+				9AEF61CD1E606F100067FA90 /* Fragment+ImageConnectionQuery.swift */,
+			);
+			name = Queries;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -82,10 +173,12 @@
 				9ADAD4631E563091008AC561 /* Sources */,
 				9ADAD4641E563091008AC561 /* Frameworks */,
 				9ADAD4651E563091008AC561 /* Resources */,
+				9AEF61C81E606C800067FA90 /* Copy Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				9AEF61C61E606C780067FA90 /* PBXTargetDependency */,
 			);
 			name = Storefront;
 			productName = Storefront;
@@ -119,12 +212,28 @@
 			mainGroup = 9ADAD45E1E563091008AC561;
 			productRefGroup = 9ADAD4681E563091008AC561 /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 9AEF61C01E606C710067FA90 /* Products */;
+					ProjectRef = 9AEF61BF1E606C710067FA90 /* Buy.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				9ADAD4661E563091008AC561 /* Storefront */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		9AEF61C41E606C710067FA90 /* Buy.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Buy.framework;
+			remoteRef = 9AEF61C31E606C710067FA90 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		9ADAD4651E563091008AC561 /* Resources */ = {
@@ -144,12 +253,25 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9AEF61D71E6070F40067FA90 /* Fragment+Shop.swift in Sources */,
+				9AEF61D11E606F930067FA90 /* Fragment+Product.swift in Sources */,
+				9AEF61D51E6070880067FA90 /* Fragment+Collection.swift in Sources */,
+				9AEF61CC1E606EFE0067FA90 /* Fragment+ProductConnectionQuery.swift in Sources */,
 				9ADAD46D1E563091008AC561 /* CollectionsController.swift in Sources */,
+				9AEF61CE1E606F100067FA90 /* Fragment+ImageConnectionQuery.swift in Sources */,
 				9ADAD46B1E563091008AC561 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		9AEF61C61E606C780067FA90 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Buy;
+			targetProxy = 9AEF61C51E606C780067FA90 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		9ADAD46E1E563091008AC561 /* Main.storyboard */ = {
@@ -305,6 +427,7 @@
 				9ADAD47B1E563091008AC561 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Sample Apps/Storefront/Storefront/Base.lproj/Main.storyboard
+++ b/Sample Apps/Storefront/Storefront/Base.lproj/Main.storyboard
@@ -21,36 +21,29 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="NZ7-wJ-ifD" customClass="StorefrontCollectionView" customModule="Storefront" customModuleProvider="target">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="300" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="FJA-Xo-Ook" customClass="StorefrontTableView" customModule="Storefront" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                                <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="0.0" id="Ybu-xt-xcb">
-                                    <size key="itemSize" width="50" height="50"/>
-                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
-                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                </collectionViewFlowLayout>
-                                <cells/>
+                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="string" keyPath="cellNibName" value="CollectionCell"/>
                                 </userDefinedRuntimeAttributes>
                                 <connections>
-                                    <outlet property="dataSource" destination="BYZ-38-t0r" id="vKf-0F-9tH"/>
-                                    <outlet property="delegate" destination="BYZ-38-t0r" id="1FI-Eg-bcp"/>
+                                    <outlet property="dataSource" destination="BYZ-38-t0r" id="2eh-FJ-GmE"/>
+                                    <outlet property="delegate" destination="BYZ-38-t0r" id="yWN-Rn-1V8"/>
                                 </connections>
-                            </collectionView>
+                            </tableView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="NZ7-wJ-ifD" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="FIi-d3-HNN"/>
-                            <constraint firstItem="NZ7-wJ-ifD" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="fZR-GP-dFQ"/>
-                            <constraint firstAttribute="trailing" secondItem="NZ7-wJ-ifD" secondAttribute="trailing" id="lLq-gT-OfF"/>
-                            <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="NZ7-wJ-ifD" secondAttribute="bottom" id="uGf-Q9-ICl"/>
+                            <constraint firstItem="FJA-Xo-Ook" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="5eC-TZ-ObZ"/>
+                            <constraint firstAttribute="trailing" secondItem="FJA-Xo-Ook" secondAttribute="trailing" id="IfH-27-oI7"/>
+                            <constraint firstItem="FJA-Xo-Ook" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="JZC-9D-Myf"/>
+                            <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="FJA-Xo-Ook" secondAttribute="bottom" id="fmZ-eY-4wD"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Collections" id="9WP-3t-7If"/>
                     <connections>
-                        <outlet property="collectionView" destination="NZ7-wJ-ifD" id="Gjl-OO-6cX"/>
+                        <outlet property="tableView" destination="FJA-Xo-Ook" id="zuu-Zf-hAN"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Sample Apps/Storefront/Storefront/Base.lproj/Main.storyboard
+++ b/Sample Apps/Storefront/Storefront/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="5HA-7N-vXJ">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -9,10 +9,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Collections Controller-->
+        <!--Collections-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="CollectionsController" customModule="Storefront" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="CollectionsViewController" customModule="Storefront" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
@@ -20,11 +20,60 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="NZ7-wJ-ifD" customClass="StorefrontCollectionView" customModule="Storefront" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="0.0" id="Ybu-xt-xcb">
+                                    <size key="itemSize" width="50" height="50"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="cellNibName" value="CollectionCell"/>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <outlet property="dataSource" destination="BYZ-38-t0r" id="vKf-0F-9tH"/>
+                                    <outlet property="delegate" destination="BYZ-38-t0r" id="1FI-Eg-bcp"/>
+                                </connections>
+                            </collectionView>
+                        </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="NZ7-wJ-ifD" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="FIi-d3-HNN"/>
+                            <constraint firstItem="NZ7-wJ-ifD" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="fZR-GP-dFQ"/>
+                            <constraint firstAttribute="trailing" secondItem="NZ7-wJ-ifD" secondAttribute="trailing" id="lLq-gT-OfF"/>
+                            <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="NZ7-wJ-ifD" secondAttribute="bottom" id="uGf-Q9-ICl"/>
+                        </constraints>
                     </view>
+                    <navigationItem key="navigationItem" title="Collections" id="9WP-3t-7If"/>
+                    <connections>
+                        <outlet property="collectionView" destination="NZ7-wJ-ifD" id="Gjl-OO-6cX"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="1076" y="138.98050974512745"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="22L-nZ-ej3">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="5HA-7N-vXJ" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="5AZ-QU-kn7">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="wBN-xs-UdS"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Jhd-ta-AAP" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="382" y="139"/>
         </scene>
     </scenes>
 </document>

--- a/Sample Apps/Storefront/Storefront/Base.lproj/Main.storyboard
+++ b/Sample Apps/Storefront/Storefront/Base.lproj/Main.storyboard
@@ -1,14 +1,18 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Collections Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="CollectionsController" customModule="Storefront" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>

--- a/Sample Apps/Storefront/Storefront/CollectionCell.swift
+++ b/Sample Apps/Storefront/Storefront/CollectionCell.swift
@@ -8,11 +8,11 @@
 
 import UIKit
 
-class CollectionCell: UICollectionViewCell, ViewModelConfigurable {
+class CollectionCell: UITableViewCell, ViewModelConfigurable {
     
     typealias ViewModelType = CollectionViewModel
     
-    @IBOutlet private weak var imageView:      UIImageView!
+    @IBOutlet private weak var titleImageView: UIImageView!
     @IBOutlet private weak var collectionView: StorefrontCollectionView!
     
     private(set) var viewModel: CollectionViewModel?
@@ -20,7 +20,7 @@ class CollectionCell: UICollectionViewCell, ViewModelConfigurable {
     func configureFrom(_ viewModel: CollectionViewModel) {
         self.viewModel = viewModel
         
-        self.imageView.setImageFrom(viewModel.imageURL)
+        self.titleImageView.setImageFrom(viewModel.imageURL)
         self.collectionView.reloadData()
     }
 }

--- a/Sample Apps/Storefront/Storefront/CollectionCell.swift
+++ b/Sample Apps/Storefront/Storefront/CollectionCell.swift
@@ -61,9 +61,12 @@ extension CollectionCell: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         
+        let layout = collectionViewLayout as! UICollectionViewFlowLayout
+        let length = collectionView.bounds.height - layout.sectionInset.top - layout.sectionInset.bottom
+        
         return CGSize(
-            width:  90.0,
-            height: 90.0
+            width:  length,
+            height: length
         )
     }
 }

--- a/Sample Apps/Storefront/Storefront/CollectionCell.swift
+++ b/Sample Apps/Storefront/Storefront/CollectionCell.swift
@@ -2,8 +2,26 @@
 //  CollectionCell.swift
 //  Storefront
 //
-//  Created by Dima Bart on 2017-02-24.
-//  Copyright © 2017 Shopify Inc. All rights reserved.
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import UIKit

--- a/Sample Apps/Storefront/Storefront/CollectionCell.swift
+++ b/Sample Apps/Storefront/Storefront/CollectionCell.swift
@@ -1,0 +1,69 @@
+//
+//  CollectionCell.swift
+//  Storefront
+//
+//  Created by Dima Bart on 2017-02-24.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+
+import UIKit
+
+class CollectionCell: UICollectionViewCell, ViewModelConfigurable {
+    
+    typealias ViewModelType = CollectionViewModel
+    
+    @IBOutlet private weak var imageView:      UIImageView!
+    @IBOutlet private weak var collectionView: StorefrontCollectionView!
+    
+    private(set) var viewModel: CollectionViewModel?
+    
+    func configureFrom(_ viewModel: CollectionViewModel) {
+        self.viewModel = viewModel
+        
+        self.imageView.setImageFrom(viewModel.imageURL)
+        self.collectionView.reloadData()
+    }
+}
+
+// ----------------------------------
+//  MARK: - UICollectionViewDataSource -
+//
+extension CollectionCell: UICollectionViewDataSource {
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return self.viewModel?.products.count ?? 0
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell    = collectionView.dequeueReusableCell(withReuseIdentifier: ProductCell.className, for: indexPath) as! ProductCell
+        let product = self.viewModel!.products[indexPath.row]
+        
+        cell.configureFrom(product)
+        
+        return cell
+    }
+}
+
+// ----------------------------------
+//  MARK: - UICollectionViewDelegate -
+//
+extension CollectionCell: UICollectionViewDelegate {
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        
+    }
+}
+
+// -----------------------------------------------
+//  MARK: - UICollectionViewDelegateFlowLayout -
+//
+extension CollectionCell: UICollectionViewDelegateFlowLayout {
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        
+        return CGSize(
+            width:  90.0,
+            height: 90.0
+        )
+    }
+}

--- a/Sample Apps/Storefront/Storefront/CollectionCell.xib
+++ b/Sample Apps/Storefront/Storefront/CollectionCell.xib
@@ -19,13 +19,13 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Zhl-ew-uEp">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="298"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="245"/>
                     </imageView>
                     <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="8u8-y0-ose" customClass="StorefrontCollectionView" customModule="Storefront" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="298" width="375" height="98"/>
+                        <rect key="frame" x="0.0" y="245.5" width="375" height="150"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="98" id="UZ2-3g-Sy4"/>
+                            <constraint firstAttribute="height" constant="150" id="UZ2-3g-Sy4"/>
                         </constraints>
                         <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="4" minimumInteritemSpacing="4" id="NRK-k7-eNK">
                             <size key="itemSize" width="90" height="90"/>

--- a/Sample Apps/Storefront/Storefront/CollectionCell.xib
+++ b/Sample Apps/Storefront/Storefront/CollectionCell.xib
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="QPF-N8-369" customClass="CollectionCell" customModule="Storefront" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="263"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="263"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="uKQ-bG-srs">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="165"/>
+                    </imageView>
+                    <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="HEB-tj-VdU" customClass="StorefrontCollectionView" customModule="Storefront" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="165" width="320" height="98"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="98" id="NVZ-nZ-BU3"/>
+                        </constraints>
+                        <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="4" minimumInteritemSpacing="4" id="tIc-4R-kR6">
+                            <size key="itemSize" width="90" height="90"/>
+                            <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                            <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                            <inset key="sectionInset" minX="4" minY="0.0" maxX="4" maxY="0.0"/>
+                        </collectionViewFlowLayout>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="cellNibName" value="ProductCell"/>
+                        </userDefinedRuntimeAttributes>
+                        <connections>
+                            <outlet property="dataSource" destination="QPF-N8-369" id="dFq-fT-a0W"/>
+                            <outlet property="delegate" destination="QPF-N8-369" id="3Q1-Jj-2QG"/>
+                        </connections>
+                    </collectionView>
+                </subviews>
+            </view>
+            <constraints>
+                <constraint firstItem="uKQ-bG-srs" firstAttribute="top" secondItem="QPF-N8-369" secondAttribute="top" id="8BX-Wb-l2s"/>
+                <constraint firstItem="HEB-tj-VdU" firstAttribute="top" secondItem="uKQ-bG-srs" secondAttribute="bottom" id="PEg-yB-iKd"/>
+                <constraint firstItem="uKQ-bG-srs" firstAttribute="leading" secondItem="QPF-N8-369" secondAttribute="leading" id="QdT-f5-vbg"/>
+                <constraint firstAttribute="trailing" secondItem="uKQ-bG-srs" secondAttribute="trailing" id="luv-ZJ-2SO"/>
+                <constraint firstItem="HEB-tj-VdU" firstAttribute="leading" secondItem="QPF-N8-369" secondAttribute="leading" id="nqH-k2-8cB"/>
+                <constraint firstAttribute="trailing" secondItem="HEB-tj-VdU" secondAttribute="trailing" id="pIQ-Ff-7wD"/>
+                <constraint firstAttribute="bottom" secondItem="HEB-tj-VdU" secondAttribute="bottom" id="qwX-gQ-SqA"/>
+            </constraints>
+            <size key="customSize" width="320" height="263"/>
+            <connections>
+                <outlet property="collectionView" destination="HEB-tj-VdU" id="jvR-uJ-OZ8"/>
+                <outlet property="imageView" destination="uKQ-bG-srs" id="yPO-Av-yEQ"/>
+            </connections>
+            <point key="canvasLocation" x="77" y="32.5"/>
+        </collectionViewCell>
+    </objects>
+</document>

--- a/Sample Apps/Storefront/Storefront/CollectionCell.xib
+++ b/Sample Apps/Storefront/Storefront/CollectionCell.xib
@@ -11,23 +11,23 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="QPF-N8-369" customClass="CollectionCell" customModule="Storefront" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="263"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="263"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="396" id="DTC-QF-jnw" customClass="CollectionCell" customModule="Storefront" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="396"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="DTC-QF-jnw" id="aMp-7Y-feU">
+                <rect key="frame" x="0.0" y="0.0" width="375" height="395"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="uKQ-bG-srs">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="165"/>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Zhl-ew-uEp">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="298"/>
                     </imageView>
-                    <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="HEB-tj-VdU" customClass="StorefrontCollectionView" customModule="Storefront" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="165" width="320" height="98"/>
+                    <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="8u8-y0-ose" customClass="StorefrontCollectionView" customModule="Storefront" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="298" width="375" height="98"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="98" id="NVZ-nZ-BU3"/>
+                            <constraint firstAttribute="height" constant="98" id="UZ2-3g-Sy4"/>
                         </constraints>
-                        <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="4" minimumInteritemSpacing="4" id="tIc-4R-kR6">
+                        <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="4" minimumInteritemSpacing="4" id="NRK-k7-eNK">
                             <size key="itemSize" width="90" height="90"/>
                             <size key="headerReferenceSize" width="0.0" height="0.0"/>
                             <size key="footerReferenceSize" width="0.0" height="0.0"/>
@@ -37,27 +37,26 @@
                             <userDefinedRuntimeAttribute type="string" keyPath="cellNibName" value="ProductCell"/>
                         </userDefinedRuntimeAttributes>
                         <connections>
-                            <outlet property="dataSource" destination="QPF-N8-369" id="dFq-fT-a0W"/>
-                            <outlet property="delegate" destination="QPF-N8-369" id="3Q1-Jj-2QG"/>
+                            <outlet property="dataSource" destination="DTC-QF-jnw" id="PH1-9e-XKl"/>
+                            <outlet property="delegate" destination="DTC-QF-jnw" id="MEp-cA-XQX"/>
                         </connections>
                     </collectionView>
                 </subviews>
-            </view>
-            <constraints>
-                <constraint firstItem="uKQ-bG-srs" firstAttribute="top" secondItem="QPF-N8-369" secondAttribute="top" id="8BX-Wb-l2s"/>
-                <constraint firstItem="HEB-tj-VdU" firstAttribute="top" secondItem="uKQ-bG-srs" secondAttribute="bottom" id="PEg-yB-iKd"/>
-                <constraint firstItem="uKQ-bG-srs" firstAttribute="leading" secondItem="QPF-N8-369" secondAttribute="leading" id="QdT-f5-vbg"/>
-                <constraint firstAttribute="trailing" secondItem="uKQ-bG-srs" secondAttribute="trailing" id="luv-ZJ-2SO"/>
-                <constraint firstItem="HEB-tj-VdU" firstAttribute="leading" secondItem="QPF-N8-369" secondAttribute="leading" id="nqH-k2-8cB"/>
-                <constraint firstAttribute="trailing" secondItem="HEB-tj-VdU" secondAttribute="trailing" id="pIQ-Ff-7wD"/>
-                <constraint firstAttribute="bottom" secondItem="HEB-tj-VdU" secondAttribute="bottom" id="qwX-gQ-SqA"/>
-            </constraints>
-            <size key="customSize" width="320" height="263"/>
+                <constraints>
+                    <constraint firstItem="8u8-y0-ose" firstAttribute="top" secondItem="Zhl-ew-uEp" secondAttribute="bottom" id="AGl-J4-40l"/>
+                    <constraint firstItem="Zhl-ew-uEp" firstAttribute="leading" secondItem="aMp-7Y-feU" secondAttribute="leading" id="fXc-wQ-Rvr"/>
+                    <constraint firstItem="Zhl-ew-uEp" firstAttribute="top" secondItem="aMp-7Y-feU" secondAttribute="top" id="h78-GL-tRa"/>
+                    <constraint firstAttribute="trailing" secondItem="8u8-y0-ose" secondAttribute="trailing" id="uaS-hz-igE"/>
+                    <constraint firstAttribute="trailing" secondItem="Zhl-ew-uEp" secondAttribute="trailing" id="wcq-me-SbO"/>
+                    <constraint firstAttribute="bottom" secondItem="8u8-y0-ose" secondAttribute="bottom" id="xIC-CN-83F"/>
+                    <constraint firstItem="8u8-y0-ose" firstAttribute="leading" secondItem="aMp-7Y-feU" secondAttribute="leading" id="zz2-Fb-kib"/>
+                </constraints>
+            </tableViewCellContentView>
             <connections>
-                <outlet property="collectionView" destination="HEB-tj-VdU" id="jvR-uJ-OZ8"/>
-                <outlet property="imageView" destination="uKQ-bG-srs" id="yPO-Av-yEQ"/>
+                <outlet property="collectionView" destination="8u8-y0-ose" id="5xM-J7-Knw"/>
+                <outlet property="titleImageView" destination="Zhl-ew-uEp" id="eaL-RD-4ye"/>
             </connections>
-            <point key="canvasLocation" x="77" y="32.5"/>
-        </collectionViewCell>
+            <point key="canvasLocation" x="-462.5" y="40"/>
+        </tableViewCell>
     </objects>
 </document>

--- a/Sample Apps/Storefront/Storefront/CollectionViewModel.swift
+++ b/Sample Apps/Storefront/Storefront/CollectionViewModel.swift
@@ -13,8 +13,10 @@ struct CollectionViewModel: ViewModel {
     
     typealias ModelType = ApiSchema.Collection
     
-    let imageURL: URL?
-    let products: [ProductViewModel]
+    let title:       String
+    let description: String
+    let imageURL:    URL?
+    let products:    [ProductViewModel]
     
     // ----------------------------------
     //  MARK: - Init -
@@ -26,7 +28,9 @@ struct CollectionViewModel: ViewModel {
             self.imageURL = nil
         }
         
-        self.products = model.products().viewModels
+        self.products    = model.products().viewModels
+        self.title       = model.title
+        self.description = model.descriptionPlainSummary
     }
 }
 

--- a/Sample Apps/Storefront/Storefront/CollectionViewModel.swift
+++ b/Sample Apps/Storefront/Storefront/CollectionViewModel.swift
@@ -1,0 +1,36 @@
+//
+//  CollectionViewModel.swift
+//  Storefront
+//
+//  Created by Dima Bart on 2017-02-24.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+
+import Foundation
+import Buy
+
+struct CollectionViewModel: ViewModel {
+    
+    typealias ModelType = ApiSchema.Collection
+    
+    let imageURL: URL?
+    let products: [ProductViewModel]
+    
+    // ----------------------------------
+    //  MARK: - Init -
+    //
+    init(from model: ApiSchema.Collection) {
+        if let source = model.image?.src {
+            self.imageURL = URL(string: source)!
+        } else {
+            self.imageURL = nil
+        }
+        
+        self.products = model.products().viewModels
+    }
+}
+
+extension ApiSchema.Collection: ViewModeling {
+    typealias ViewModelType = CollectionViewModel
+}
+

--- a/Sample Apps/Storefront/Storefront/CollectionViewModel.swift
+++ b/Sample Apps/Storefront/Storefront/CollectionViewModel.swift
@@ -2,8 +2,26 @@
 //  CollectionViewModel.swift
 //  Storefront
 //
-//  Created by Dima Bart on 2017-02-24.
-//  Copyright © 2017 Shopify Inc. All rights reserved.
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import Foundation

--- a/Sample Apps/Storefront/Storefront/CollectionViewModel.swift
+++ b/Sample Apps/Storefront/Storefront/CollectionViewModel.swift
@@ -29,7 +29,7 @@ import Buy
 
 struct CollectionViewModel: ViewModel {
     
-    typealias ModelType = ApiSchema.Collection
+    typealias ModelType = Storefront.Collection
     
     let title:       String
     let description: String
@@ -39,7 +39,7 @@ struct CollectionViewModel: ViewModel {
     // ----------------------------------
     //  MARK: - Init -
     //
-    init(from model: ApiSchema.Collection) {
+    init(from model: Storefront.Collection) {
         if let source = model.image?.src {
             self.imageURL = URL(string: source)!
         } else {
@@ -52,7 +52,7 @@ struct CollectionViewModel: ViewModel {
     }
 }
 
-extension ApiSchema.Collection: ViewModeling {
+extension Storefront.Collection: ViewModeling {
     typealias ViewModelType = CollectionViewModel
 }
 

--- a/Sample Apps/Storefront/Storefront/CollectionViewModel.swift
+++ b/Sample Apps/Storefront/Storefront/CollectionViewModel.swift
@@ -46,7 +46,7 @@ struct CollectionViewModel: ViewModel {
             self.imageURL = nil
         }
         
-        self.products    = model.products().viewModels
+        self.products    = model.productsArray().viewModels
         self.title       = model.title
         self.description = model.descriptionPlainSummary
     }

--- a/Sample Apps/Storefront/Storefront/CollectionsViewController.swift
+++ b/Sample Apps/Storefront/Storefront/CollectionsViewController.swift
@@ -11,7 +11,7 @@ import Buy
 
 class CollectionsViewController: UIViewController {
 
-    @IBOutlet weak var collectionView: StorefrontCollectionView!
+    @IBOutlet weak var tableView: StorefrontTableView!
     
     var collections: [CollectionViewModel] = []
     
@@ -41,7 +41,7 @@ class CollectionsViewController: UIViewController {
             
             if let query = query {
                 self.collections = query.shop.collections().viewModels
-                self.collectionView.reloadData()
+                self.tableView.reloadData()
             } else {
                 print("Failed to load collections: \(error)")
             }
@@ -54,14 +54,18 @@ class CollectionsViewController: UIViewController {
 // ----------------------------------
 //  MARK: - UICollectionViewDataSource -
 //
-extension CollectionsViewController: UICollectionViewDataSource {
+extension CollectionsViewController: UITableViewDataSource {
     
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    func numberOfSections(in tableView: UITableView) -> Int {
         return self.collections.count
     }
     
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell       = collectionView.dequeueReusableCell(withReuseIdentifier: CollectionCell.className, for: indexPath) as! CollectionCell
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell       = tableView.dequeueReusableCell(withIdentifier: CollectionCell.className, for: indexPath) as! CollectionCell
         let collection = self.collections[indexPath.row]
         
         cell.configureFrom(collection)
@@ -73,23 +77,9 @@ extension CollectionsViewController: UICollectionViewDataSource {
 // ----------------------------------
 //  MARK: - UICollectionViewDelegate -
 //
-extension CollectionsViewController: UICollectionViewDelegate {
+extension CollectionsViewController: UITableViewDelegate {
     
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         
-    }
-}
-
-// -----------------------------------------------
-//  MARK: - UICollectionViewDelegateFlowLayout -
-//
-extension CollectionsViewController: UICollectionViewDelegateFlowLayout {
-    
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        
-        return CGSize(
-            width:  collectionView.bounds.width,
-            height: collectionView.bounds.width / 1.25
-        )
     }
 }

--- a/Sample Apps/Storefront/Storefront/CollectionsViewController.swift
+++ b/Sample Apps/Storefront/Storefront/CollectionsViewController.swift
@@ -2,8 +2,26 @@
 //  CollectionsViewController.swift
 //  Storefront
 //
-//  Created by Dima Bart on 2017-02-16.
-//  Copyright © 2017 Shopify Inc. All rights reserved.
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import UIKit

--- a/Sample Apps/Storefront/Storefront/CollectionsViewController.swift
+++ b/Sample Apps/Storefront/Storefront/CollectionsViewController.swift
@@ -72,6 +72,14 @@ extension CollectionsViewController: UITableViewDataSource {
         
         return cell
     }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        let ratio  = CGFloat(16.0 / 9.0)
+        let width  = tableView.bounds.width
+        let height = width / ratio // height for header
+        
+        return height + 150.0 // 150 is the height of the product collection
+    }
 }
 
 // ----------------------------------

--- a/Sample Apps/Storefront/Storefront/CollectionsViewController.swift
+++ b/Sample Apps/Storefront/Storefront/CollectionsViewController.swift
@@ -1,0 +1,95 @@
+//
+//  CollectionsViewController.swift
+//  Storefront
+//
+//  Created by Dima Bart on 2017-02-16.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+
+import UIKit
+import Buy
+
+class CollectionsViewController: UIViewController {
+
+    @IBOutlet weak var collectionView: StorefrontCollectionView!
+    
+    var collections: [CollectionViewModel] = []
+    
+    // ----------------------------------
+    //  MARK: - View Loading -
+    //
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        let query = ApiSchema.buildQuery { $0
+            .shop { $0
+                .collections(first: 25) { $0
+                    .edges { $0
+                        .node { $0
+                            .fragmentForStandardImage()
+                            .products(first: 25) { $0
+                                .fragmentForStandardProduct()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let client = GraphClient(shopDomain: "your-shop.myshopify.com", apiKey: "your-api-key")
+        let task   = client.queryGraphWith(query) { (query, error) in
+            
+            if let query = query {
+                self.collections = query.shop.collections().viewModels
+                self.collectionView.reloadData()
+            } else {
+                print("Failed to load collections: \(error)")
+            }
+        }
+        
+        task?.resume()
+    }
+}
+
+// ----------------------------------
+//  MARK: - UICollectionViewDataSource -
+//
+extension CollectionsViewController: UICollectionViewDataSource {
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return self.collections.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell       = collectionView.dequeueReusableCell(withReuseIdentifier: CollectionCell.className, for: indexPath) as! CollectionCell
+        let collection = self.collections[indexPath.row]
+        
+        cell.configureFrom(collection)
+        
+        return cell
+    }
+}
+
+// ----------------------------------
+//  MARK: - UICollectionViewDelegate -
+//
+extension CollectionsViewController: UICollectionViewDelegate {
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        
+    }
+}
+
+// -----------------------------------------------
+//  MARK: - UICollectionViewDelegateFlowLayout -
+//
+extension CollectionsViewController: UICollectionViewDelegateFlowLayout {
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        
+        return CGSize(
+            width:  collectionView.bounds.width,
+            height: collectionView.bounds.width / 1.25
+        )
+    }
+}

--- a/Sample Apps/Storefront/Storefront/CollectionsViewController.swift
+++ b/Sample Apps/Storefront/Storefront/CollectionsViewController.swift
@@ -26,6 +26,8 @@ class CollectionsViewController: UIViewController {
                 .collections(first: 25) { $0
                     .edges { $0
                         .node { $0
+                            .title()
+                            .descriptionPlainSummary()
                             .fragmentForStandardImage()
                             .products(first: 25) { $0
                                 .fragmentForStandardProduct()
@@ -56,6 +58,9 @@ class CollectionsViewController: UIViewController {
 //
 extension CollectionsViewController: UITableViewDataSource {
     
+    // ----------------------------------
+    //  MARK: - Data -
+    //
     func numberOfSections(in tableView: UITableView) -> Int {
         return self.collections.count
     }
@@ -73,6 +78,20 @@ extension CollectionsViewController: UITableViewDataSource {
         return cell
     }
     
+    // ----------------------------------
+    //  MARK: - Titles -
+    //
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return self.collections[section].title
+    }
+    
+    func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return self.collections[section].description
+    }
+    
+    // ----------------------------------
+    //  MARK: - Height -
+    //
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         let ratio  = CGFloat(16.0 / 9.0)
         let width  = tableView.bounds.width

--- a/Sample Apps/Storefront/Storefront/CollectionsViewController.swift
+++ b/Sample Apps/Storefront/Storefront/CollectionsViewController.swift
@@ -60,7 +60,7 @@ class CollectionsViewController: UIViewController {
         let task   = client.queryGraphWith(query) { (query, error) in
             
             if let query = query {
-                self.collections = query.shop.collections().viewModels
+                self.collections = query.shop.collectionsArray().viewModels
                 self.tableView.reloadData()
             } else {
                 print("Failed to load collections: \(error)")

--- a/Sample Apps/Storefront/Storefront/CollectionsViewController.swift
+++ b/Sample Apps/Storefront/Storefront/CollectionsViewController.swift
@@ -39,7 +39,7 @@ class CollectionsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        let query = ApiSchema.buildQuery { $0
+        let query = Storefront.buildQuery { $0
             .shop { $0
                 .collections(first: 25) { $0
                     .edges { $0
@@ -67,7 +67,7 @@ class CollectionsViewController: UIViewController {
             }
         }
         
-        task?.resume()
+        task.resume()
     }
 }
 

--- a/Sample Apps/Storefront/Storefront/Fragment+Collection.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+Collection.swift
@@ -27,9 +27,9 @@
 import Foundation
 import Buy
 
-extension ApiSchema.Collection {
+extension Storefront.Collection {
     
-    func products() -> [ApiSchema.Product] {
+    func products() -> [Storefront.Product] {
         return self.products.edges.map { $0.node }
     }
 }

--- a/Sample Apps/Storefront/Storefront/Fragment+Collection.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+Collection.swift
@@ -2,8 +2,26 @@
 //  Fragment+Collection.swift
 //  Storefront
 //
-//  Created by Dima Bart on 2017-02-24.
-//  Copyright © 2017 Shopify Inc. All rights reserved.
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import Foundation

--- a/Sample Apps/Storefront/Storefront/Fragment+Collection.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+Collection.swift
@@ -1,0 +1,17 @@
+//
+//  Fragment+Collection.swift
+//  Storefront
+//
+//  Created by Dima Bart on 2017-02-24.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+
+import Foundation
+import Buy
+
+extension ApiSchema.Collection {
+    
+    func products() -> [ApiSchema.Product] {
+        return self.products.edges.map { $0.node }
+    }
+}

--- a/Sample Apps/Storefront/Storefront/Fragment+Collection.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+Collection.swift
@@ -28,7 +28,7 @@ import Buy
 
 extension Storefront.Collection {
     
-    func products() -> [Storefront.Product] {
+    func productsArray() -> [Storefront.Product] {
         return self.products.edges.map { $0.node }
     }
 }

--- a/Sample Apps/Storefront/Storefront/Fragment+Collection.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+Collection.swift
@@ -24,7 +24,6 @@
 //  THE SOFTWARE.
 //
 
-import Foundation
 import Buy
 
 extension Storefront.Collection {

--- a/Sample Apps/Storefront/Storefront/Fragment+CollectionQuery.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+CollectionQuery.swift
@@ -1,0 +1,21 @@
+//
+//  Fragment+CollectionQuery.swift
+//  Storefront
+//
+//  Created by Dima Bart on 2017-02-24.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+
+import Foundation
+import Buy
+
+extension ApiSchema.CollectionQuery {
+    
+    @discardableResult
+    func fragmentForStandardImage() -> ApiSchema.CollectionQuery { return self
+        .image { $0
+            .src()
+        }
+    }
+}
+

--- a/Sample Apps/Storefront/Storefront/Fragment+CollectionQuery.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+CollectionQuery.swift
@@ -2,8 +2,26 @@
 //  Fragment+CollectionQuery.swift
 //  Storefront
 //
-//  Created by Dima Bart on 2017-02-24.
-//  Copyright © 2017 Shopify Inc. All rights reserved.
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import Foundation

--- a/Sample Apps/Storefront/Storefront/Fragment+CollectionQuery.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+CollectionQuery.swift
@@ -27,10 +27,10 @@
 import Foundation
 import Buy
 
-extension ApiSchema.CollectionQuery {
+extension Storefront.CollectionQuery {
     
     @discardableResult
-    func fragmentForStandardImage() -> ApiSchema.CollectionQuery { return self
+    func fragmentForStandardImage() -> Storefront.CollectionQuery { return self
         .image { $0
             .src()
         }

--- a/Sample Apps/Storefront/Storefront/Fragment+CollectionQuery.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+CollectionQuery.swift
@@ -24,7 +24,6 @@
 //  THE SOFTWARE.
 //
 
-import Foundation
 import Buy
 
 extension Storefront.CollectionQuery {

--- a/Sample Apps/Storefront/Storefront/Fragment+ImageConnectionQuery.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+ImageConnectionQuery.swift
@@ -24,7 +24,6 @@
 //  THE SOFTWARE.
 //
 
-import Foundation
 import Buy
 
 extension Storefront.ImageConnectionQuery {

--- a/Sample Apps/Storefront/Storefront/Fragment+ImageConnectionQuery.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+ImageConnectionQuery.swift
@@ -15,9 +15,7 @@ extension ApiSchema.ImageConnectionQuery {
     func fragmentForStandardProductImage() -> ApiSchema.ImageConnectionQuery { return self
         .edges { $0
             .node { $0
-                .id()
                 .src()
-                .altText()
             }
         }
     }

--- a/Sample Apps/Storefront/Storefront/Fragment+ImageConnectionQuery.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+ImageConnectionQuery.swift
@@ -27,10 +27,10 @@
 import Foundation
 import Buy
 
-extension ApiSchema.ImageConnectionQuery {
+extension Storefront.ImageConnectionQuery {
     
     @discardableResult
-    func fragmentForStandardProductImage() -> ApiSchema.ImageConnectionQuery { return self
+    func fragmentForStandardProductImage() -> Storefront.ImageConnectionQuery { return self
         .edges { $0
             .node { $0
                 .src()

--- a/Sample Apps/Storefront/Storefront/Fragment+ImageConnectionQuery.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+ImageConnectionQuery.swift
@@ -2,8 +2,26 @@
 //  Fragment+ImageConnectionQuery.swift
 //  Storefront
 //
-//  Created by Dima Bart on 2017-02-24.
-//  Copyright © 2017 Shopify Inc. All rights reserved.
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import Foundation

--- a/Sample Apps/Storefront/Storefront/Fragment+ImageConnectionQuery.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+ImageConnectionQuery.swift
@@ -1,0 +1,24 @@
+//
+//  Fragment+ImageConnectionQuery.swift
+//  Storefront
+//
+//  Created by Dima Bart on 2017-02-24.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+
+import Foundation
+import Buy
+
+extension ApiSchema.ImageConnectionQuery {
+    
+    @discardableResult
+    func fragmentForStandardProductImage() -> ApiSchema.ImageConnectionQuery { return self
+        .edges { $0
+            .node { $0
+                .id()
+                .src()
+                .altText()
+            }
+        }
+    }
+}

--- a/Sample Apps/Storefront/Storefront/Fragment+Product.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+Product.swift
@@ -27,9 +27,9 @@
 import Foundation
 import Buy
 
-extension ApiSchema.Product {
+extension Storefront.Product {
 
-    func images() -> [ApiSchema.Image] {
+    func images() -> [Storefront.Image] {
         return self.images.edges.map { $0.node }
     }
 }

--- a/Sample Apps/Storefront/Storefront/Fragment+Product.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+Product.swift
@@ -2,8 +2,26 @@
 //  Fragment+Product.swift
 //  Storefront
 //
-//  Created by Dima Bart on 2017-02-24.
-//  Copyright © 2017 Shopify Inc. All rights reserved.
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import Foundation

--- a/Sample Apps/Storefront/Storefront/Fragment+Product.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+Product.swift
@@ -24,7 +24,6 @@
 //  THE SOFTWARE.
 //
 
-import Foundation
 import Buy
 
 extension Storefront.Product {

--- a/Sample Apps/Storefront/Storefront/Fragment+Product.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+Product.swift
@@ -28,7 +28,7 @@ import Buy
 
 extension Storefront.Product {
 
-    func images() -> [Storefront.Image] {
+    func imagesArray() -> [Storefront.Image] {
         return self.images.edges.map { $0.node }
     }
 }

--- a/Sample Apps/Storefront/Storefront/Fragment+Product.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+Product.swift
@@ -1,0 +1,17 @@
+//
+//  Fragment+Product.swift
+//  Storefront
+//
+//  Created by Dima Bart on 2017-02-24.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+
+import Foundation
+import Buy
+
+extension ApiSchema.Product {
+
+    func images() -> [ApiSchema.Image] {
+        return self.images.edges.map { $0.node }
+    }
+}

--- a/Sample Apps/Storefront/Storefront/Fragment+ProductConnectionQuery.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+ProductConnectionQuery.swift
@@ -2,8 +2,26 @@
 //  Fragment+ProductConnectionQuery.swift
 //  Storefront
 //
-//  Created by Dima Bart on 2017-02-24.
-//  Copyright © 2017 Shopify Inc. All rights reserved.
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import Foundation

--- a/Sample Apps/Storefront/Storefront/Fragment+ProductConnectionQuery.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+ProductConnectionQuery.swift
@@ -27,10 +27,10 @@
 import Foundation
 import Buy
 
-extension ApiSchema.ProductConnectionQuery {
+extension Storefront.ProductConnectionQuery {
     
     @discardableResult
-    func fragmentForStandardProduct() -> ApiSchema.ProductConnectionQuery { return self
+    func fragmentForStandardProduct() -> Storefront.ProductConnectionQuery { return self
         .edges { $0
             .node { $0
                 .images(first: 1) { $0

--- a/Sample Apps/Storefront/Storefront/Fragment+ProductConnectionQuery.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+ProductConnectionQuery.swift
@@ -24,7 +24,6 @@
 //  THE SOFTWARE.
 //
 
-import Foundation
 import Buy
 
 extension Storefront.ProductConnectionQuery {

--- a/Sample Apps/Storefront/Storefront/Fragment+ProductConnectionQuery.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+ProductConnectionQuery.swift
@@ -1,0 +1,27 @@
+//
+//  Fragment+ProductConnectionQuery.swift
+//  Storefront
+//
+//  Created by Dima Bart on 2017-02-24.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+
+import Foundation
+import Buy
+
+extension ApiSchema.ProductConnectionQuery {
+    
+    @discardableResult
+    func fragmentForStandardProduct() -> ApiSchema.ProductConnectionQuery { return self
+        .edges { $0
+            .node { $0
+                .id()
+                .title()
+                .handle()
+                .images(first: 10) { $0
+                    .fragmentForStandardProductImage()
+                }
+            }
+        }
+    }
+}

--- a/Sample Apps/Storefront/Storefront/Fragment+ProductConnectionQuery.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+ProductConnectionQuery.swift
@@ -15,10 +15,7 @@ extension ApiSchema.ProductConnectionQuery {
     func fragmentForStandardProduct() -> ApiSchema.ProductConnectionQuery { return self
         .edges { $0
             .node { $0
-                .id()
-                .title()
-                .handle()
-                .images(first: 10) { $0
+                .images(first: 1) { $0
                     .fragmentForStandardProductImage()
                 }
             }

--- a/Sample Apps/Storefront/Storefront/Fragment+Shop.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+Shop.swift
@@ -2,8 +2,26 @@
 //  Fragment+Shop.swift
 //  Storefront
 //
-//  Created by Dima Bart on 2017-02-24.
-//  Copyright © 2017 Shopify Inc. All rights reserved.
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import Foundation

--- a/Sample Apps/Storefront/Storefront/Fragment+Shop.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+Shop.swift
@@ -28,7 +28,7 @@ import Buy
 
 extension Storefront.Shop {
     
-    func collections() -> [Storefront.Collection] {
+    func collectionsArray() -> [Storefront.Collection] {
         return self.collections.edges.map { $0.node }
     }
 }

--- a/Sample Apps/Storefront/Storefront/Fragment+Shop.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+Shop.swift
@@ -1,0 +1,17 @@
+//
+//  Fragment+Shop.swift
+//  Storefront
+//
+//  Created by Dima Bart on 2017-02-24.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+
+import Foundation
+import Buy
+
+extension ApiSchema.Shop {
+    
+    func collections() -> [ApiSchema.Collection] {
+        return self.collections.edges.map { $0.node }
+    }
+}

--- a/Sample Apps/Storefront/Storefront/Fragment+Shop.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+Shop.swift
@@ -24,7 +24,6 @@
 //  THE SOFTWARE.
 //
 
-import Foundation
 import Buy
 
 extension Storefront.Shop {

--- a/Sample Apps/Storefront/Storefront/Fragment+Shop.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+Shop.swift
@@ -27,9 +27,9 @@
 import Foundation
 import Buy
 
-extension ApiSchema.Shop {
+extension Storefront.Shop {
     
-    func collections() -> [ApiSchema.Collection] {
+    func collections() -> [Storefront.Collection] {
         return self.collections.edges.map { $0.node }
     }
 }

--- a/Sample Apps/Storefront/Storefront/NSObject+Name.swift
+++ b/Sample Apps/Storefront/Storefront/NSObject+Name.swift
@@ -1,0 +1,16 @@
+//
+//  NSObject+Name.swift
+//  Storefront
+//
+//  Created by Dima Bart on 2017-02-24.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+
+import Foundation
+
+extension NSObject {
+    
+    static var className: String {
+        return NSStringFromClass(self).components(separatedBy: ".").last!
+    }
+}

--- a/Sample Apps/Storefront/Storefront/NSObject+Name.swift
+++ b/Sample Apps/Storefront/Storefront/NSObject+Name.swift
@@ -2,8 +2,26 @@
 //  NSObject+Name.swift
 //  Storefront
 //
-//  Created by Dima Bart on 2017-02-24.
-//  Copyright © 2017 Shopify Inc. All rights reserved.
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import Foundation

--- a/Sample Apps/Storefront/Storefront/NSObject+Name.swift
+++ b/Sample Apps/Storefront/Storefront/NSObject+Name.swift
@@ -29,6 +29,6 @@ import Foundation
 extension NSObject {
     
     static var className: String {
-        return NSStringFromClass(self).components(separatedBy: ".").last!
+        return String(describing: self)
     }
 }

--- a/Sample Apps/Storefront/Storefront/ProductCell.swift
+++ b/Sample Apps/Storefront/Storefront/ProductCell.swift
@@ -2,8 +2,26 @@
 //  ProductCell.swift
 //  Storefront
 //
-//  Created by Dima Bart on 2017-02-24.
-//  Copyright © 2017 Shopify Inc. All rights reserved.
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import UIKit

--- a/Sample Apps/Storefront/Storefront/ProductCell.swift
+++ b/Sample Apps/Storefront/Storefront/ProductCell.swift
@@ -1,0 +1,24 @@
+//
+//  ProductCell.swift
+//  Storefront
+//
+//  Created by Dima Bart on 2017-02-24.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+
+import UIKit
+
+class ProductCell: UICollectionViewCell, ViewModelConfigurable {
+
+    typealias ViewModelType = ProductViewModel
+    
+    @IBOutlet private weak var imageView: UIImageView!
+    
+    private(set) var viewModel: ProductViewModel?
+    
+    func configureFrom(_ viewModel: ProductViewModel) {
+        self.viewModel = viewModel
+        
+        self.imageView.setImageFrom(viewModel.imageURL)
+    }
+}

--- a/Sample Apps/Storefront/Storefront/ProductCell.xib
+++ b/Sample Apps/Storefront/Storefront/ProductCell.xib
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="gTV-IL-0wX" customClass="ProductCell" customModule="Storefront" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="90" height="90"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                <rect key="frame" x="0.0" y="0.0" width="90" height="90"/>
+                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                <subviews>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="wIx-of-QVi">
+                        <rect key="frame" x="0.0" y="0.0" width="90" height="90"/>
+                    </imageView>
+                </subviews>
+            </view>
+            <constraints>
+                <constraint firstItem="wIx-of-QVi" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="9Wr-ii-ksx"/>
+                <constraint firstItem="wIx-of-QVi" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="PeQ-EE-gMl"/>
+                <constraint firstAttribute="bottom" secondItem="wIx-of-QVi" secondAttribute="bottom" id="eTV-ho-Aix"/>
+                <constraint firstAttribute="trailing" secondItem="wIx-of-QVi" secondAttribute="trailing" id="tNw-F3-gDC"/>
+            </constraints>
+            <size key="customSize" width="90" height="90"/>
+            <connections>
+                <outlet property="imageView" destination="wIx-of-QVi" id="RKQ-Dv-sPv"/>
+            </connections>
+            <point key="canvasLocation" x="-96" y="-27"/>
+        </collectionViewCell>
+    </objects>
+</document>

--- a/Sample Apps/Storefront/Storefront/ProductViewModel.swift
+++ b/Sample Apps/Storefront/Storefront/ProductViewModel.swift
@@ -2,8 +2,26 @@
 //  ProductViewModel.swift
 //  Storefront
 //
-//  Created by Dima Bart on 2017-02-24.
-//  Copyright © 2017 Shopify Inc. All rights reserved.
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import Foundation

--- a/Sample Apps/Storefront/Storefront/ProductViewModel.swift
+++ b/Sample Apps/Storefront/Storefront/ProductViewModel.swift
@@ -1,0 +1,32 @@
+//
+//  ProductViewModel.swift
+//  Storefront
+//
+//  Created by Dima Bart on 2017-02-24.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+
+import Foundation
+import Buy
+
+struct ProductViewModel: ViewModel {
+    
+    typealias ModelType = ApiSchema.Product
+    
+    let imageURL: URL?
+    
+    // ----------------------------------
+    //  MARK: - Init -
+    //
+    init(from model: ModelType) {
+        if let image = model.images().first {
+            self.imageURL = URL(string: image.src)!
+        } else {
+            self.imageURL = nil
+        }
+    }
+}
+
+extension ApiSchema.Product: ViewModeling {
+    typealias ViewModelType = ProductViewModel
+}

--- a/Sample Apps/Storefront/Storefront/ProductViewModel.swift
+++ b/Sample Apps/Storefront/Storefront/ProductViewModel.swift
@@ -29,7 +29,7 @@ import Buy
 
 struct ProductViewModel: ViewModel {
     
-    typealias ModelType = ApiSchema.Product
+    typealias ModelType = Storefront.Product
     
     let imageURL: URL?
     
@@ -45,6 +45,6 @@ struct ProductViewModel: ViewModel {
     }
 }
 
-extension ApiSchema.Product: ViewModeling {
+extension Storefront.Product: ViewModeling {
     typealias ViewModelType = ProductViewModel
 }

--- a/Sample Apps/Storefront/Storefront/ProductViewModel.swift
+++ b/Sample Apps/Storefront/Storefront/ProductViewModel.swift
@@ -37,7 +37,7 @@ struct ProductViewModel: ViewModel {
     //  MARK: - Init -
     //
     init(from model: ModelType) {
-        if let image = model.images().first {
+        if let image = model.imagesArray().first {
             self.imageURL = URL(string: image.src)!
         } else {
             self.imageURL = nil

--- a/Sample Apps/Storefront/Storefront/StorefrontCollectionView.swift
+++ b/Sample Apps/Storefront/Storefront/StorefrontCollectionView.swift
@@ -1,0 +1,25 @@
+//
+//  StorefrontCollectionView.swift
+//  Storefront
+//
+//  Created by Dima Bart on 2017-02-24.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+
+import UIKit
+
+class StorefrontCollectionView: UICollectionView {
+    
+    @IBInspectable private dynamic var cellNibName: String?
+    
+    // ----------------------------------
+    //  MARK: - Awake -
+    //
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        
+        if let className = self.value(forKey: "cellNibName") as? String {
+            self.register(UINib(nibName: className, bundle: nil), forCellWithReuseIdentifier: className)
+        }
+    }
+}

--- a/Sample Apps/Storefront/Storefront/StorefrontCollectionView.swift
+++ b/Sample Apps/Storefront/Storefront/StorefrontCollectionView.swift
@@ -2,8 +2,26 @@
 //  StorefrontCollectionView.swift
 //  Storefront
 //
-//  Created by Dima Bart on 2017-02-24.
-//  Copyright © 2017 Shopify Inc. All rights reserved.
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import UIKit

--- a/Sample Apps/Storefront/Storefront/StorefrontTableView.swift
+++ b/Sample Apps/Storefront/Storefront/StorefrontTableView.swift
@@ -1,0 +1,25 @@
+//
+//  StorefrontTableView.swift
+//  Storefront
+//
+//  Created by Dima Bart on 2017-02-27.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+
+import UIKit
+
+class StorefrontTableView: UITableView {
+    
+    @IBInspectable private dynamic var cellNibName: String?
+    
+    // ----------------------------------
+    //  MARK: - Awake -
+    //
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        
+        if let className = self.value(forKey: "cellNibName") as? String {
+            self.register(UINib(nibName: className, bundle: nil), forCellReuseIdentifier: className)
+        }
+    }
+}

--- a/Sample Apps/Storefront/Storefront/StorefrontTableView.swift
+++ b/Sample Apps/Storefront/Storefront/StorefrontTableView.swift
@@ -2,8 +2,26 @@
 //  StorefrontTableView.swift
 //  Storefront
 //
-//  Created by Dima Bart on 2017-02-27.
-//  Copyright © 2017 Shopify Inc. All rights reserved.
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import UIKit

--- a/Sample Apps/Storefront/Storefront/UIImageView+Remote.swift
+++ b/Sample Apps/Storefront/Storefront/UIImageView+Remote.swift
@@ -1,0 +1,63 @@
+//
+//  UIImageView+Remote.swift
+//  Storefront
+//
+//  Created by Dima Bart on 2017-02-24.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+
+import UIKit
+
+extension UIImageView {
+    
+    typealias Completion = () -> Void
+    
+    private struct Key {
+        static var image = "com.storefront.image.key"
+    }
+    
+    private var currentTask: URLSessionDataTask? {
+        get {
+            return objc_getAssociatedObject(self, &Key.image) as? URLSessionDataTask
+        }
+        set {
+            objc_setAssociatedObject(self, &Key.image, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+    
+    func setImageFrom(_ url: URL?, placeholder: UIImage? = nil, completion: Completion? = nil) {
+        
+        self.currentTask?.cancel()
+        self.image = nil
+        
+        /* -----------------------------------
+         ** Set the placeholder image if one
+         ** was provided.
+         */
+        if let placeholder = placeholder {
+            self.image = placeholder
+        }
+        
+        /* ---------------------------------
+         ** If the url is provided, kick off
+         ** the image request and update the
+         ** current data task.
+         */
+        if let url = url {
+            
+            self.currentTask = URLSession.shared.dataTask(with: url) { (data, response, error) in
+                
+                if let data = data, let image = UIImage(data: data) {
+                    DispatchQueue.main.async {
+                        self.image = image
+                    }
+                }
+            }
+            self.currentTask?.resume()
+            
+        } else {
+            self.image       = nil
+            self.currentTask = nil
+        }
+    }
+}

--- a/Sample Apps/Storefront/Storefront/UIImageView+Remote.swift
+++ b/Sample Apps/Storefront/Storefront/UIImageView+Remote.swift
@@ -2,8 +2,26 @@
 //  UIImageView+Remote.swift
 //  Storefront
 //
-//  Created by Dima Bart on 2017-02-24.
-//  Copyright © 2017 Shopify Inc. All rights reserved.
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import UIKit

--- a/Sample Apps/Storefront/Storefront/ViewModel.swift
+++ b/Sample Apps/Storefront/Storefront/ViewModel.swift
@@ -2,8 +2,26 @@
 //  ViewModel.swift
 //  Storefront
 //
-//  Created by Dima Bart on 2017-02-24.
-//  Copyright © 2017 Shopify Inc. All rights reserved.
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import Foundation

--- a/Sample Apps/Storefront/Storefront/ViewModel.swift
+++ b/Sample Apps/Storefront/Storefront/ViewModel.swift
@@ -1,0 +1,16 @@
+//
+//  ViewModel.swift
+//  Storefront
+//
+//  Created by Dima Bart on 2017-02-24.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+
+import Foundation
+
+protocol ViewModel {
+    
+    associatedtype ModelType
+    
+    init(from model: ModelType)
+}

--- a/Sample Apps/Storefront/Storefront/ViewModelConfigurable.swift
+++ b/Sample Apps/Storefront/Storefront/ViewModelConfigurable.swift
@@ -2,8 +2,26 @@
 //  ViewModelConfigurable.swift
 //  Storefront
 //
-//  Created by Dima Bart on 2017-02-24.
-//  Copyright © 2017 Shopify Inc. All rights reserved.
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import Foundation

--- a/Sample Apps/Storefront/Storefront/ViewModelConfigurable.swift
+++ b/Sample Apps/Storefront/Storefront/ViewModelConfigurable.swift
@@ -1,0 +1,18 @@
+//
+//  ViewModelConfigurable.swift
+//  Storefront
+//
+//  Created by Dima Bart on 2017-02-24.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+
+import Foundation
+
+protocol ViewModelConfigurable {
+    
+    associatedtype ViewModelType
+    
+    var viewModel: ViewModelType? { get }
+    
+    func configureFrom(_ viewModel: ViewModelType)
+}

--- a/Sample Apps/Storefront/Storefront/ViewModeling.swift
+++ b/Sample Apps/Storefront/Storefront/ViewModeling.swift
@@ -2,8 +2,26 @@
 //  ViewModeling.swift
 //  Storefront
 //
-//  Created by Dima Bart on 2017-02-24.
-//  Copyright © 2017 Shopify Inc. All rights reserved.
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import Foundation

--- a/Sample Apps/Storefront/Storefront/ViewModeling.swift
+++ b/Sample Apps/Storefront/Storefront/ViewModeling.swift
@@ -1,0 +1,30 @@
+//
+//  ViewModeling.swift
+//  Storefront
+//
+//  Created by Dima Bart on 2017-02-24.
+//  Copyright © 2017 Shopify Inc. All rights reserved.
+//
+
+import Foundation
+
+protocol ViewModeling {
+    
+    associatedtype ViewModelType: ViewModel
+    
+    var viewModel: ViewModelType { get }
+}
+
+extension ViewModeling where ViewModelType.ModelType == Self {
+    
+    var viewModel: ViewModelType {
+        return ViewModelType(from: self)
+    }
+}
+
+extension Array where Element: ViewModeling {
+    
+    var viewModels: [Element.ViewModelType] {
+        return self.map { $0.viewModel }
+    }
+}


### PR DESCRIPTION
__NOTE:__ Don't get overwhelmed by the line change count. Nearly 500 lines are header comments. There's also a bunch of storyboard / nib files that you're better off looking at in Xcode.

### What this does
Adds a hybrid collection view to display collections (vertically) and products (horizontally). 

#### View models
Here, we also set the groundwork for `ViewModel` support with the 3 primary classes:
- `ViewModel.swift` - view models will implement this protocol
- `ViewModeling.swift` - objects that can be represented by a view model will implement this protocol
- `ViewModelConfigurable.swift`- objects that can be configured using a view model will implement this protocol

#### Fragments
To alleviate the pain of digging through connections & edges and to simplify query building, extensions on `Storefront` objects were introduced that provide these conveniences. These are located under the `Fragments` group in `Model` and `Query` groups respectively. They are named using the following format: `Fragment+Object.swift`.

### `StorefrontTableView` & `StorefrontCollectionView`
These subclasses offer a `cellNibName` property to Interface Builder so that a cell can be registered within Interface Builder itself.

### `UIImageView+Remote`
An extension on `UIImageView` provides asynchronous, cancellable image request functionality without relying on 3rd party dependencies like `SDWebImage` or `Alamofire`.