### PR TITLE
Do not create a collection model without JSON content

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Storefront.m
@@ -164,7 +164,11 @@ static NSString * const BUYCollectionsKey = @"collection_listings";
 	return [self getRequestForURL:url completionHandler:^(NSDictionary *json, NSHTTPURLResponse *response, NSError *error) {
 		BUYCollection *collection = nil;
 		if (json && !error) {
-			collection = (BUYCollection *)[self.modelManager buy_objectWithEntityName:[BUYCollection entityName] JSONDictionary:json[BUYCollectionsKey][0]];
+			NSArray<NSDictionary *> *arrayJSON = json[BUYCollectionsKey];
+			NSDictionary *collectionJSON = [arrayJSON firstObject];
+			if (collectionJSON != nil) {
+				collection = (BUYCollection *)[self.modelManager buy_objectWithEntityName:[BUYCollection entityName] JSONDictionary:collectionJSON];
+			}
 		}
 		block(collection, error);
 	}];


### PR DESCRIPTION
This fixes two bugs at once.

First, we were indexing into an array that could be empty, leading to a crash.

Second, we don't want to create a collection model if we didn't receive one.

I don't consider this an error, but clients will have to support a `nil` result.