### PR TITLE
Add product collection view.

### DIFF
--- a/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
+++ b/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
@@ -33,6 +33,9 @@
 		9AEF61D11E606F930067FA90 /* Fragment+Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AEF61D01E606F930067FA90 /* Fragment+Product.swift */; };
 		9AEF61D51E6070880067FA90 /* Fragment+Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AEF61D41E6070880067FA90 /* Fragment+Collection.swift */; };
 		9AEF61D71E6070F40067FA90 /* Fragment+Shop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AEF61D61E6070F40067FA90 /* Fragment+Shop.swift */; };
+		9AFA3B7D1E6DB7110056C5AA /* ProductsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFA3B7C1E6DB7110056C5AA /* ProductsViewController.swift */; };
+		9AFA3B7F1E6DC5FD0056C5AA /* Storyboard+ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFA3B7E1E6DC5FD0056C5AA /* Storyboard+ViewController.swift */; };
+		9AFA3B811E6DEEA90056C5AA /* GraphClient+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFA3B801E6DEEA90056C5AA /* GraphClient+Shared.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +52,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 9AEF60F21E5F42D90067FA90;
 			remoteInfo = Buy;
+		};
+		9AFA3B7A1E6DB6FE0056C5AA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9AEF61BF1E606C710067FA90 /* Buy.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 9AFA38EA1E64850A0056C5AA;
+			remoteInfo = BuyTests;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -94,6 +104,9 @@
 		9AEF61D01E606F930067FA90 /* Fragment+Product.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Fragment+Product.swift"; sourceTree = "<group>"; };
 		9AEF61D41E6070880067FA90 /* Fragment+Collection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Fragment+Collection.swift"; sourceTree = "<group>"; };
 		9AEF61D61E6070F40067FA90 /* Fragment+Shop.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Fragment+Shop.swift"; sourceTree = "<group>"; };
+		9AFA3B7C1E6DB7110056C5AA /* ProductsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductsViewController.swift; sourceTree = "<group>"; };
+		9AFA3B7E1E6DC5FD0056C5AA /* Storyboard+ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Storyboard+ViewController.swift"; sourceTree = "<group>"; };
+		9AFA3B801E6DEEA90056C5AA /* GraphClient+Shared.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GraphClient+Shared.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -112,6 +125,7 @@
 			isa = PBXGroup;
 			children = (
 				9AAFAB791E60BDED00864A17 /* Collections */,
+				9AFA3B781E6DB6FE0056C5AA /* Products */,
 			);
 			name = "View Controllers";
 			sourceTree = "<group>";
@@ -145,6 +159,8 @@
 			children = (
 				9AAFAB8E1E60C6AC00864A17 /* UIImageView+Remote.swift */,
 				9AAFAB931E60D2D000864A17 /* NSObject+Name.swift */,
+				9AFA3B7E1E6DC5FD0056C5AA /* Storyboard+ViewController.swift */,
+				9AFA3B801E6DEEA90056C5AA /* GraphClient+Shared.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -212,6 +228,7 @@
 			isa = PBXGroup;
 			children = (
 				9AEF61C41E606C710067FA90 /* Buy.framework */,
+				9AFA3B7B1E6DB6FE0056C5AA /* BuyTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -243,6 +260,14 @@
 				9AAFAB951E60D83600864A17 /* Fragment+CollectionQuery.swift */,
 			);
 			name = Queries;
+			sourceTree = "<group>";
+		};
+		9AFA3B781E6DB6FE0056C5AA /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				9AFA3B7C1E6DB7110056C5AA /* ProductsViewController.swift */,
+			);
+			name = Products;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -316,6 +341,13 @@
 			remoteRef = 9AEF61C31E606C710067FA90 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		9AFA3B7B1E6DB6FE0056C5AA /* BuyTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = BuyTests.xctest;
+			remoteRef = 9AFA3B7A1E6DB6FE0056C5AA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
@@ -352,11 +384,14 @@
 				9AAFAB941E60D2D000864A17 /* NSObject+Name.swift in Sources */,
 				9AEF61CC1E606EFE0067FA90 /* Fragment+ProductConnectionQuery.swift in Sources */,
 				9AAFAB8F1E60C6AC00864A17 /* UIImageView+Remote.swift in Sources */,
+				9AFA3B7D1E6DB7110056C5AA /* ProductsViewController.swift in Sources */,
 				9ADAD46D1E563091008AC561 /* CollectionsViewController.swift in Sources */,
 				9AAFAB821E60BEE000864A17 /* CollectionViewModel.swift in Sources */,
 				9AAFAB801E60BE9800864A17 /* ViewModelConfigurable.swift in Sources */,
 				9AEF61CE1E606F100067FA90 /* Fragment+ImageConnectionQuery.swift in Sources */,
 				9ADAD46B1E563091008AC561 /* AppDelegate.swift in Sources */,
+				9AFA3B811E6DEEA90056C5AA /* GraphClient+Shared.swift in Sources */,
+				9AFA3B7F1E6DC5FD0056C5AA /* Storyboard+ViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sample Apps/Storefront/Storefront/Base.lproj/Main.storyboard
+++ b/Sample Apps/Storefront/Storefront/Base.lproj/Main.storyboard
@@ -12,7 +12,7 @@
         <!--Collections-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="CollectionsViewController" customModule="Storefront" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="CollectionsViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="BYZ-38-t0r" customClass="CollectionsViewController" customModule="Storefront" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
@@ -44,11 +44,62 @@
                     <navigationItem key="navigationItem" title="Collections" id="9WP-3t-7If"/>
                     <connections>
                         <outlet property="tableView" destination="FJA-Xo-Ook" id="zuu-Zf-hAN"/>
+                        <segue destination="AbI-Ns-2vc" kind="show" id="f9n-Ry-sCt"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1076" y="138.98050974512745"/>
+        </scene>
+        <!--Products-->
+        <scene sceneID="vIO-P4-DiX">
+            <objects>
+                <viewController storyboardIdentifier="ProductsViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="AbI-Ns-2vc" customClass="ProductsViewController" customModule="Storefront" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="mlK-I5-tBJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="oTA-Tk-tHe"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="xKM-7h-oPY">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="l3f-iD-z0W" customClass="StorefrontCollectionView" customModule="Storefront" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <inset key="scrollIndicatorInsets" minX="0.0" minY="5" maxX="0.0" maxY="5"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="5" minimumInteritemSpacing="5" id="LCc-sn-ckA">
+                                    <size key="itemSize" width="50" height="50"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="10" minY="10" maxX="10" maxY="10"/>
+                                </collectionViewFlowLayout>
+                                <cells/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="cellNibName" value="ProductCell"/>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <outlet property="dataSource" destination="AbI-Ns-2vc" id="yxj-ig-aOM"/>
+                                    <outlet property="delegate" destination="AbI-Ns-2vc" id="IA6-Hn-FDk"/>
+                                    <outlet property="prefetchDataSource" destination="AbI-Ns-2vc" id="u0I-sB-XBE"/>
+                                </connections>
+                            </collectionView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="l3f-iD-z0W" secondAttribute="trailing" id="971-jO-5TT"/>
+                            <constraint firstItem="oTA-Tk-tHe" firstAttribute="top" secondItem="l3f-iD-z0W" secondAttribute="bottom" id="9Pu-yp-tHC"/>
+                            <constraint firstItem="l3f-iD-z0W" firstAttribute="leading" secondItem="xKM-7h-oPY" secondAttribute="leading" id="aFP-HO-uyh"/>
+                            <constraint firstItem="l3f-iD-z0W" firstAttribute="top" secondItem="xKM-7h-oPY" secondAttribute="top" id="t6s-Aa-fox"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="Products" id="So2-vy-uwr"/>
+                    <connections>
+                        <outlet property="collectionView" destination="l3f-iD-z0W" id="ZWP-72-Gmz"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Nes-dj-osI" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1784.8" y="138.98050974512745"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="22L-nZ-ej3">

--- a/Sample Apps/Storefront/Storefront/CollectionCell.xib
+++ b/Sample Apps/Storefront/Storefront/CollectionCell.xib
@@ -22,7 +22,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="245"/>
                     </imageView>
                     <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="8u8-y0-ose" customClass="StorefrontCollectionView" customModule="Storefront" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="245.5" width="375" height="150"/>
+                        <rect key="frame" x="0.0" y="245" width="375" height="150"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="150" id="UZ2-3g-Sy4"/>

--- a/Sample Apps/Storefront/Storefront/CollectionViewModel.swift
+++ b/Sample Apps/Storefront/Storefront/CollectionViewModel.swift
@@ -31,6 +31,7 @@ struct CollectionViewModel: ViewModel {
     
     typealias ModelType = Storefront.Collection
     
+    let model:       ModelType
     let title:       String
     let description: String
     let imageURL:    URL?
@@ -46,6 +47,7 @@ struct CollectionViewModel: ViewModel {
             self.imageURL = nil
         }
         
+        self.model       = model
         self.products    = model.productsArray().viewModels
         self.title       = model.title
         self.description = model.descriptionPlainSummary

--- a/Sample Apps/Storefront/Storefront/CollectionsViewController.swift
+++ b/Sample Apps/Storefront/Storefront/CollectionsViewController.swift
@@ -31,7 +31,7 @@ class CollectionsViewController: UIViewController {
 
     @IBOutlet weak var tableView: StorefrontTableView!
     
-    var collections: [CollectionViewModel] = []
+    fileprivate var collections: [CollectionViewModel] = []
     
     // ----------------------------------
     //  MARK: - View Loading -
@@ -44,6 +44,7 @@ class CollectionsViewController: UIViewController {
                 .collections(first: 25) { $0
                     .edges { $0
                         .node { $0
+                            .id()
                             .title()
                             .descriptionPlainSummary()
                             .fragmentForStandardImage()
@@ -55,9 +56,8 @@ class CollectionsViewController: UIViewController {
                 }
             }
         }
-
-        let client = GraphClient(shopDomain: "your-shop.myshopify.com", apiKey: "your-api-key")
-        let task   = client.queryGraphWith(query) { (query, error) in
+        
+        let task = GraphClient.shared.queryGraphWith(query) { (query, error) in
             
             if let query = query {
                 self.collections = query.shop.collectionsArray().viewModels
@@ -89,7 +89,7 @@ extension CollectionsViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell       = tableView.dequeueReusableCell(withIdentifier: CollectionCell.className, for: indexPath) as! CollectionCell
-        let collection = self.collections[indexPath.row]
+        let collection = self.collections[indexPath.section]
         
         cell.configureFrom(collection)
         
@@ -125,6 +125,10 @@ extension CollectionsViewController: UITableViewDataSource {
 extension CollectionsViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let collection = self.collections[indexPath.section]
         
+        let productsController: ProductsViewController = self.storyboard!.instantiateViewController()
+        productsController.collection = collection
+        self.navigationController!.pushViewController(productsController, animated: true)
     }
 }

--- a/Sample Apps/Storefront/Storefront/GraphClient+Shared.swift
+++ b/Sample Apps/Storefront/Storefront/GraphClient+Shared.swift
@@ -1,5 +1,5 @@
 //
-//  ViewModel.swift
+//  GraphClient+Shared.swift
 //  Storefront
 //
 //  Created by Shopify.
@@ -25,12 +25,8 @@
 //
 
 import Foundation
+import Buy
 
-protocol ViewModel {
-    
-    associatedtype ModelType
-    
-    var model: ModelType { get }
-    
-    init(from model: ModelType)
+extension GraphClient {
+    static let shared: GraphClient = GraphClient(shopDomain: "your-shop.myshopify.com", apiKey: "your-api-key")
 }

--- a/Sample Apps/Storefront/Storefront/ProductViewModel.swift
+++ b/Sample Apps/Storefront/Storefront/ProductViewModel.swift
@@ -31,6 +31,7 @@ struct ProductViewModel: ViewModel {
     
     typealias ModelType = Storefront.Product
     
+    let model:    ModelType
     let imageURL: URL?
     
     // ----------------------------------
@@ -42,6 +43,8 @@ struct ProductViewModel: ViewModel {
         } else {
             self.imageURL = nil
         }
+        
+        self.model = model
     }
 }
 

--- a/Sample Apps/Storefront/Storefront/ProductsViewController.swift
+++ b/Sample Apps/Storefront/Storefront/ProductsViewController.swift
@@ -1,0 +1,119 @@
+//
+//  ProductsViewController.swift
+//  Storefront
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import UIKit
+import Buy
+
+class ProductsViewController: UIViewController {
+    
+    @IBOutlet weak var collectionView: StorefrontCollectionView!
+    
+    var collection: CollectionViewModel!
+    
+    fileprivate let columns:  Int = 2
+    fileprivate var products: [ProductViewModel] = []
+    
+    // ----------------------------------
+    //  MARK: - View Loading -
+    //
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        let query = Storefront.buildQuery { $0
+            .node(id: self.collection.model.id) { $0
+                .onCollection { $0
+                    .products(first: 25) { $0
+                        .fragmentForStandardProduct()
+                    }
+                }
+            }
+        }
+        
+        let task = GraphClient.shared.queryGraphWith(query) { (query, error) in
+            
+            if let query = query,
+                let collection = query.node as? Storefront.Collection {
+                
+                self.products = collection.products.edges.map { $0.node }.viewModels
+                self.collectionView.reloadData()
+                
+            } else {
+                print("Failed to load products in collection (\(self.collection.model.id.rawValue)): \(error)")
+            }
+        }
+        
+        task.resume()
+    }
+}
+
+// ----------------------------------
+//  MARK: - UICollectionViewDataSource -
+//
+extension ProductsViewController: UICollectionViewDataSource {
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return self.products.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        
+        let cell       = collectionView.dequeueReusableCell(withReuseIdentifier: ProductCell.className, for: indexPath) as! ProductCell
+        let collection = self.products[indexPath.item]
+        
+        cell.configureFrom(collection)
+        
+        return cell
+    }
+}
+
+extension ProductsViewController: UICollectionViewDelegateFlowLayout {
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        
+        let layout         = collectionView.collectionViewLayout as! UICollectionViewFlowLayout
+        let itemSpacing    = layout.minimumInteritemSpacing * CGFloat(self.columns - 1)
+        let sectionSpacing = layout.sectionInset.left + layout.sectionInset.right
+        let length         = (collectionView.bounds.width - itemSpacing - sectionSpacing) / CGFloat(self.columns)
+        
+        return CGSize(
+            width:  length,
+            height: length
+        )
+    }
+}
+
+// ----------------------------------
+//  MARK: - UICollectionViewDelegate -
+//
+extension ProductsViewController: UICollectionViewDelegate {
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        
+        
+        
+        collectionView.deselectItem(at: indexPath, animated: true)
+    }
+}

--- a/Sample Apps/Storefront/Storefront/Storyboard+ViewController.swift
+++ b/Sample Apps/Storefront/Storefront/Storyboard+ViewController.swift
@@ -1,5 +1,5 @@
 //
-//  ViewModel.swift
+//  Storyboard+ViewController.swift
 //  Storefront
 //
 //  Created by Shopify.
@@ -24,13 +24,16 @@
 //  THE SOFTWARE.
 //
 
-import Foundation
+import UIKit
 
-protocol ViewModel {
+extension UIStoryboard {
     
-    associatedtype ModelType
-    
-    var model: ModelType { get }
-    
-    init(from model: ModelType)
+    func instantiateViewController<T: UIViewController>() -> T {
+        
+        let viewController = self.instantiateViewController(withIdentifier: T.className)
+        guard let typedViewController = viewController as? T else {
+            fatalError("Unable to cast view controller of type (\(type(of: viewController))) to (\(T.className))")
+        }
+        return typedViewController
+    }
 }


### PR DESCRIPTION
### What this does
Adds a products grid using a `UICollectionView`. Also makes some minor adjustment to the `ViewModel` family of protocols to store the original model inside the view model. Doing so, allows us to pass around view models in the UI layer but still have access to underlying properties (namely GraphQL ID) for queries and mutations.