### PR TITLE
Product information and HTML parsing.

### DIFF
--- a/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
+++ b/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
@@ -19,6 +19,11 @@
 		9A9FFF111E79C0AD00F6DFF7 /* Fragment+VariantConnectionQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9FFF101E79C0AD00F6DFF7 /* Fragment+VariantConnectionQuery.swift */; };
 		9A9FFF131E79CCC800F6DFF7 /* PaginatedArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9FFF121E79CCC800F6DFF7 /* PaginatedArray.swift */; };
 		9A9FFF1C1E7FF3A800F6DFF7 /* ImageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9FFF1B1E7FF3A800F6DFF7 /* ImageViewModel.swift */; };
+		9A9FFF221E800D9600F6DFF7 /* ProductHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9FFF201E800D9600F6DFF7 /* ProductHeaderCell.swift */; };
+		9A9FFF231E800D9600F6DFF7 /* ProductHeaderCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A9FFF211E800D9600F6DFF7 /* ProductHeaderCell.xib */; };
+		9A9FFF271E80172C00F6DFF7 /* ProductDetailsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9FFF251E80172C00F6DFF7 /* ProductDetailsCell.swift */; };
+		9A9FFF281E80172C00F6DFF7 /* ProductDetailsCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A9FFF261E80172C00F6DFF7 /* ProductDetailsCell.xib */; };
+		9A9FFF2A1E8044BC00F6DFF7 /* HTMLParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9FFF291E8044BC00F6DFF7 /* HTMLParser.swift */; };
 		9AAFAB7B1E60BDF900864A17 /* CollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB7A1E60BDF900864A17 /* CollectionCell.swift */; };
 		9AAFAB7E1E60BE6500864A17 /* ViewModeling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB7D1E60BE6500864A17 /* ViewModeling.swift */; };
 		9AAFAB801E60BE9800864A17 /* ViewModelConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB7F1E60BE9800864A17 /* ViewModelConfigurable.swift */; };
@@ -96,6 +101,11 @@
 		9A9FFF101E79C0AD00F6DFF7 /* Fragment+VariantConnectionQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Fragment+VariantConnectionQuery.swift"; sourceTree = "<group>"; };
 		9A9FFF121E79CCC800F6DFF7 /* PaginatedArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaginatedArray.swift; sourceTree = "<group>"; };
 		9A9FFF1B1E7FF3A800F6DFF7 /* ImageViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageViewModel.swift; sourceTree = "<group>"; };
+		9A9FFF201E800D9600F6DFF7 /* ProductHeaderCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductHeaderCell.swift; sourceTree = "<group>"; };
+		9A9FFF211E800D9600F6DFF7 /* ProductHeaderCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ProductHeaderCell.xib; sourceTree = "<group>"; };
+		9A9FFF251E80172C00F6DFF7 /* ProductDetailsCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDetailsCell.swift; sourceTree = "<group>"; };
+		9A9FFF261E80172C00F6DFF7 /* ProductDetailsCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ProductDetailsCell.xib; sourceTree = "<group>"; };
+		9A9FFF291E8044BC00F6DFF7 /* HTMLParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLParser.swift; sourceTree = "<group>"; };
 		9AAFAB7A1E60BDF900864A17 /* CollectionCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionCell.swift; sourceTree = "<group>"; };
 		9AAFAB7D1E60BE6500864A17 /* ViewModeling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModeling.swift; sourceTree = "<group>"; };
 		9AAFAB7F1E60BE9800864A17 /* ViewModelConfigurable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModelConfigurable.swift; sourceTree = "<group>"; };
@@ -138,6 +148,10 @@
 		9A21F29B1E7ADF9000E00F4B /* Details */ = {
 			isa = PBXGroup;
 			children = (
+				9A9FFF201E800D9600F6DFF7 /* ProductHeaderCell.swift */,
+				9A9FFF211E800D9600F6DFF7 /* ProductHeaderCell.xib */,
+				9A9FFF251E80172C00F6DFF7 /* ProductDetailsCell.swift */,
+				9A9FFF261E80172C00F6DFF7 /* ProductDetailsCell.xib */,
 				9A21F2971E7AD30F00E00F4B /* ProductDetailsViewController.swift */,
 			);
 			name = Details;
@@ -157,6 +171,7 @@
 			isa = PBXGroup;
 			children = (
 				9A9FFEFC1E78432F00F6DFF7 /* Currency.swift */,
+				9A9FFF291E8044BC00F6DFF7 /* HTMLParser.swift */,
 			);
 			name = Formatters;
 			sourceTree = "<group>";
@@ -403,7 +418,9 @@
 				9ADAD4751E563091008AC561 /* LaunchScreen.storyboard in Resources */,
 				9ADAD4721E563091008AC561 /* Assets.xcassets in Resources */,
 				9AAFAB8A1E60C17100864A17 /* ProductCell.xib in Resources */,
+				9A9FFF281E80172C00F6DFF7 /* ProductDetailsCell.xib in Resources */,
 				9ADAD4701E563091008AC561 /* Main.storyboard in Resources */,
+				9A9FFF231E800D9600F6DFF7 /* ProductHeaderCell.xib in Resources */,
 				9AAFAB841E60BF4400864A17 /* CollectionCell.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -415,6 +432,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A9FFF221E800D9600F6DFF7 /* ProductHeaderCell.swift in Sources */,
 				9A21F2981E7AD30F00E00F4B /* ProductDetailsViewController.swift in Sources */,
 				9A8E88511E719A6E0042879D /* Graph.swift in Sources */,
 				9AAFAB861E60C15300864A17 /* ProductViewModel.swift in Sources */,
@@ -427,6 +445,7 @@
 				9A15B73A1E64627A0078E7C5 /* StorefrontTableView.swift in Sources */,
 				9A21F29F1E7EC8AE00E00F4B /* ImageViewController.swift in Sources */,
 				9AAFAB8C1E60C3C700864A17 /* ViewModel.swift in Sources */,
+				9A9FFF2A1E8044BC00F6DFF7 /* HTMLParser.swift in Sources */,
 				9AAFAB7B1E60BDF900864A17 /* CollectionCell.swift in Sources */,
 				9AAFAB941E60D2D000864A17 /* NSObject+Name.swift in Sources */,
 				9AEF61CC1E606EFE0067FA90 /* Fragment+ProductConnectionQuery.swift in Sources */,
@@ -437,6 +456,7 @@
 				9AAFAB821E60BEE000864A17 /* CollectionViewModel.swift in Sources */,
 				9AFA3B871E6DFF530056C5AA /* DepressibleCell.swift in Sources */,
 				9A9FFEEA1E772DF500F6DFF7 /* VariantViewModel.swift in Sources */,
+				9A9FFF271E80172C00F6DFF7 /* ProductDetailsCell.swift in Sources */,
 				9A21F29A1E7AD4FD00E00F4B /* ParallaxViewController.swift in Sources */,
 				9A9FFF1C1E7FF3A800F6DFF7 /* ImageViewModel.swift in Sources */,
 				9AAFAB801E60BE9800864A17 /* ViewModelConfigurable.swift in Sources */,

--- a/Sample Apps/Storefront/Storefront/Base.lproj/Main.storyboard
+++ b/Sample Apps/Storefront/Storefront/Base.lproj/Main.storyboard
@@ -114,7 +114,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="VPS-G8-uAc">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="VPS-G8-uAc">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -144,6 +144,7 @@
                     <connections>
                         <outlet property="headerView" destination="S4d-Jp-5KL" id="7B1-N3-TTY"/>
                         <outlet property="scrollView" destination="VPS-G8-uAc" id="5O9-JR-suo"/>
+                        <outlet property="tableView" destination="VPS-G8-uAc" id="Fr9-5d-OMK"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="RC0-fd-D51" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -172,6 +173,10 @@
         <scene sceneID="Mok-Ul-a0k">
             <objects>
                 <viewController id="YjN-Wq-G4f" customClass="ImageViewController" customModule="Storefront" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Mhz-pO-5Y1"/>
+                        <viewControllerLayoutGuide type="bottom" id="cxb-1W-g4T"/>
+                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Xdf-pA-7Je">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="200"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Sample Apps/Storefront/Storefront/CollectionViewModel.swift
+++ b/Sample Apps/Storefront/Storefront/CollectionViewModel.swift
@@ -48,7 +48,7 @@ final class CollectionViewModel: ViewModel {
         
         self.title       = model.node.title
         self.imageURL    = model.node.image?.src
-        self.description = model.node.descriptionPlainSummary
+        self.description = model.node.descriptionHtml
         
         self.products    = PageableArray(
             with:     model.node.products.edges,

--- a/Sample Apps/Storefront/Storefront/GraphQuery.swift
+++ b/Sample Apps/Storefront/Storefront/GraphQuery.swift
@@ -41,7 +41,7 @@ final class GraphQuery {
                         .node { $0
                             .id()
                             .title()
-                            .descriptionPlainSummary()
+                            .descriptionHtml()
                             .image { $0
                                 .src()
                             }

--- a/Sample Apps/Storefront/Storefront/HTMLParser.swift
+++ b/Sample Apps/Storefront/Storefront/HTMLParser.swift
@@ -1,5 +1,5 @@
 //
-//  Fragment+ProductConnectionQuery.swift
+//  HTMLParser.swift
 //  Storefront
 //
 //  Created by Shopify.
@@ -24,27 +24,28 @@
 //  THE SOFTWARE.
 //
 
-import Buy
+import UIKit
 
-extension Storefront.ProductConnectionQuery {
+final class HTMLParser {
     
-    @discardableResult
-    func fragmentForStandardProduct() -> Storefront.ProductConnectionQuery { return self
-        .pageInfo { $0
-            .hasNextPage()
-        }
-        .edges { $0
-            .cursor()
-            .node { $0
-                .title()
-                .descriptionHtml()
-                .variants(first: 250) { $0
-                    .fragmentForStandardVariant()
-                }
-                .images(first: 250) { $0
-                    .fragmentForStandardProductImage()
-                }
-            }
-        }
+    static func attributedStringFrom(_ html: String, font: String, size: CGFloat) -> NSAttributedString? {
+        
+        var style = ""
+        style += "<style>html { "
+        style += "font-family: \"\(font)\" !important;"
+        style += "font-size: \(size) !important;"
+        style += "}</style>"
+        
+        let styledHTML = html.trimmingCharacters(in: CharacterSet.newlines).appending(style)
+        
+        let options = [
+            NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType,
+        ]
+        
+        return try? NSAttributedString(
+            data:               styledHTML.data(using: .utf8)!,
+            options:            options,
+            documentAttributes: nil
+        )
     }
 }

--- a/Sample Apps/Storefront/Storefront/HTMLParser.swift
+++ b/Sample Apps/Storefront/Storefront/HTMLParser.swift
@@ -37,13 +37,15 @@ final class HTMLParser {
         style += "}</style>"
         
         let styledHTML = html.trimmingCharacters(in: CharacterSet.newlines).appending(style)
+        let htmlData   = styledHTML.data(using: .utf8)!
         
-        let options = [
-            NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType,
+        let options: [String: Any] = [
+            NSDocumentTypeDocumentAttribute      : NSHTMLTextDocumentType,
+            NSCharacterEncodingDocumentAttribute : String.Encoding.utf8.rawValue,
         ]
         
         return try? NSAttributedString(
-            data:               styledHTML.data(using: .utf8)!,
+            data:               htmlData,
             options:            options,
             documentAttributes: nil
         )

--- a/Sample Apps/Storefront/Storefront/ProductDetailsCell.swift
+++ b/Sample Apps/Storefront/Storefront/ProductDetailsCell.swift
@@ -1,5 +1,5 @@
 //
-//  Fragment+ProductConnectionQuery.swift
+//  ProductDetailsCell.swift
 //  Storefront
 //
 //  Created by Shopify.
@@ -24,27 +24,21 @@
 //  THE SOFTWARE.
 //
 
-import Buy
+import UIKit
 
-extension Storefront.ProductConnectionQuery {
+class ProductDetailsCell: UITableViewCell, ViewModelConfigurable {
+    typealias ViewModelType = ProductViewModel
     
-    @discardableResult
-    func fragmentForStandardProduct() -> Storefront.ProductConnectionQuery { return self
-        .pageInfo { $0
-            .hasNextPage()
-        }
-        .edges { $0
-            .cursor()
-            .node { $0
-                .title()
-                .descriptionHtml()
-                .variants(first: 250) { $0
-                    .fragmentForStandardVariant()
-                }
-                .images(first: 250) { $0
-                    .fragmentForStandardProductImage()
-                }
-            }
-        }
+    @IBOutlet private weak var contentLabel: UILabel!
+    
+    var viewModel: ViewModelType?
+    
+    // ----------------------------------
+    //  MARK: - Configure -
+    //
+    func configureFrom(_ viewModel: ViewModelType) {
+        self.viewModel = viewModel
+        
+        self.contentLabel.attributedText = HTMLParser.attributedStringFrom(viewModel.summary, font: "Apple SD Gothic Neo", size: 17.0)
     }
 }

--- a/Sample Apps/Storefront/Storefront/ProductDetailsCell.xib
+++ b/Sample Apps/Storefront/Storefront/ProductDetailsCell.xib
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="90" id="KGk-i7-Jjw" customClass="ProductDetailsCell" customModule="Storefront" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="360" height="92"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="360" height="91"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Inc-gz-9eX">
+                        <rect key="frame" x="15" y="7" width="330" height="70"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Some content to showcase how a product description will be rendered in a table view cell with automatic height." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1la-Bu-vTQ">
+                                <rect key="frame" x="0.0" y="0.0" width="330" height="70"/>
+                                <fontDescription key="fontDescription" name="AppleSDGothicNeo-Regular" family="Apple SD Gothic Neo" pointSize="17"/>
+                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="Inc-gz-9eX" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="7" id="0lU-Yk-QJd"/>
+                    <constraint firstItem="Inc-gz-9eX" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="15" id="1do-bp-Yfe"/>
+                    <constraint firstAttribute="trailing" secondItem="Inc-gz-9eX" secondAttribute="trailing" constant="15" id="B55-sd-SJs"/>
+                    <constraint firstAttribute="bottom" secondItem="Inc-gz-9eX" secondAttribute="bottom" constant="15" id="SIc-R6-rbL"/>
+                </constraints>
+            </tableViewCellContentView>
+            <inset key="separatorInset" minX="9999" minY="0.0" maxX="0.0" maxY="0.0"/>
+            <connections>
+                <outlet property="contentLabel" destination="1la-Bu-vTQ" id="i8Y-84-crm"/>
+            </connections>
+            <point key="canvasLocation" x="-83" y="-61"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Sample Apps/Storefront/Storefront/ProductHeaderCell.swift
+++ b/Sample Apps/Storefront/Storefront/ProductHeaderCell.swift
@@ -1,5 +1,5 @@
 //
-//  Fragment+ProductConnectionQuery.swift
+//  ProductHeaderCell.swift
 //  Storefront
 //
 //  Created by Shopify.
@@ -24,27 +24,23 @@
 //  THE SOFTWARE.
 //
 
-import Buy
+import UIKit
 
-extension Storefront.ProductConnectionQuery {
+class ProductHeaderCell: UITableViewCell, ViewModelConfigurable {
+    typealias ViewModelType = ProductViewModel
     
-    @discardableResult
-    func fragmentForStandardProduct() -> Storefront.ProductConnectionQuery { return self
-        .pageInfo { $0
-            .hasNextPage()
-        }
-        .edges { $0
-            .cursor()
-            .node { $0
-                .title()
-                .descriptionHtml()
-                .variants(first: 250) { $0
-                    .fragmentForStandardVariant()
-                }
-                .images(first: 250) { $0
-                    .fragmentForStandardProductImage()
-                }
-            }
-        }
+    @IBOutlet private weak var titleLabel:  UILabel!
+    @IBOutlet private weak var priceButton: UIButton!
+    
+    var viewModel: ViewModelType?
+    
+    // ----------------------------------
+    //  MARK: - Configure -
+    //
+    func configureFrom(_ viewModel: ViewModelType) {
+        self.viewModel = viewModel
+        
+        self.titleLabel.text = viewModel.title
+        self.priceButton.setTitle(viewModel.price, for: .normal)
     }
 }

--- a/Sample Apps/Storefront/Storefront/ProductHeaderCell.xib
+++ b/Sample Apps/Storefront/Storefront/ProductHeaderCell.xib
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="99" id="KGk-i7-Jjw" customClass="ProductHeaderCell" customModule="Storefront" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="360" height="99"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="360" height="98"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="vpm-Ra-eDu">
+                        <rect key="frame" x="15" y="15" width="330" height="77"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Some awesome bracelet with something else" lineBreakMode="tailTruncation" numberOfLines="2" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jHY-5b-TA1">
+                                <rect key="frame" x="0.0" y="14.5" width="229" height="48"/>
+                                <fontDescription key="fontDescription" name="AppleSDGothicNeo-Bold" family="Apple SD Gothic Neo" pointSize="20"/>
+                                <color key="textColor" white="0.10000000000000001" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Ba-rT-kGe">
+                                <rect key="frame" x="249" y="21.5" width="81" height="34"/>
+                                <color key="backgroundColor" red="0.39108031989999997" green="0.71921610830000005" blue="0.2192518115" alpha="1" colorSpace="calibratedRGB"/>
+                                <fontDescription key="fontDescription" name="AppleSDGothicNeo-Medium" family="Apple SD Gothic Neo" pointSize="17"/>
+                                <inset key="contentEdgeInsets" minX="17" minY="7" maxX="17" maxY="6"/>
+                                <state key="normal" title="$13.99">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                            </button>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="vpm-Ra-eDu" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="15" id="7mU-jB-pq0"/>
+                    <constraint firstAttribute="bottom" secondItem="vpm-Ra-eDu" secondAttribute="bottom" constant="7" id="SWH-9s-3uj"/>
+                    <constraint firstItem="vpm-Ra-eDu" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="15" id="Zt0-t1-BUt"/>
+                    <constraint firstAttribute="trailing" secondItem="vpm-Ra-eDu" secondAttribute="trailing" constant="15" id="wpo-8c-N9B"/>
+                </constraints>
+            </tableViewCellContentView>
+            <inset key="separatorInset" minX="9999" minY="0.0" maxX="0.0" maxY="0.0"/>
+            <connections>
+                <outlet property="priceButton" destination="5Ba-rT-kGe" id="HY0-xp-ett"/>
+                <outlet property="titleLabel" destination="jHY-5b-TA1" id="y6y-dD-oCJ"/>
+            </connections>
+            <point key="canvasLocation" x="97" y="76.5"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Sample Apps/Storefront/Storefront/ProductViewModel.swift
+++ b/Sample Apps/Storefront/Storefront/ProductViewModel.swift
@@ -35,6 +35,7 @@ final class ProductViewModel: ViewModel {
     let cursor:   String
     
     let title:    String
+    let summary:  String
     let price:    String
     let images:   PageableArray<ImageViewModel>
     let variants: PageableArray<VariantViewModel>
@@ -53,6 +54,7 @@ final class ProductViewModel: ViewModel {
         let lowestPrice = variants.first?.price
         
         self.title    = model.node.title
+        self.summary  = model.node.descriptionHtml
         self.price    = lowestPrice == nil ? "No price" : Currency.stringFrom(lowestPrice!)
         
         self.images   = PageableArray(


### PR DESCRIPTION
### What this does

Implements the rest of product details. Since product descriptions are provide in HTML, we needed to implement an HTML -> `NSAttributedString` converter. This class is called `HTMLParser`. It handles the styling and conversion of HTML into a useable attributed string that we display using a simple `UILabel`. Font names and sizes are injected into the HTML string using `<style></style>` tags as this is the only way to apply formatting to the provided HTML.

The product details are displayed using two types of cells:
- `ProductHeaderCell`
- `ProductDetailsCell`