### PR TITLE
Support subclassing of BUYClient

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK.xcodeproj/project.pbxproj
+++ b/Mobile Buy SDK/Mobile Buy SDK.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		4EC78C9F1E953FA9009E27B7 /* BUYClient+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 8498DCB01CDD1B4A00BD12A8 /* BUYClient+Internal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		841ADE001CB6C942000004B0 /* NSArray+BUYAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 841ADDEB1CB6C942000004B0 /* NSArray+BUYAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		841ADE021CB6C942000004B0 /* NSArray+BUYAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 841ADDEC1CB6C942000004B0 /* NSArray+BUYAdditions.m */; };
 		841ADE041CB6C942000004B0 /* NSDate+BUYAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 841ADDED1CB6C942000004B0 /* NSDate+BUYAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1482,6 +1483,7 @@
 				849810931CB7E07900CFAB58 /* BUYDeliveryRangeTransformer.h in Headers */,
 				901931371BC5B9BC00D1134E /* BUYTaxLine.h in Headers */,
 				84B0A7351CE10ED900253EB0 /* BUYPaymentController.h in Headers */,
+				4EC78C9F1E953FA9009E27B7 /* BUYClient+Internal.h in Headers */,
 				9019313A1BC5B9BC00D1134E /* BUYImageLink.h in Headers */,
 				9019313B1BC5B9BC00D1134E /* BUYOptionValue.h in Headers */,
 				84B0A7311CE10ED900253EB0 /* BUYApplePayPaymentProvider.h in Headers */,

--- a/Mobile Buy SDK/Mobile Buy SDK/Buy.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Buy.h
@@ -84,6 +84,9 @@
 #import "BUYClient+Checkout.h"
 #import "BUYClient+Storefront.h"
 
+// Subclassing support
+#import "BUYClient+Internal.h"
+
 // Foundation extensions
 #import "NSArray+BUYAdditions.h"
 #import "NSDate+BUYAdditions.h"

--- a/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Internal.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Data/BUYClient+Internal.h
@@ -42,16 +42,16 @@ typedef void (^BUYClientRequestJSONCompletion)(NSDictionary *json, NSHTTPURLResp
 - (NSOperation *)getRequestForURL:(NSURL *)url    completionHandler:(BUYClientRequestJSONCompletion)completionHandler;
 - (NSOperation *)deleteRequestForURL:(NSURL *)url completionHandler:(BUYClientRequestJSONCompletion)completionHandler;
 
-- (NSOperation *)postRequestForURL:(NSURL *)url  object:(id <BUYSerializable>)object completionHandler:(BUYClientRequestJSONCompletion)completionHandler;
+- (NSOperation *)postRequestForURL:(NSURL *)url  object:(id<BUYSerializable>)object completionHandler:(BUYClientRequestJSONCompletion)completionHandler;
 - (NSOperation *)putRequestForURL:(NSURL *)url   object:(id<BUYSerializable>)object  completionHandler:(BUYClientRequestJSONCompletion)completionHandler;
-- (NSOperation *)patchRequestForURL:(NSURL *)url object:(id <BUYSerializable>)object completionHandler:(BUYClientRequestJSONCompletion)completionHandler;
+- (NSOperation *)patchRequestForURL:(NSURL *)url object:(id<BUYSerializable>)object completionHandler:(BUYClientRequestJSONCompletion)completionHandler;
 
 - (NSOperation *)getRequestForURL:(NSURL *)url    start:(BOOL)start completionHandler:(BUYClientRequestJSONCompletion)completionHandler;
 - (NSOperation *)deleteRequestForURL:(NSURL *)url start:(BOOL)start completionHandler:(BUYClientRequestJSONCompletion)completionHandler;
 
-- (NSOperation *)postRequestForURL:(NSURL *)url  object:(id <BUYSerializable>)object start:(BOOL)start completionHandler:(BUYClientRequestJSONCompletion)completionHandler;
+- (NSOperation *)postRequestForURL:(NSURL *)url  object:(id<BUYSerializable>)object start:(BOOL)start completionHandler:(BUYClientRequestJSONCompletion)completionHandler;
 - (NSOperation *)putRequestForURL:(NSURL *)url   object:(id<BUYSerializable>)object  start:(BOOL)start completionHandler:(BUYClientRequestJSONCompletion)completionHandler;
-- (NSOperation *)patchRequestForURL:(NSURL *)url object:(id <BUYSerializable>)object start:(BOOL)start completionHandler:(BUYClientRequestJSONCompletion)completionHandler;
+- (NSOperation *)patchRequestForURL:(NSURL *)url object:(id<BUYSerializable>)object start:(BOOL)start completionHandler:(BUYClientRequestJSONCompletion)completionHandler;
 
 - (BUYStatus)statusForStatusCode:(NSUInteger)statusCode error:(NSError *)error;
 


### PR DESCRIPTION
This exposes the internal API of the BUYClient to allow subclasses to hook into some behaviours.