### PR TITLE
Apple Pay integration

### DIFF
--- a/Buy.xcodeproj/project.pbxproj
+++ b/Buy.xcodeproj/project.pbxproj
@@ -97,6 +97,16 @@
 		9A4068C41E8AE613000254CD /* UserError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A40686A1E8AE613000254CD /* UserError.swift */; };
 		9A4068C51E8AE613000254CD /* WeightUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A40686B1E8AE613000254CD /* WeightUnit.swift */; };
 		9A4068C61E8AE613000254CD /* Storefront.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A40686C1E8AE613000254CD /* Storefront.swift */; };
+		9A4068E51E8E7659000254CD /* Pay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A4068DC1E8E7658000254CD /* Pay.framework */; };
+		9A4068EA1E8E7659000254CD /* PayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4068E91E8E7659000254CD /* PayTests.swift */; };
+		9A4068EC1E8E7659000254CD /* Pay.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A4068DE1E8E7659000254CD /* Pay.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9A4068F91E8E767B000254CD /* PayAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4068F31E8E767B000254CD /* PayAddress.swift */; };
+		9A4068FA1E8E767B000254CD /* PayCheckout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4068F41E8E767B000254CD /* PayCheckout.swift */; };
+		9A4068FB1E8E767B000254CD /* PayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4068F51E8E767B000254CD /* PayController.swift */; };
+		9A4068FC1E8E767B000254CD /* PayCurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4068F61E8E767B000254CD /* PayCurrency.swift */; };
+		9A4068FD1E8E767B000254CD /* PayLineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4068F71E8E767B000254CD /* PayLineItem.swift */; };
+		9A4068FE1E8E767B000254CD /* PayShippingRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4068F81E8E767B000254CD /* PayShippingRate.swift */; };
+		9A40690A1E8E82E2000254CD /* PassKit+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4069091E8E82E2000254CD /* PassKit+Extensions.swift */; };
 		9AAFAB721E60766E00864A17 /* Global.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB711E60766E00864A17 /* Global.swift */; };
 		9AAFAB751E60809400864A17 /* GraphResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB741E60809400864A17 /* GraphResult.swift */; };
 		9AAFAB771E6080A500864A17 /* GraphError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB761E6080A500864A17 /* GraphError.swift */; };
@@ -109,6 +119,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		9A4068E61E8E7659000254CD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9AEF60EA1E5F42D90067FA90 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9A4068DB1E8E7658000254CD;
+			remoteInfo = Pay;
+		};
 		9AFA38F01E64850A0056C5AA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9AEF60EA1E5F42D90067FA90 /* Project object */;
@@ -209,6 +226,19 @@
 		9A40686A1E8AE613000254CD /* UserError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserError.swift; sourceTree = "<group>"; };
 		9A40686B1E8AE613000254CD /* WeightUnit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeightUnit.swift; sourceTree = "<group>"; };
 		9A40686C1E8AE613000254CD /* Storefront.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Storefront.swift; sourceTree = "<group>"; };
+		9A4068DC1E8E7658000254CD /* Pay.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pay.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A4068DE1E8E7659000254CD /* Pay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Pay.h; sourceTree = "<group>"; };
+		9A4068DF1E8E7659000254CD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9A4068E41E8E7659000254CD /* PayTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PayTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A4068E91E8E7659000254CD /* PayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayTests.swift; sourceTree = "<group>"; };
+		9A4068EB1E8E7659000254CD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9A4068F31E8E767B000254CD /* PayAddress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayAddress.swift; sourceTree = "<group>"; };
+		9A4068F41E8E767B000254CD /* PayCheckout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayCheckout.swift; sourceTree = "<group>"; };
+		9A4068F51E8E767B000254CD /* PayController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayController.swift; sourceTree = "<group>"; };
+		9A4068F61E8E767B000254CD /* PayCurrency.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayCurrency.swift; sourceTree = "<group>"; };
+		9A4068F71E8E767B000254CD /* PayLineItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayLineItem.swift; sourceTree = "<group>"; };
+		9A4068F81E8E767B000254CD /* PayShippingRate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayShippingRate.swift; sourceTree = "<group>"; };
+		9A4069091E8E82E2000254CD /* PassKit+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PassKit+Extensions.swift"; sourceTree = "<group>"; };
 		9AAFAB711E60766E00864A17 /* Global.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Global.swift; sourceTree = "<group>"; };
 		9AAFAB741E60809400864A17 /* GraphResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphResult.swift; sourceTree = "<group>"; };
 		9AAFAB761E6080A500864A17 /* GraphError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphError.swift; sourceTree = "<group>"; };
@@ -224,6 +254,21 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		9A4068D81E8E7658000254CD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9A4068E11E8E7659000254CD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A4068E51E8E7659000254CD /* Pay.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9AEF60EF1E5F42D90067FA90 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -338,6 +383,31 @@
 			path = Storefront;
 			sourceTree = "<group>";
 		};
+		9A4068DD1E8E7659000254CD /* Pay */ = {
+			isa = PBXGroup;
+			children = (
+				9A4068DE1E8E7659000254CD /* Pay.h */,
+				9A4068F51E8E767B000254CD /* PayController.swift */,
+				9A4068F41E8E767B000254CD /* PayCheckout.swift */,
+				9A4068F71E8E767B000254CD /* PayLineItem.swift */,
+				9A4068F61E8E767B000254CD /* PayCurrency.swift */,
+				9A4068F31E8E767B000254CD /* PayAddress.swift */,
+				9A4068F81E8E767B000254CD /* PayShippingRate.swift */,
+				9A4069091E8E82E2000254CD /* PassKit+Extensions.swift */,
+				9A4068DF1E8E7659000254CD /* Info.plist */,
+			);
+			path = Pay;
+			sourceTree = "<group>";
+		};
+		9A4068E81E8E7659000254CD /* PayTests */ = {
+			isa = PBXGroup;
+			children = (
+				9A4068E91E8E7659000254CD /* PayTests.swift */,
+				9A4068EB1E8E7659000254CD /* Info.plist */,
+			);
+			path = PayTests;
+			sourceTree = "<group>";
+		};
 		9AAFAB701E60766300864A17 /* Global */ = {
 			isa = PBXGroup;
 			children = (
@@ -362,6 +432,8 @@
 				9AFA3B6B1E6D9A5E0056C5AA /* Support */,
 				9AEF60F51E5F42D90067FA90 /* Buy */,
 				9AFA38EB1E64850A0056C5AA /* BuyTests */,
+				9A4068DD1E8E7659000254CD /* Pay */,
+				9A4068E81E8E7659000254CD /* PayTests */,
 				9AEF60F41E5F42D90067FA90 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -371,6 +443,8 @@
 			children = (
 				9AEF60F31E5F42D90067FA90 /* Buy.framework */,
 				9AFA38EA1E64850A0056C5AA /* BuyTests.xctest */,
+				9A4068DC1E8E7658000254CD /* Pay.framework */,
+				9A4068E41E8E7659000254CD /* PayTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -426,6 +500,14 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		9A4068D91E8E7658000254CD /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A4068EC1E8E7659000254CD /* Pay.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9AEF60F01E5F42D90067FA90 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -437,6 +519,42 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		9A4068DB1E8E7658000254CD /* Pay */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9A4068F11E8E7659000254CD /* Build configuration list for PBXNativeTarget "Pay" */;
+			buildPhases = (
+				9A4068D71E8E7658000254CD /* Sources */,
+				9A4068D81E8E7658000254CD /* Frameworks */,
+				9A4068D91E8E7658000254CD /* Headers */,
+				9A4068DA1E8E7658000254CD /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Pay;
+			productName = Pay;
+			productReference = 9A4068DC1E8E7658000254CD /* Pay.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		9A4068E31E8E7659000254CD /* PayTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9A4068F21E8E7659000254CD /* Build configuration list for PBXNativeTarget "PayTests" */;
+			buildPhases = (
+				9A4068E01E8E7659000254CD /* Sources */,
+				9A4068E11E8E7659000254CD /* Frameworks */,
+				9A4068E21E8E7659000254CD /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				9A4068E71E8E7659000254CD /* PBXTargetDependency */,
+			);
+			name = PayTests;
+			productName = PayTests;
+			productReference = 9A4068E41E8E7659000254CD /* PayTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		9AEF60F21E5F42D90067FA90 /* Buy */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9AEF60FB1E5F42D90067FA90 /* Build configuration list for PBXNativeTarget "Buy" */;
@@ -479,10 +597,21 @@
 		9AEF60EA1E5F42D90067FA90 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0820;
+				LastSwiftUpdateCheck = 0830;
 				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = "Shopify Inc.";
 				TargetAttributes = {
+					9A4068DB1E8E7658000254CD = {
+						CreatedOnToolsVersion = 8.3;
+						DevelopmentTeam = A7XGC83MZE;
+						LastSwiftMigration = 0830;
+						ProvisioningStyle = Automatic;
+					};
+					9A4068E31E8E7659000254CD = {
+						CreatedOnToolsVersion = 8.3;
+						DevelopmentTeam = A7XGC83MZE;
+						ProvisioningStyle = Automatic;
+					};
 					9AEF60F21E5F42D90067FA90 = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = A7XGC83MZE;
@@ -509,11 +638,27 @@
 			targets = (
 				9AEF60F21E5F42D90067FA90 /* Buy */,
 				9AFA38E91E64850A0056C5AA /* BuyTests */,
+				9A4068DB1E8E7658000254CD /* Pay */,
+				9A4068E31E8E7659000254CD /* PayTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		9A4068DA1E8E7658000254CD /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9A4068E21E8E7659000254CD /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9AEF60F11E5F42D90067FA90 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -531,6 +676,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		9A4068D71E8E7658000254CD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A4068FA1E8E767B000254CD /* PayCheckout.swift in Sources */,
+				9A4068FC1E8E767B000254CD /* PayCurrency.swift in Sources */,
+				9A40690A1E8E82E2000254CD /* PassKit+Extensions.swift in Sources */,
+				9A4068FE1E8E767B000254CD /* PayShippingRate.swift in Sources */,
+				9A4068F91E8E767B000254CD /* PayAddress.swift in Sources */,
+				9A4068FB1E8E767B000254CD /* PayController.swift in Sources */,
+				9A4068FD1E8E767B000254CD /* PayLineItem.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9A4068E01E8E7659000254CD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A4068EA1E8E7659000254CD /* PayTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9AEF60EE1E5F42D90067FA90 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -645,6 +812,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		9A4068E71E8E7659000254CD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9A4068DB1E8E7658000254CD /* Pay */;
+			targetProxy = 9A4068E61E8E7659000254CD /* PBXContainerItemProxy */;
+		};
 		9AFA38F11E64850A0056C5AA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 9AEF60F21E5F42D90067FA90 /* Buy */;
@@ -653,6 +825,81 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		9A4068ED1E8E7659000254CD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = A7XGC83MZE;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Pay/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.shopify.Pay;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		9A4068EE1E8E7659000254CD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = A7XGC83MZE;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Pay/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.shopify.Pay;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
+		9A4068EF1E8E7659000254CD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				DEVELOPMENT_TEAM = A7XGC83MZE;
+				INFOPLIST_FILE = PayTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.shopify.PayTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		9A4068F01E8E7659000254CD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				DEVELOPMENT_TEAM = A7XGC83MZE;
+				INFOPLIST_FILE = PayTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.shopify.PayTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
 		9AEF60F91E5F42D90067FA90 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -764,6 +1011,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Buy/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.shopify.Buy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -784,6 +1032,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Buy/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.shopify.Buy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -819,6 +1068,22 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		9A4068F11E8E7659000254CD /* Build configuration list for PBXNativeTarget "Pay" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9A4068ED1E8E7659000254CD /* Debug */,
+				9A4068EE1E8E7659000254CD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		9A4068F21E8E7659000254CD /* Build configuration list for PBXNativeTarget "PayTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9A4068EF1E8E7659000254CD /* Debug */,
+				9A4068F01E8E7659000254CD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		9AEF60ED1E5F42D90067FA90 /* Build configuration list for PBXProject "Buy" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Pay/Info.plist
+++ b/Pay/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Pay/PassKit+Extensions.swift
+++ b/Pay/PassKit+Extensions.swift
@@ -1,0 +1,55 @@
+//
+//  PassKit+Extensions.swift
+//  Pay
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+import PassKit
+
+// ----------------------------------
+//  MARK: - Decimal -
+//
+internal extension Decimal {
+    
+    func summaryItemNamed(_ name: String) -> PKPaymentSummaryItem {
+        return PKPaymentSummaryItem(label: name, amount: self)
+    }
+}
+
+internal extension Double {
+    
+    func summaryItemNamed(_ name: String) -> PKPaymentSummaryItem {
+        return Decimal(self).summaryItemNamed(name)
+    }
+}
+
+// ----------------------------------
+//  MARK: - PKPaymentSummaryItem -
+//
+internal extension PKPaymentSummaryItem {
+    
+    convenience init(label: String, amount: Decimal) {
+        self.init(label: label, amount: amount as NSDecimalNumber)
+    }
+}

--- a/Pay/Pay.h
+++ b/Pay/Pay.h
@@ -1,0 +1,37 @@
+//
+//  Pay.h
+//  Pay
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for Pay.
+FOUNDATION_EXPORT double PayVersionNumber;
+
+//! Project version string for Pay.
+FOUNDATION_EXPORT const unsigned char PayVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <Pay/PublicHeader.h>
+
+

--- a/Pay/PayAddress.swift
+++ b/Pay/PayAddress.swift
@@ -1,0 +1,131 @@
+//
+//  PayAddress.swift
+//  Pay
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+import PassKit
+
+public struct PayPostalAddress {
+    
+    public let city:         String?
+    public let country:      String?
+    public let countryCode:  String?
+    public let province:     String?
+    public let zip:          String?
+    
+    // ----------------------------------
+    //  MARK: - Init -
+    //
+    public init(city: String? = nil,
+         country:     String? = nil,
+         countryCode: String? = nil,
+         province:    String? = nil,
+         zip:         String? = nil) {
+        
+        self.city         = city
+        self.country      = country
+        self.countryCode  = countryCode
+        self.province     = province
+        self.zip          = zip
+    }
+}
+
+public struct PayAddress {
+    
+    public let addressLine1: String?
+    public let addressLine2: String?
+    public let city:         String?
+    public let country:      String?
+    public let countryCode:  String?
+    public let province:     String?
+    public let zip:          String?
+    
+    public let firstName:    String?
+    public let lastName:     String?
+    public let phone:        String?
+    
+    // ----------------------------------
+    //  MARK: - Init -
+    //
+    public init(addressLine1: String? = nil,
+        addressLine2: String? = nil,
+        city:         String? = nil,
+        country:      String? = nil,
+        countryCode:  String? = nil,
+        province:     String? = nil,
+        zip:          String? = nil,
+        
+        firstName:    String? = nil,
+        lastName:     String? = nil,
+        phone:        String? = nil) {
+        
+        self.addressLine1 = addressLine1
+        self.addressLine2 = addressLine2
+        self.city         = city
+        self.country      = country
+        self.countryCode  = countryCode
+        self.province     = province
+        self.zip          = zip
+        
+        self.firstName    = firstName
+        self.lastName     = lastName
+        self.phone        = phone
+    }
+}
+
+// ----------------------------------
+//  MARK: - PassKit -
+//
+internal extension PayPostalAddress {
+    
+    init(with address: CNPostalAddress) {
+        self.init(
+            city:        address.city,
+            country:     address.country,
+            countryCode: address.isoCountryCode,
+            province:    address.state,
+            zip:         address.postalCode
+        )
+    }
+}
+
+internal extension PayAddress {
+    
+    init(with contact: PKContact) {
+        let lines = contact.postalAddress!.street.components(separatedBy: .newlines)
+        self.init(
+            addressLine1: lines.count > 0 ? lines[0] : nil,
+            addressLine2: lines.count > 1 ? lines[1] : nil,
+            city:         contact.postalAddress!.city,
+            country:      contact.postalAddress!.country,
+            countryCode:  contact.postalAddress!.isoCountryCode,
+            province:     contact.postalAddress!.state,
+            zip:          contact.postalAddress!.postalCode,
+            firstName:    contact.name?.givenName,
+            lastName:     contact.name?.familyName,
+            phone:        contact.phoneNumber?.stringValue
+        )
+    }
+}

--- a/Pay/PayCheckout.swift
+++ b/Pay/PayCheckout.swift
@@ -1,0 +1,107 @@
+//
+//  PayCheckout.swift
+//  Pay
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+import PassKit
+
+public struct PayCheckout {
+
+    public let hasLineItems:    Bool
+    public let hasDiscount:     Bool
+    public let needsShipping:   Bool
+    
+    public let lineItems:       [PayLineItem]
+    public let shippingAddress: PayAddress?
+    public let shippingRate:    PayShippingRate?
+    
+    public let discountAmount:  Decimal
+    public let subtotalPrice:   Decimal
+    public let totalTax:        Decimal
+    public let paymentDue:      Decimal
+    
+    // ----------------------------------
+    //  MARK: - Init -
+    //
+    public init(lineItems: [PayLineItem], shippingAddress: PayAddress?, shippingRate: PayShippingRate?, discountAmount: Decimal, subtotalPrice: Decimal, needsShipping: Bool, totalTax: Decimal, paymentDue: Decimal) {
+        
+        self.lineItems       = lineItems
+        self.shippingAddress = shippingAddress
+        self.shippingRate    = shippingRate
+        
+        self.discountAmount  = discountAmount
+        self.subtotalPrice   = subtotalPrice
+        self.totalTax        = totalTax
+        self.paymentDue      = paymentDue
+        
+        self.hasLineItems    = !lineItems.isEmpty
+        self.hasDiscount     = false // TODO: Add discount
+        self.needsShipping   = needsShipping
+    }
+}
+
+// ----------------------------------
+//  MARK: - PassKits -
+//
+internal extension PayCheckout {
+    
+    var summaryItems: [PKPaymentSummaryItem] {
+        var summaryItems: [PKPaymentSummaryItem] = []
+        
+        if self.hasLineItems /* or has discount */ {
+            summaryItems.append(self.lineItems.totalPrice.summaryItemNamed("CART TOTAL"))
+        }
+        
+        // TODO: if self.hasDiscount { add discount summary item }
+        
+        //        if (hasDiscount) {
+        //            NSString *discountLabel = [self.discount.code length] > 0 ? [NSString stringWithFormat:@"DISCOUNT (%@)", self.discount.code] : @"DISCOUNT";
+        //            [summaryItems addObject:[PKPaymentSummaryItem summaryItemWithLabel:discountLabel amount:[self.discount.amount buy_decimalNumberAsNegative]]];
+        //        }
+        
+        summaryItems.append(self.subtotalPrice.summaryItemNamed("SUBTOTAL"))
+        
+        if let shippingRate = self.shippingRate, shippingRate.price > 0.0 {
+            summaryItems.append(shippingRate.price.summaryItemNamed("SHIPPING"))
+        }
+        
+        if self.totalTax > 0.0 {
+            summaryItems.append(self.totalTax.summaryItemNamed("TAXES"))
+        }
+        
+        // TODO: if !self.giftCards.isEmpty { add gift card summary item }
+        
+        //        if ([self.giftCards count] > 0) {
+        //            for (BUYGiftCard *giftCard in self.giftCards) {
+        //                NSString *giftCardLabel = [giftCard.lastCharacters length] > 0 ? [NSString stringWithFormat:@"GIFT CARD (•••• %@)", giftCard.lastCharacters] : @"GIFT CARD";
+        //                [summaryItems addObject:[PKPaymentSummaryItem summaryItemWithLabel:giftCardLabel amount:giftCard.amountUsed ? [giftCard.amountUsed buy_decimalNumberAsNegative] : [giftCard.balance buy_decimalNumberAsNegative]]];
+        //            }
+        //        }
+        
+        summaryItems.append(self.paymentDue.summaryItemNamed("TOTAL"))
+        
+        return summaryItems
+    }
+}

--- a/Pay/PayController.swift
+++ b/Pay/PayController.swift
@@ -1,0 +1,187 @@
+//
+//  PayController.swift
+//  Pay
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+import PassKit
+
+public protocol PayControllerDelegate: class {
+    func payController(_ payController: PayController, didRequestShippingRatesFor address: PayPostalAddress, provide: @escaping (PayCheckout, [PayShippingRate]) -> Void)
+    func payController(_ payController: PayController, didSelectShippingRate shippingRate: PayShippingRate, provide: @escaping  (PayCheckout) -> Void)
+    func payController(_ payController: PayController, didCompletePayment token: Data, checkout: PayCheckout, completeTransaction: @escaping (PayController.TransactionStatus) -> Void)
+    func payControllerDidFinish(_ payController: PayController)
+}
+
+public class PayController: NSObject {
+    
+    public enum TransactionStatus {
+        case success
+        case failure
+    }
+    
+    public weak var delegate: PayControllerDelegate?
+    
+    public let merchantID: String
+    
+    public fileprivate(set) var currency:      PayCurrency?
+    public fileprivate(set) var checkout:      PayCheckout?
+    public fileprivate(set) var shippingRates: [PayShippingRate]?
+    
+    // ----------------------------------
+    //  MARK: - Init -
+    //
+    public init(merchantID: String) {
+        self.merchantID = merchantID
+    }
+    
+    // ----------------------------------
+    //  MARK: - Begin Checkout -
+    //
+    public func authorizePaymentUsing(_ checkout: PayCheckout, currency: PayCurrency) {
+        self.checkout = checkout
+        self.currency = currency
+        
+        let paymentRequest  = self.paymentRequestUsing(checkout, currency: currency, merchantID: self.merchantID)
+        let controller      = PKPaymentAuthorizationController(paymentRequest: paymentRequest)
+        controller.delegate = self
+        controller.present(completion: nil)
+    }
+    
+    // ----------------------------------
+    //  MARK: - Payment Creation -
+    //
+    private func paymentRequestUsing(_ checkout: PayCheckout, currency: PayCurrency, merchantID: String) -> PKPaymentRequest {
+        let request                           = PKPaymentRequest()
+        request.countryCode                   = currency.countryCode
+        request.currencyCode                  = currency.currencyCode
+        request.merchantIdentifier            = merchantID
+        request.requiredBillingAddressFields  = .all
+        request.requiredShippingAddressFields = checkout.needsShipping ? [.all] : [.email, .phone]
+        request.supportedNetworks             = [.visa, .masterCard, .amex]
+        request.merchantCapabilities          = [.capability3DS]
+        request.paymentSummaryItems           = checkout.summaryItems
+        
+        return request
+    }
+}
+
+// ------------------------------------------------------
+//  MARK: - PKPaymentAuthorizationControllerDelegate -
+//
+extension PayController: PKPaymentAuthorizationControllerDelegate {
+    
+    // -------------------------------------------------------
+    //  MARK: - PKPaymentAuthorizationControllerDelegate -
+    //
+    public func paymentAuthorizationController(_ controller: PKPaymentAuthorizationController, didAuthorizePayment payment: PKPayment, completion: @escaping (PKPaymentAuthorizationStatus) -> Void) {
+     
+        print("Authorized payment. Completing...")
+        self.delegate?.payController(self, didCompletePayment: payment.token.paymentData, checkout: self.checkout!, completeTransaction: { status in
+            
+            print("Completion status : \(status)")
+            
+            switch status {
+            case .success: completion(.success)
+            case .failure: completion(.failure)
+            }
+        })
+    }
+    
+    public func paymentAuthorizationController(_ controller: PKPaymentAuthorizationController, didSelectShippingContact contact: PKContact, completion: @escaping (PKPaymentAuthorizationStatus, [PKShippingMethod], [PKPaymentSummaryItem]) -> Void) {
+        print("Selecting shipping contact...")
+        
+        guard let postalAddress = contact.postalAddress else {
+            completion(.invalidShippingPostalAddress, [], self.checkout!.summaryItems)
+            return
+        }
+        
+        let payPostalAddress = PayPostalAddress(with: postalAddress)
+        
+        /* ---------------------------------
+         ** Request the delegate to provide
+         ** shipping rates for the given
+         ** postal address. The partial info
+         ** should be enough to obtain rates.
+         */
+        self.delegate?.payController(self, didRequestShippingRatesFor: payPostalAddress, provide: { updatedCheckout, shippingRates in
+            
+            /* ---------------------------------
+             ** The delegate has an opportunity
+             ** to return empty shipping rates
+             ** which indicates invalid or incomplete
+             ** postal address.
+             */
+            guard !shippingRates.isEmpty else {
+                completion(.invalidShippingPostalAddress, [], self.checkout!.summaryItems)
+                return
+            }
+            
+            self.checkout      = updatedCheckout
+            self.shippingRates = shippingRates
+            
+            /* -----------------------------------------
+             ** Give the delegate a chance to update the
+             ** checkout with the first shipping rate as
+             ** the default. Apple Pay selects it but
+             ** doesn't invoke the delegate method.
+             */
+            self.delegate?.payController(self, didSelectShippingRate: shippingRates.first!, provide: { updatedCheckout in
+                self.checkout = updatedCheckout
+                
+                print("Selected shipping contact.")
+                completion(.success, shippingRates.summaryItems, updatedCheckout.summaryItems)
+            })
+        })
+    }
+    
+    public func paymentAuthorizationController(_ controller: PKPaymentAuthorizationController, didSelectShippingMethod shippingMethod: PKShippingMethod, completion: @escaping (PKPaymentAuthorizationStatus, [PKPaymentSummaryItem]) -> Void) {
+        print("Selecting delivery method...")
+        
+        /* --------------------------------------
+         ** This should never fail since shipping
+         ** methods are mapped 1:1 from shipping
+         ** rates.
+         */
+        guard let shippingRate = self.shippingRates!.shippingRateFor(shippingMethod) else {
+            completion(.failure, self.checkout!.summaryItems)
+            return
+        }
+        
+        self.delegate?.payController(self, didSelectShippingRate: shippingRate, provide: { updatedCheckout in
+            self.checkout = updatedCheckout
+            
+            print("Selected delivery method.")
+            completion(.success, updatedCheckout.summaryItems)
+        })
+    }
+    
+    public func paymentAuthorizationControllerDidFinish(_ controller: PKPaymentAuthorizationController) {
+        
+        print("Dismissing authorization controller.")
+        controller.dismiss(completion: nil)
+        
+        self.delegate?.payControllerDidFinish(self)
+    }
+}

--- a/Pay/PayCurrency.swift
+++ b/Pay/PayCurrency.swift
@@ -1,0 +1,41 @@
+//
+//  PayCurrency.swift
+//  Pay
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+public struct PayCurrency {
+    
+    public let currencyCode: String
+    public let countryCode:  String
+    
+    // ----------------------------------
+    //  MARK: - Init -
+    //
+    public init(currencyCode: String, countryCode: String) {
+        self.currencyCode = currencyCode
+        self.countryCode  = countryCode
+    }
+}

--- a/Pay/PayLineItem.swift
+++ b/Pay/PayLineItem.swift
@@ -43,10 +43,8 @@ public struct PayLineItem {
 public extension Array where Element == PayLineItem {
     
     public var totalPrice: Decimal {
-        var accumulator: Decimal = 0.0
-        self.forEach { item in
-            accumulator += item.price * Decimal(item.quantity)
+        return self.reduce(0) {
+            $0 + $1.price * Decimal($1.quantity)
         }
-        return accumulator
     }
 }

--- a/Pay/PayLineItem.swift
+++ b/Pay/PayLineItem.swift
@@ -1,0 +1,52 @@
+//
+//  PayLineItem.swift
+//  Pay
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+public struct PayLineItem {
+    
+    public let price:    Decimal
+    public let quantity: Int
+    
+    // ----------------------------------
+    //  MARK: - Init -
+    //
+    public init(price: Decimal, quantity: Int) {
+        self.price    = price
+        self.quantity = quantity
+    }
+}
+
+public extension Array where Element == PayLineItem {
+    
+    public var totalPrice: Decimal {
+        var accumulator: Decimal = 0.0
+        self.forEach { item in
+            accumulator += item.price * Decimal(item.quantity)
+        }
+        return accumulator
+    }
+}

--- a/Pay/PayShippingRate.swift
+++ b/Pay/PayShippingRate.swift
@@ -1,0 +1,121 @@
+//
+//  PayShippingRate.swift
+//  Pay
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+import PassKit
+
+public struct PayShippingRate {
+    
+    public struct DeliveryRange: CustomStringConvertible {
+        public let from: Date
+        public let to:   Date?
+        
+        public init(from: Date, to: Date? = nil) {
+            self.from = from
+            self.to   = to
+        }
+        
+        public var description: String {
+            let now        = Date()
+            let firstDelta = now.daysUntil(self.from)
+            
+            if let toDate = self.to {
+                let secondDelta = now.daysUntil(toDate)
+                return "\(firstDelta)-\(secondDelta) days"
+            } else {
+                let suffix  = firstDelta == 1 ? "" : "s"
+                return "\(firstDelta) day\(suffix)"
+            }
+        }
+    }
+    
+    public let handle:        String
+    public let title:         String
+    public let price:         Decimal
+    public let deliveryRange: DeliveryRange?
+    
+    // ----------------------------------
+    //  MARK: - Init -
+    //
+    public init(handle: String, title: String, price: Decimal, deliveryRange: DeliveryRange? = nil) {
+        self.handle        = handle
+        self.title         = title
+        self.price         = price
+        self.deliveryRange = deliveryRange
+    }
+}
+
+// ----------------------------------
+//  MARK: - Date -
+//
+private extension Date {
+    
+    static let calendar = Calendar.current
+    
+    func daysUntil(_ date: Date) -> Int {
+        
+        let calendar = Date.calendar
+        let start    = calendar.startOfDay(for: self)
+        let end      = calendar.startOfDay(for: date)
+        let delta    = calendar.dateComponents([.day], from: start, to: end)
+        
+        return delta.day!
+    }
+}
+
+// ----------------------------------
+//  MARK: - PassKit -
+//
+internal extension PayShippingRate {
+    
+    var summaryItem: PKShippingMethod {
+        let item = PKShippingMethod(label: self.title, amount: self.price)
+        
+        if let deliveryRange = self.deliveryRange {
+            item.detail = deliveryRange.description
+        } else {
+            item.detail = ""
+        }
+        item.identifier = self.handle
+        
+        return item
+    }
+}
+
+internal extension Array where Element == PayShippingRate {
+    
+    var summaryItems: [PKShippingMethod] {
+        return self.map {
+            $0.summaryItem
+        }
+    }
+    
+    func shippingRateFor(_ shippingMethod: PKShippingMethod) -> Element? {
+        return self.filter {
+            $0.handle == shippingMethod.identifier!
+        }.first
+    }
+}

--- a/PayTests/Info.plist
+++ b/PayTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/PayTests/PayTests.swift
+++ b/PayTests/PayTests.swift
@@ -1,0 +1,37 @@
+//
+//  PayTests.swift
+//  PayTests
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import XCTest
+@testable import Pay
+
+class PayTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        
+        
+    }
+}

--- a/Sample Apps/Storefront/Storefront/CartController.swift
+++ b/Sample Apps/Storefront/Storefront/CartController.swift
@@ -38,19 +38,15 @@ class CartController {
     private(set) var items: [CartItem] = []
     
     var subtotal: Decimal {
-        var accumulator: Decimal = 0.0
-        for item in self.items {
-            accumulator += item.variant.price * Decimal(item.quantity)
+        return self.items.reduce(0) {
+            $0 + $1.variant.price * Decimal($1.quantity)
         }
-        return accumulator
     }
     
     var itemCount: Int {
-        var accumulator = 0
-        for item in self.items {
-            accumulator += item.quantity
+        return self.items.reduce(0) {
+            $0 + $1.quantity
         }
-        return accumulator
     }
     
     private let ioQueue    = DispatchQueue(label: "com.storefront.writeQueue")


### PR DESCRIPTION
**TLDR;** 👀  needed. If you're gonna review any PR from the SDK, this is the one to review. Also, please ignore the ludicrous `1080 additions`, a lot of is the project file and file header comments. This PR should be very reviewable.

### Intentions

The purpose of `PayController` and this abstraction is to provide the easiest solution for developers to integrate with  Pay. The intention is to limit *all* possible  Pay implementation to a reasonably-flexible, `PayCheckout` focused solution that doesn't require people to read the documentation for an hour to figure out how to use it. If you feel confused looking at this API, this is a red flag.

### What this does

Adds a target and framework called `Pay` that encapsulates everything developers will need to support Apple Pay. It is a separate target to maintain separation between the `Buy` SDK and the  Pay support. This way it's up to the developer to explicitly add a dependency on `Pay` and `PassKit`.

### Review Notes

The main class to review here is `PayController`. This is the meat of  Pay support. It provides an abstraction on top of `PKPaymentAuthorizationController` without exposing any dependencies on `PassKit`, while keeping the mental overhead to a minimum. It uses other supporting model classes like `PayCheckout` and `PayCurrency` to encapsulate data provided from `Storefront.Checkout` and other GraphQL models. 

### FAQ
> Why the WIP status?

Currently, the `PayController` doesn't provide any billing / shipping address upon successfully completing the payment. We'll need an object to encapsulate all the relevant state of a completed payment that can be used to update the checkout and send the payment token. This isn't done yet.

> Why the need for `PayCheckout` and other `Pay...` wrappers? Why not use GraphQL models directly?

Why? Since the GraphQL returns partial data and we can't guarantee the presence of fields required in `PayController`, we force end-users to create an intermediate representation of all models needed in  Pay. That way, if they forgot to request a field in their models, their code will crash (not ours).

> Where the tests at?

They're coming later.