### PR TITLE
Custom URL scalar

### DIFF
--- a/Buy/Generated/Storefront/Domain.swift
+++ b/Buy/Generated/Storefront/Domain.swift
@@ -43,7 +43,7 @@ extension Storefront {
 				guard let value = value as? String else {
 					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
 				}
-				return value
+				return URL(string: value)!
 
 				default:
 				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
@@ -68,12 +68,12 @@ extension Storefront {
 			return field(field: "sslEnabled", aliasSuffix: aliasSuffix) as! Bool
 		}
 
-		open var url: String {
+		open var url: URL {
 			return internalGetUrl()
 		}
 
-		func internalGetUrl(aliasSuffix: String? = nil) -> String {
-			return field(field: "url", aliasSuffix: aliasSuffix) as! String
+		func internalGetUrl(aliasSuffix: String? = nil) -> URL {
+			return field(field: "url", aliasSuffix: aliasSuffix) as! URL
 		}
 
 		override open func childObjectType(key: String) -> GraphQL.ChildObjectType {

--- a/Buy/Generated/Storefront/Image.swift
+++ b/Buy/Generated/Storefront/Image.swift
@@ -45,7 +45,7 @@ extension Storefront {
 				guard let value = value as? String else {
 					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
 				}
-				return value
+				return URL(string: value)!
 
 				default:
 				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
@@ -70,12 +70,12 @@ extension Storefront {
 			return field(field: "id", aliasSuffix: aliasSuffix) as! GraphQL.ID?
 		}
 
-		open var src: String {
+		open var src: URL {
 			return internalGetSrc()
 		}
 
-		func internalGetSrc(aliasSuffix: String? = nil) -> String {
-			return field(field: "src", aliasSuffix: aliasSuffix) as! String
+		func internalGetSrc(aliasSuffix: String? = nil) -> URL {
+			return field(field: "src", aliasSuffix: aliasSuffix) as! URL
 		}
 
 		override open func childObjectType(key: String) -> GraphQL.ChildObjectType {

--- a/Buy/Generated/Storefront/Order.swift
+++ b/Buy/Generated/Storefront/Order.swift
@@ -168,7 +168,7 @@ extension Storefront {
 				guard let value = value as? String else {
 					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
 				}
-				return value
+				return URL(string: value)!
 
 				case "displayFinancialStatus":
 				if value is NSNull { return nil }
@@ -291,12 +291,12 @@ extension Storefront {
 			return field(field: "currencyCode", aliasSuffix: aliasSuffix) as! Storefront.CurrencyCode
 		}
 
-		open var customerUrl: String? {
+		open var customerUrl: URL? {
 			return internalGetCustomerUrl()
 		}
 
-		func internalGetCustomerUrl(aliasSuffix: String? = nil) -> String? {
-			return field(field: "customerUrl", aliasSuffix: aliasSuffix) as! String?
+		func internalGetCustomerUrl(aliasSuffix: String? = nil) -> URL? {
+			return field(field: "customerUrl", aliasSuffix: aliasSuffix) as! URL?
 		}
 
 		open var displayFinancialStatus: Storefront.OrderDisplayFinancialStatus? {

--- a/Buy/Generated/Storefront/ShopPolicy.swift
+++ b/Buy/Generated/Storefront/ShopPolicy.swift
@@ -55,7 +55,7 @@ extension Storefront {
 				guard let value = value as? String else {
 					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
 				}
-				return value
+				return URL(string: value)!
 
 				default:
 				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
@@ -88,12 +88,12 @@ extension Storefront {
 			return field(field: "title", aliasSuffix: aliasSuffix) as! String
 		}
 
-		open var url: String {
+		open var url: URL {
 			return internalGetUrl()
 		}
 
-		func internalGetUrl(aliasSuffix: String? = nil) -> String {
-			return field(field: "url", aliasSuffix: aliasSuffix) as! String
+		func internalGetUrl(aliasSuffix: String? = nil) -> URL {
+			return field(field: "url", aliasSuffix: aliasSuffix) as! URL
 		}
 
 		override open func childObjectType(key: String) -> GraphQL.ChildObjectType {

--- a/Scripts/update_schema
+++ b/Scripts/update_schema
@@ -19,6 +19,12 @@ customScalars = [
 	  serialize_expr:   ->(expr) { "GraphQL.iso8601DateParser.string(from: #{expr})" },
 	),
 	GraphQLSwiftGen::Scalar.new(
+      type_name:       'URL',
+      swift_type:      'URL',
+      deserialize_expr: ->(expr) { "URL(string: #{expr})!" },
+      serialize_expr:   ->(expr) { "#{expr}.absoluteString" },
+    ),
+	GraphQLSwiftGen::Scalar.new(
 	  type_name:       'Money',
 	  swift_type:      'NSDecimalNumber',
 	  deserialize_expr: ->(expr) { "NSDecimalNumber(string: #{expr}, locale: GraphQL.posixLocale)" },


### PR DESCRIPTION
### What this does
Adds a custom `URL` scalar and serializer / deserializer as part of the schema generation script. Doing so allows us to use the native `URL` type in Swift foundation instead of a `String` representing the URL.

Most of the changes are auto-generated. The only manual additions are to `update_schema`.

cc: @sav007 Not sure if this is possible / applicable to Android.