### PR TITLE
Improve checkout validation message

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYError+BUYAdditions.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Utils/BUYError+BUYAdditions.m
@@ -72,15 +72,19 @@
 
 - (NSString *)quantityRemainingMessage
 {
-	NSNumber *remaining = (id)self.options[@"remaining"];
-	NSString *localizedString;
-	
-	if ([remaining isEqualToNumber:@0]) {
-		localizedString = NSLocalizedString(@"Completely sold out", @"String describing a line item with zero stock available");
+	if ([self.code isEqualToString:@"invalid"]) {
+		return NSLocalizedString(@"This item is no longer available", @"String describing a line item that is no longer in the channel");
 	} else {
-		localizedString = NSLocalizedString(@"Only %1$@ left in stock, reduce the quantity and try again.", @"String describing an out of stock line item with first parameter representing amount remaining");
+		NSNumber *remaining = (id)self.options[@"remaining"];
+		NSString *localizedString;
+		
+		if ([remaining isEqualToNumber:@0]) {
+			localizedString = NSLocalizedString(@"Completely sold out", @"String describing a line item with zero stock available");
+		} else {
+			localizedString = NSLocalizedString(@"Only %1$@ left in stock, reduce the quantity and try again.", @"String describing an out of stock line item with first parameter representing amount remaining");
+		}
+		return [NSString localizedStringWithFormat:localizedString, remaining];
 	}
-	return [NSString localizedStringWithFormat:localizedString, remaining];
 }
 
 @end


### PR DESCRIPTION
### What
Improves validation message for invalid variant_id.

Resolves https://github.com/Shopify/instant-app/issues/133
### How
In case when checkout refresh contains variant_id of the object that is not present in the channel, validation message (obtained through `-[BUYError quantityRemainingMessage]`) is ambiguous in the sense that it assumes there was issue with remaining quantity, but actual error message contains `invalid` code and no options that is assumed to be present.

Proposed change is to detect that case and show more meaningful error message for that context.

### Testing

In order to test this scenario one need to reference variant_id that is not present in the channel. I was testing on Instant-app generated for puravida shop. I altered code making checkout refresh call to following
```
- (NSOperation *)requestForURL:(NSURL *)url method:(NSString *)method 
object:(id <BUYSerializable>)object 
start:(BOOL)start completionHandler:(BUYClientRequestJSONCompletion)completionHandler
{
	NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
	if (object) {
		NSDictionary *myJSON = @{
				@"checkout": @{
					@"line_items": @[
						@{
							@"variant_id":@"5620385029",
							@"quantity": @1
						}
					]
				}
		};
		
		request.HTTPBody = [NSJSONSerialization dataWithJSONObject:myJSON options:0 error:nil];
	}
...
```
and then see what error message shows in the UI
<img width="394" alt="screen shot 2017-04-06 at 9 51 44 pm" src="https://cloud.githubusercontent.com/assets/354010/24804939/0fac475c-1b7e-11e7-8cdd-701ff2b0d9c8.png">
