### PR TITLE
Authorization token

### DIFF
--- a/Pay/PayAuthorization.swift
+++ b/Pay/PayAuthorization.swift
@@ -47,8 +47,8 @@ public struct PayAuthorization {
     // ----------------------------------
     //  MARK: - Init -
     //
-    internal init(token: String, billingAddress: PayAddress, shippingAddress: PayAddress, shippingRate: PayShippingRate?) {
-        self.token           = token
+    internal init(paymentData: Data, billingAddress: PayAddress, shippingAddress: PayAddress, shippingRate: PayShippingRate?) {
+        self.token           = String(data: paymentData, encoding: .utf8)!
         self.billingAddress  = billingAddress
         self.shippingAddress = shippingAddress
         self.shippingRate    = shippingRate

--- a/Pay/PaySession.swift
+++ b/Pay/PaySession.swift
@@ -181,7 +181,7 @@ extension PaySession: PKPaymentAuthorizationControllerDelegate {
          ** We can then safely force-unwrap both contacts.
          */
         let authorization = PayAuthorization(
-            token:           payment.token.paymentData.hexString,
+            paymentData:     payment.token.paymentData,
             billingAddress:  PayAddress(with: payment.billingContact!),
             shippingAddress: PayAddress(with: payment.shippingContact!),
             shippingRate:    shippingRate

--- a/Pay/PaySession.swift
+++ b/Pay/PaySession.swift
@@ -282,10 +282,3 @@ extension PaySession: PKPaymentAuthorizationControllerDelegate {
         self.delegate?.paySessionDidFinish(self)
     }
 }
-
-private extension Data {
-    
-    var hexString: String {
-        return self.map { String($0, radix: 16) }.joined()
-    }
-}

--- a/PayTests/PayAuthorizationTests.swift
+++ b/PayTests/PayAuthorizationTests.swift
@@ -33,10 +33,11 @@ class PayAuthorizationTests: XCTestCase {
     //  MARK: - Init -
     //
     func testInit() {
+        let paymentData   = "123".data(using: .utf8)!
         let address       = Models.createAddress()
         let rate          = Models.createShippingRate()
         let authorization = PayAuthorization(
-            token:           "123",
+            paymentData:     paymentData,
             billingAddress:  address,
             shippingAddress: address,
             shippingRate:    rate

--- a/PayTests/PaySessionTests.swift
+++ b/PayTests/PaySessionTests.swift
@@ -106,7 +106,7 @@ class PaySessionTests: XCTestCase {
          */
         delegate.didAuthorizePayment = { session, authorization, checkout, complete in
             
-            let tokenString = token.paymentData.map { String($0, radix: 16) }.joined()
+            let tokenString = String(data: token.paymentData, encoding: .utf8)
             XCTAssertEqual(authorization.token, tokenString)
             XCTAssertEqual(authorization.billingAddress.city,  contact.postalAddress!.city)
             XCTAssertEqual(authorization.shippingAddress.city, contact.postalAddress!.city)


### PR DESCRIPTION
Fix how `PKPayment` token is handled before passing it off to a `completeCheckout` query. It needed to be a simple string instead of a hex string representing the data.