### PR TITLE
Fix argument types in client API

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.h
@@ -220,7 +220,7 @@ typedef void (^BUYDataTagsListBlock)(NSArray <NSString *> * _Nullable tags, NSUI
 *
 *  @return The associated NSOperation
 */
-- (NSOperation *)getProductTagsInCollection:(NSString *)collectionId page:(NSUInteger)page completion:(BUYDataTagsListBlock)block;
+- (NSOperation *)getProductTagsInCollection:(nullable NSNumber *)collectionId page:(NSUInteger)page completion:(BUYDataTagsListBlock)block;
 
 /**
  *  Fetch a single collection by the handle of the collection.
@@ -251,7 +251,7 @@ typedef void (^BUYDataTagsListBlock)(NSArray <NSString *> * _Nullable tags, NSUI
  *
  *  @return The associated BUYRequestOperation
  */
-- (NSOperation *)getCollectionsByIds:(NSArray<NSString *> *)collectionIds page:(NSUInteger)page completion:(BUYDataCollectionsBlock)block;
+- (NSOperation *)getCollectionsByIds:(NSArray<NSNumber *> *)collectionIds page:(NSUInteger)page completion:(BUYDataCollectionsBlock)block;
 
 /**
  *  Fetches the products in the given collection with the collection's

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.m
@@ -130,16 +130,16 @@ static NSString * const BUYCollectionsKey = @"collection_listings";
 
 - (NSOperation *)getProductTagsPage:(NSUInteger)page completion:(BUYDataTagsListBlock)block
 {
-	return [self getProductTagsInCollection:@"" page:page completion:block];
+	return [self getProductTagsInCollection:nil page:page completion:block];
 }
 
-- (NSOperation *)getProductTagsInCollection:(NSString *)collectionId page:(NSUInteger)page completion:(BUYDataTagsListBlock)block
+- (NSOperation *)getProductTagsInCollection:(NSNumber *)collectionId page:(NSUInteger)page completion:(BUYDataTagsListBlock)block
 {
 	NSMutableDictionary *params = @{
 									@"limit" : @(self.productTagPageSize),
 									@"page"  : @(page),
 									}.mutableCopy;
-	if (collectionId.length) {
+	if (collectionId != nil) {
 		params[@"collection_id"] = collectionId;
 	}
 	
@@ -187,7 +187,7 @@ static NSString * const BUYCollectionsKey = @"collection_listings";
 	}];
 }
 
-- (NSOperation *)getCollectionsByIds:(NSArray<NSString *> *)collectionIds page:(NSUInteger)page completion:(BUYDataCollectionsBlock)block
+- (NSOperation *)getCollectionsByIds:(NSArray<NSNumber *> *)collectionIds page:(NSUInteger)page completion:(BUYDataCollectionsBlock)block
 {
 	NSURL *url = [self urlForCollectionListingsWithParameters:@{
 																@"collection_ids": [collectionIds componentsJoinedByString:@","],


### PR DESCRIPTION
Object identifiers are numbers, not strings.

As a consequence, we need to support a `nil` value for collection ID when fetching product tags.