### PR TITLE
Pay session

### DIFF
--- a/Buy.xcodeproj/project.pbxproj
+++ b/Buy.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		9A4068EC1E8E7659000254CD /* Pay.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A4068DE1E8E7659000254CD /* Pay.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9A4068F91E8E767B000254CD /* PayAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4068F31E8E767B000254CD /* PayAddress.swift */; };
 		9A4068FA1E8E767B000254CD /* PayCheckout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4068F41E8E767B000254CD /* PayCheckout.swift */; };
-		9A4068FB1E8E767B000254CD /* PayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4068F51E8E767B000254CD /* PayController.swift */; };
+		9A4068FB1E8E767B000254CD /* PaySession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4068F51E8E767B000254CD /* PaySession.swift */; };
 		9A4068FC1E8E767B000254CD /* PayCurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4068F61E8E767B000254CD /* PayCurrency.swift */; };
 		9A4068FD1E8E767B000254CD /* PayLineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4068F71E8E767B000254CD /* PayLineItem.swift */; };
 		9A4068FE1E8E767B000254CD /* PayShippingRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4068F81E8E767B000254CD /* PayShippingRate.swift */; };
@@ -116,6 +116,7 @@
 		9AAFAB721E60766E00864A17 /* Global.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB711E60766E00864A17 /* Global.swift */; };
 		9AAFAB751E60809400864A17 /* Graph.Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB741E60809400864A17 /* Graph.Result.swift */; };
 		9AAFAB771E6080A500864A17 /* Graph.QueryError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAFAB761E6080A500864A17 /* Graph.QueryError.swift */; };
+		9AB421B11E93CA45005098C4 /* PayAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB421B01E93CA45005098C4 /* PayAuthorization.swift */; };
 		9AEF60F81E5F42D90067FA90 /* Buy.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AEF60F61E5F42D90067FA90 /* Buy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9AEF61A11E5F5A190067FA90 /* GraphQL+ScalarSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AEF61A01E5F5A190067FA90 /* GraphQL+ScalarSupport.swift */; };
 		9AEF61B91E5F64230067FA90 /* Graph.Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AEF61B81E5F64230067FA90 /* Graph.Client.swift */; };
@@ -150,7 +151,7 @@
 		9A4068EB1E8E7659000254CD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9A4068F31E8E767B000254CD /* PayAddress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayAddress.swift; sourceTree = "<group>"; };
 		9A4068F41E8E767B000254CD /* PayCheckout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayCheckout.swift; sourceTree = "<group>"; };
-		9A4068F51E8E767B000254CD /* PayController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayController.swift; sourceTree = "<group>"; };
+		9A4068F51E8E767B000254CD /* PaySession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaySession.swift; sourceTree = "<group>"; };
 		9A4068F61E8E767B000254CD /* PayCurrency.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayCurrency.swift; sourceTree = "<group>"; };
 		9A4068F71E8E767B000254CD /* PayLineItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayLineItem.swift; sourceTree = "<group>"; };
 		9A4068F81E8E767B000254CD /* PayShippingRate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayShippingRate.swift; sourceTree = "<group>"; };
@@ -254,6 +255,7 @@
 		9AAFAB711E60766E00864A17 /* Global.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Global.swift; sourceTree = "<group>"; };
 		9AAFAB741E60809400864A17 /* Graph.Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.Result.swift; sourceTree = "<group>"; };
 		9AAFAB761E6080A500864A17 /* Graph.QueryError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.QueryError.swift; sourceTree = "<group>"; };
+		9AB421B01E93CA45005098C4 /* PayAuthorization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayAuthorization.swift; sourceTree = "<group>"; };
 		9AEF60F31E5F42D90067FA90 /* Buy.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Buy.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9AEF60F61E5F42D90067FA90 /* Buy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Buy.h; sourceTree = "<group>"; };
 		9AEF60F71E5F42D90067FA90 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -303,12 +305,13 @@
 			isa = PBXGroup;
 			children = (
 				9A4068DE1E8E7659000254CD /* Pay.h */,
-				9A4068F51E8E767B000254CD /* PayController.swift */,
+				9A4068F51E8E767B000254CD /* PaySession.swift */,
 				9A4068F41E8E767B000254CD /* PayCheckout.swift */,
 				9A4068F71E8E767B000254CD /* PayLineItem.swift */,
 				9A4068F61E8E767B000254CD /* PayCurrency.swift */,
 				9A4068F31E8E767B000254CD /* PayAddress.swift */,
 				9A4068F81E8E767B000254CD /* PayShippingRate.swift */,
+				9AB421B01E93CA45005098C4 /* PayAuthorization.swift */,
 				9A4069091E8E82E2000254CD /* PassKit+Extensions.swift */,
 				9A4068DF1E8E7659000254CD /* Info.plist */,
 			);
@@ -702,8 +705,9 @@
 				9A4068FC1E8E767B000254CD /* PayCurrency.swift in Sources */,
 				9A40690A1E8E82E2000254CD /* PassKit+Extensions.swift in Sources */,
 				9A4068FE1E8E767B000254CD /* PayShippingRate.swift in Sources */,
+				9AB421B11E93CA45005098C4 /* PayAuthorization.swift in Sources */,
 				9A4068F91E8E767B000254CD /* PayAddress.swift in Sources */,
-				9A4068FB1E8E767B000254CD /* PayController.swift in Sources */,
+				9A4068FB1E8E767B000254CD /* PaySession.swift in Sources */,
 				9A4068FD1E8E767B000254CD /* PayLineItem.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Pay/PayAddress.swift
+++ b/Pay/PayAddress.swift
@@ -31,7 +31,6 @@ public struct PayPostalAddress {
     
     public let city:         String?
     public let country:      String?
-    public let countryCode:  String?
     public let province:     String?
     public let zip:          String?
     
@@ -46,7 +45,6 @@ public struct PayPostalAddress {
         
         self.city         = city
         self.country      = country
-        self.countryCode  = countryCode
         self.province     = province
         self.zip          = zip
     }
@@ -58,13 +56,13 @@ public struct PayAddress {
     public let addressLine2: String?
     public let city:         String?
     public let country:      String?
-    public let countryCode:  String?
     public let province:     String?
     public let zip:          String?
     
     public let firstName:    String?
     public let lastName:     String?
     public let phone:        String?
+    public let email:        String?
     
     // ----------------------------------
     //  MARK: - Init -
@@ -73,25 +71,25 @@ public struct PayAddress {
         addressLine2: String? = nil,
         city:         String? = nil,
         country:      String? = nil,
-        countryCode:  String? = nil,
         province:     String? = nil,
         zip:          String? = nil,
         
         firstName:    String? = nil,
         lastName:     String? = nil,
-        phone:        String? = nil) {
+        phone:        String? = nil,
+        email:        String? = nil) {
         
         self.addressLine1 = addressLine1
         self.addressLine2 = addressLine2
         self.city         = city
         self.country      = country
-        self.countryCode  = countryCode
         self.province     = province
         self.zip          = zip
         
         self.firstName    = firstName
         self.lastName     = lastName
         self.phone        = phone
+        self.email        = email
     }
 }
 
@@ -104,7 +102,6 @@ internal extension PayPostalAddress {
         self.init(
             city:        address.city,
             country:     address.country,
-            countryCode: address.isoCountryCode,
             province:    address.state,
             zip:         address.postalCode
         )
@@ -120,12 +117,12 @@ internal extension PayAddress {
             addressLine2: lines.count > 1 ? lines[1] : nil,
             city:         contact.postalAddress!.city,
             country:      contact.postalAddress!.country,
-            countryCode:  contact.postalAddress!.isoCountryCode,
             province:     contact.postalAddress!.state,
             zip:          contact.postalAddress!.postalCode,
             firstName:    contact.name?.givenName,
             lastName:     contact.name?.familyName,
-            phone:        contact.phoneNumber?.stringValue
+            phone:        contact.phoneNumber?.stringValue,
+            email:        contact.emailAddress
         )
     }
 }

--- a/Pay/PayAuthorization.swift
+++ b/Pay/PayAuthorization.swift
@@ -1,0 +1,46 @@
+//
+//  PayAuthorization.swift
+//  Pay
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+public class PayAuthorization {
+
+    public let token: String
+    
+    public let billingAddress:  PayAddress
+    public let shippingAddress: PayAddress
+    public let shippingRate:    PayShippingRate?
+    
+    // ----------------------------------
+    //  MARK: - Init -
+    //
+    internal init(token: String, billingAddress: PayAddress, shippingAddress: PayAddress, shippingRate: PayShippingRate?) {
+        self.token           = token
+        self.billingAddress  = billingAddress
+        self.shippingAddress = shippingAddress
+        self.shippingRate    = shippingRate
+    }
+}

--- a/Pay/PayAuthorization.swift
+++ b/Pay/PayAuthorization.swift
@@ -26,7 +26,7 @@
 
 import Foundation
 
-public class PayAuthorization {
+public struct PayAuthorization {
 
     public let token: String
     

--- a/Pay/PayCheckout.swift
+++ b/Pay/PayCheckout.swift
@@ -29,6 +29,7 @@ import PassKit
 
 public struct PayCheckout {
 
+    public let id:              String
     public let hasLineItems:    Bool
     public let hasDiscount:     Bool
     public let needsShipping:   Bool
@@ -45,8 +46,9 @@ public struct PayCheckout {
     // ----------------------------------
     //  MARK: - Init -
     //
-    public init(lineItems: [PayLineItem], shippingAddress: PayAddress?, shippingRate: PayShippingRate?, discountAmount: Decimal, subtotalPrice: Decimal, needsShipping: Bool, totalTax: Decimal, paymentDue: Decimal) {
+    public init(id: String, lineItems: [PayLineItem], shippingAddress: PayAddress?, shippingRate: PayShippingRate?, discountAmount: Decimal, subtotalPrice: Decimal, needsShipping: Bool, totalTax: Decimal, paymentDue: Decimal) {
         
+        self.id              = id
         self.lineItems       = lineItems
         self.shippingAddress = shippingAddress
         self.shippingRate    = shippingRate

--- a/Pay/PaySession.swift
+++ b/Pay/PaySession.swift
@@ -1,5 +1,5 @@
 //
-//  PayController.swift
+//  PaySession.swift
 //  Pay
 //
 //  Created by Shopify.
@@ -27,33 +27,36 @@
 import Foundation
 import PassKit
 
-public protocol PayControllerDelegate: class {
-    func payController(_ payController: PayController, didRequestShippingRatesFor address: PayPostalAddress, provide: @escaping (PayCheckout, [PayShippingRate]) -> Void)
-    func payController(_ payController: PayController, didSelectShippingRate shippingRate: PayShippingRate, provide: @escaping  (PayCheckout) -> Void)
-    func payController(_ payController: PayController, didCompletePayment token: Data, checkout: PayCheckout, completeTransaction: @escaping (PayController.TransactionStatus) -> Void)
-    func payControllerDidFinish(_ payController: PayController)
+public protocol PaySessionDelegate: class {
+    func paySession(_ paySession: PaySession, didRequestShippingRatesFor address: PayPostalAddress, checkout: PayCheckout, provide: @escaping (PayCheckout?, [PayShippingRate]) -> Void)
+    func paySession(_ paySession: PaySession, didSelectShippingRate shippingRate: PayShippingRate, checkout: PayCheckout, provide: @escaping (PayCheckout?) -> Void)
+    func paySession(_ paySession: PaySession, didAuthorizePayment authorization: PayAuthorization, checkout: PayCheckout, completeTransaction: @escaping (PaySession.TransactionStatus) -> Void)
+    
+    func paySessionDidFinish(_ paySession: PaySession)
 }
 
-public class PayController: NSObject {
+public class PaySession: NSObject {
     
     public enum TransactionStatus {
         case success
         case failure
     }
     
-    public weak var delegate: PayControllerDelegate?
+    public weak var delegate: PaySessionDelegate?
     
     public let merchantID: String
+    public let identifier: String
     
-    public fileprivate(set) var currency:      PayCurrency?
-    public fileprivate(set) var checkout:      PayCheckout?
-    public fileprivate(set) var shippingRates: [PayShippingRate]?
+    internal fileprivate(set) var currency:      PayCurrency?
+    internal fileprivate(set) var checkout:      PayCheckout?
+    internal fileprivate(set) var shippingRates: [PayShippingRate]?
     
     // ----------------------------------
     //  MARK: - Init -
     //
     public init(merchantID: String) {
         self.merchantID = merchantID
+        self.identifier = UUID().uuidString
     }
     
     // ----------------------------------
@@ -90,16 +93,28 @@ public class PayController: NSObject {
 // ------------------------------------------------------
 //  MARK: - PKPaymentAuthorizationControllerDelegate -
 //
-extension PayController: PKPaymentAuthorizationControllerDelegate {
+extension PaySession: PKPaymentAuthorizationControllerDelegate {
     
     // -------------------------------------------------------
     //  MARK: - PKPaymentAuthorizationControllerDelegate -
     //
     public func paymentAuthorizationController(_ controller: PKPaymentAuthorizationController, didAuthorizePayment payment: PKPayment, completion: @escaping (PKPaymentAuthorizationStatus) -> Void) {
      
+        /* -----------------------------------------------
+         ** The PKPayment object provides `billingContact`
+         ** and `shippingContact` only when required fields
+         ** are set on the payment request, which they are.
+         ** We can then safely force-unwrap both contacts.
+         */
+        let authorization = PayAuthorization(
+            token:           payment.token.paymentData.hexString,
+            billingAddress:  PayAddress(with: payment.billingContact!),
+            shippingAddress: PayAddress(with: payment.shippingContact!),
+            shippingRate:    self.shippingRates?.shippingRateFor(payment.shippingMethod!)
+        )
+        
         print("Authorized payment. Completing...")
-        self.delegate?.payController(self, didCompletePayment: payment.token.paymentData, checkout: self.checkout!, completeTransaction: { status in
-            
+        self.delegate?.paySession(self, didAuthorizePayment: authorization, checkout: self.checkout!, completeTransaction: { status in
             print("Completion status : \(status)")
             
             switch status {
@@ -125,7 +140,7 @@ extension PayController: PKPaymentAuthorizationControllerDelegate {
          ** postal address. The partial info
          ** should be enough to obtain rates.
          */
-        self.delegate?.payController(self, didRequestShippingRatesFor: payPostalAddress, provide: { updatedCheckout, shippingRates in
+        self.delegate?.paySession(self, didRequestShippingRatesFor: payPostalAddress, checkout: self.checkout!, provide: { updatedCheckout, shippingRates in
             
             /* ---------------------------------
              ** The delegate has an opportunity
@@ -133,7 +148,7 @@ extension PayController: PKPaymentAuthorizationControllerDelegate {
              ** which indicates invalid or incomplete
              ** postal address.
              */
-            guard !shippingRates.isEmpty else {
+            guard let updatedCheckout = updatedCheckout, !shippingRates.isEmpty else {
                 completion(.invalidShippingPostalAddress, [], self.checkout!.summaryItems)
                 return
             }
@@ -147,11 +162,15 @@ extension PayController: PKPaymentAuthorizationControllerDelegate {
              ** the default. Apple Pay selects it but
              ** doesn't invoke the delegate method.
              */
-            self.delegate?.payController(self, didSelectShippingRate: shippingRates.first!, provide: { updatedCheckout in
-                self.checkout = updatedCheckout
-                
-                print("Selected shipping contact.")
-                completion(.success, shippingRates.summaryItems, updatedCheckout.summaryItems)
+            self.delegate?.paySession(self, didSelectShippingRate: shippingRates.first!, checkout: updatedCheckout, provide: { updatedCheckout in
+                if let updatedCheckout = updatedCheckout {
+                    self.checkout = updatedCheckout
+                    
+                    print("Selected shipping contact.")
+                    completion(.success, shippingRates.summaryItems, updatedCheckout.summaryItems)
+                } else {
+                    completion(.failure, [], [])
+                }
             })
         })
     }
@@ -169,11 +188,15 @@ extension PayController: PKPaymentAuthorizationControllerDelegate {
             return
         }
         
-        self.delegate?.payController(self, didSelectShippingRate: shippingRate, provide: { updatedCheckout in
-            self.checkout = updatedCheckout
-            
-            print("Selected delivery method.")
-            completion(.success, updatedCheckout.summaryItems)
+        self.delegate?.paySession(self, didSelectShippingRate: shippingRate, checkout: self.checkout!, provide: { updatedCheckout in
+            if let updatedCheckout = updatedCheckout {
+                self.checkout = updatedCheckout
+                
+                print("Selected delivery method.")
+                completion(.success, updatedCheckout.summaryItems)
+            } else {
+                completion(.failure, [])
+            }
         })
     }
     
@@ -182,6 +205,13 @@ extension PayController: PKPaymentAuthorizationControllerDelegate {
         print("Dismissing authorization controller.")
         controller.dismiss(completion: nil)
         
-        self.delegate?.payControllerDidFinish(self)
+        self.delegate?.paySessionDidFinish(self)
+    }
+}
+
+private extension Data {
+    
+    var hexString: String {
+        return self.map { String($0, radix: 16) }.joined()
     }
 }

--- a/Pay/PayShippingRate.swift
+++ b/Pay/PayShippingRate.swift
@@ -97,7 +97,7 @@ internal extension PayShippingRate {
         if let deliveryRange = self.deliveryRange {
             item.detail = deliveryRange.description
         } else {
-            item.detail = ""
+            item.detail = "No delivery range provided."
         }
         item.identifier = self.handle
         


### PR DESCRIPTION
### What this does

Renames `PayController` to `PaySession` and encapsulates a payment authorization in `PayAuthorization` to provide all necessary info to complete a checkout after successful  Pay invocation.

**NOTE: Disregarding failing tests, requires Xcode 8.3.***