### PR TITLE
Add support for persisting CartItem(s) to disk.

### DIFF
--- a/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
+++ b/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9A0ED6861E83F120008C605E /* Serializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0ED6851E83F120008C605E /* Serializable.swift */; };
+		9A0ED68A1E83FF2D008C605E /* GraphQL+Serializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0ED6891E83FF2D008C605E /* GraphQL+Serializable.swift */; };
 		9A15B73A1E64627A0078E7C5 /* StorefrontTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A15B7391E64627A0078E7C5 /* StorefrontTableView.swift */; };
 		9A21F2981E7AD30F00E00F4B /* ProductDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A21F2971E7AD30F00E00F4B /* ProductDetailsViewController.swift */; };
 		9A21F29A1E7AD4FD00E00F4B /* ParallaxViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A21F2991E7AD4FD00E00F4B /* ParallaxViewController.swift */; };
@@ -100,6 +102,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		9A0ED6851E83F120008C605E /* Serializable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Serializable.swift; sourceTree = "<group>"; };
+		9A0ED6891E83FF2D008C605E /* GraphQL+Serializable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GraphQL+Serializable.swift"; sourceTree = "<group>"; };
 		9A15B7391E64627A0078E7C5 /* StorefrontTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorefrontTableView.swift; sourceTree = "<group>"; };
 		9A21F2971E7AD30F00E00F4B /* ProductDetailsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDetailsViewController.swift; sourceTree = "<group>"; };
 		9A21F2991E7AD4FD00E00F4B /* ParallaxViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParallaxViewController.swift; sourceTree = "<group>"; };
@@ -167,6 +171,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9A0ED6881E83FF1B008C605E /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				9A0ED6891E83FF2D008C605E /* GraphQL+Serializable.swift */,
+			);
+			name = Extensions;
+			sourceTree = "<group>";
+		};
 		9A21F29B1E7ADF9000E00F4B /* Details */ = {
 			isa = PBXGroup;
 			children = (
@@ -181,6 +193,7 @@
 			children = (
 				9A8E88501E719A6E0042879D /* Graph.swift */,
 				9A8E88591E719EB20042879D /* GraphQuery.swift */,
+				9A0ED6881E83FF1B008C605E /* Extensions */,
 				9AEF61CA1E606EEB0067FA90 /* Fragments */,
 			);
 			name = API;
@@ -284,6 +297,7 @@
 				9AAFAB8B1E60C3C700864A17 /* ViewModel.swift */,
 				9AAFAB7D1E60BE6500864A17 /* ViewModeling.swift */,
 				9AAFAB7F1E60BE9800864A17 /* ViewModelConfigurable.swift */,
+				9A0ED6851E83F120008C605E /* Serializable.swift */,
 			);
 			name = Protocols;
 			sourceTree = "<group>";
@@ -536,9 +550,11 @@
 				9AC583CF1E81BF96005DB319 /* CartCell.swift in Sources */,
 				9AAFAB8F1E60C6AC00864A17 /* UIImageView+Remote.swift in Sources */,
 				9AFA3B7D1E6DB7110056C5AA /* ProductsViewController.swift in Sources */,
+				9A0ED6861E83F120008C605E /* Serializable.swift in Sources */,
 				9A9FFF051E796F2100F6DFF7 /* Paginating.swift in Sources */,
 				9ADAD46D1E563091008AC561 /* CollectionsViewController.swift in Sources */,
 				9AAFAB821E60BEE000864A17 /* CollectionViewModel.swift in Sources */,
+				9A0ED68A1E83FF2D008C605E /* GraphQL+Serializable.swift in Sources */,
 				9AFA3B871E6DFF530056C5AA /* DepressibleCell.swift in Sources */,
 				9A9FFEEA1E772DF500F6DFF7 /* VariantViewModel.swift in Sources */,
 				9A9FFF4A1E81B59700F6DFF7 /* CartController.swift in Sources */,

--- a/Sample Apps/Storefront/Storefront/CartItem.swift
+++ b/Sample Apps/Storefront/Storefront/CartItem.swift
@@ -26,7 +26,13 @@
 
 import Foundation
 
-class CartItem: Equatable, Hashable {
+class CartItem: Equatable, Hashable, Serializable {
+    
+    private struct Key {
+        static let product  = "product"
+        static let quantity = "quantity"
+        static let variant  = "variant"
+    }
     
     let product: ProductViewModel
     let variant: VariantViewModel
@@ -36,10 +42,41 @@ class CartItem: Equatable, Hashable {
     // ----------------------------------
     //  MARK: - Init -
     //
-    init(product: ProductViewModel, variant: VariantViewModel, quantity: Int = 1) {
+    required init(product: ProductViewModel, variant: VariantViewModel, quantity: Int = 1) {
         self.product  = product
         self.variant  = variant
         self.quantity = quantity
+    }
+    
+    // ----------------------------------
+    //  MARK: - Serializable -
+    //
+    static func deserialize(from representation: SerializedRepresentation) -> Self? {
+        guard let product = ProductViewModel.deserialize(from: representation[Key.product] as! SerializedRepresentation) else {
+            return nil
+        }
+        
+        guard let variant = VariantViewModel.deserialize(from: representation[Key.variant] as! SerializedRepresentation) else {
+            return nil
+        }
+        
+        guard let quantity = representation[Key.quantity] as? Int else {
+            return nil
+        }
+        
+        return self.init(
+            product:  product,
+            variant:  variant,
+            quantity: quantity
+        )
+    }
+    
+    func serialize() -> SerializedRepresentation {
+        return [
+            Key.quantity : self.quantity,
+            Key.product  : self.product.serialize(),
+            Key.variant  : self.variant.serialize(),
+        ]
     }
 }
 

--- a/Sample Apps/Storefront/Storefront/CartItemViewModel.swift
+++ b/Sample Apps/Storefront/Storefront/CartItemViewModel.swift
@@ -26,7 +26,7 @@
 
 import Foundation
 
-class CartItemViewModel: ViewModel {
+final class CartItemViewModel: ViewModel {
     typealias ModelType = CartItem
     
     let model: ModelType

--- a/Sample Apps/Storefront/Storefront/CartViewController.swift
+++ b/Sample Apps/Storefront/Storefront/CartViewController.swift
@@ -95,17 +95,16 @@ extension CartViewController: CartCellDelegate {
     
     func cartCell(_ cell: CartCell, didUpdateQuantity quantity: Int) {
         if let indexPath = self.tableView.indexPath(for: cell) {
-            let cartItem  = CartController.shared.items[indexPath.row]
             
-            if quantity != cartItem.quantity {
-                cartItem.quantity = quantity
+            let didUpdate = CartController.shared.updateQuantity(quantity, at: indexPath.row)
+            if didUpdate {
                 
                 self.tableView.beginUpdates()
                 self.tableView.reloadRows(at: [indexPath], with: .none)
                 self.tableView.endUpdates()
+                
+                self.updateSubtotal()
             }
-            
-            self.updateSubtotal()
         }
     }
 }

--- a/Sample Apps/Storefront/Storefront/GraphQL+Serializable.swift
+++ b/Sample Apps/Storefront/Storefront/GraphQL+Serializable.swift
@@ -1,5 +1,5 @@
 //
-//  AppDelegate.swift
+//  GraphQL+Serializable.swift
 //  Storefront
 //
 //  Created by Shopify.
@@ -24,25 +24,15 @@
 //  THE SOFTWARE.
 //
 
-import UIKit
+import Buy
 
-@UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate {
-
-    var window: UIWindow?
-
-    // ----------------------------------
-    //  MARK: - Application Launch -
-    //
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        
-        /* ----------------------------------------
-         ** Initialize the cart controller and pre-
-         ** load any cached cart items.
-         */
-        _ = CartController.shared
-        
-        return true
+extension GraphQL.AbstractResponse: Serializable {
+    
+    static func deserialize(from representation: SerializedRepresentation) -> Self? {
+        return try? self.init(fields: representation)
+    }
+    
+    func serialize() -> SerializedRepresentation {
+        return self.fields
     }
 }
-

--- a/Sample Apps/Storefront/Storefront/Serializable.swift
+++ b/Sample Apps/Storefront/Storefront/Serializable.swift
@@ -1,5 +1,5 @@
 //
-//  AppDelegate.swift
+//  Serializable.swift
 //  Storefront
 //
 //  Created by Shopify.
@@ -24,25 +24,31 @@
 //  THE SOFTWARE.
 //
 
-import UIKit
+import Foundation
 
-@UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate {
+typealias SerializedRepresentation = [String : Any]
 
-    var window: UIWindow?
-
-    // ----------------------------------
-    //  MARK: - Application Launch -
-    //
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        
-        /* ----------------------------------------
-         ** Initialize the cart controller and pre-
-         ** load any cached cart items.
-         */
-        _ = CartController.shared
-        
-        return true
-    }
+protocol Serializable {
+    
+    static func deserialize(from representation: SerializedRepresentation) -> Self?
+    
+    func serialize() -> SerializedRepresentation
 }
 
+// ----------------------------------
+//  MARK: - Collection Conveniences -
+//
+extension Array where Element: Serializable {
+    
+    static func deserialize(from representation: [SerializedRepresentation]) -> [Element]? {
+        return representation.flatMap {
+            Element.deserialize(from: $0)
+        }
+    }
+    
+    func serialize() -> [SerializedRepresentation] {
+        return self.map {
+            $0.serialize()
+        }
+    }
+}

--- a/Sample Apps/Storefront/Storefront/ViewModel.swift
+++ b/Sample Apps/Storefront/Storefront/ViewModel.swift
@@ -26,11 +26,28 @@
 
 import Foundation
 
-protocol ViewModel {
+protocol ViewModel: Serializable {
     
-    associatedtype ModelType
+    associatedtype ModelType: Serializable
     
     var model: ModelType { get }
     
     init(from model: ModelType)
+}
+
+// ----------------------------------
+//  MARK: - Serializable -
+//
+extension ViewModel {
+    
+    static func deserialize(from representation: SerializedRepresentation) -> Self? {
+        if let model = ModelType.deserialize(from: representation) {
+            return Self.init(from: model)
+        }
+        return nil
+    }
+    
+    func serialize() -> SerializedRepresentation {
+        return self.model.serialize()
+    }
 }


### PR DESCRIPTION
### What this does

- adds Serializable protocol that all GraphQL entities automatically conform to by extending AbstractResponse
- conforms `CartItem` to Serializable
- enables `CartController` to flush cart items to disk on a background thread whenever there’s changes
- enables `CartController` to read from cached cart on disk during initialization