### PR TITLE
Checkout ID

### DIFF
--- a/Pay/PayCheckout.swift
+++ b/Pay/PayCheckout.swift
@@ -33,6 +33,7 @@ import PassKit
 ///
 public struct PayCheckout {
 
+    public let id:              String
     public let hasLineItems:    Bool
     public let needsShipping:   Bool
     
@@ -48,8 +49,9 @@ public struct PayCheckout {
     // ----------------------------------
     //  MARK: - Init -
     //
-    public init(lineItems: [PayLineItem], discount: PayDiscount?, shippingAddress: PayAddress?, shippingRate: PayShippingRate?, discountAmount: Decimal, subtotalPrice: Decimal, needsShipping: Bool, totalTax: Decimal, paymentDue: Decimal) {
+    public init(id: String, lineItems: [PayLineItem], discount: PayDiscount?, shippingAddress: PayAddress?, shippingRate: PayShippingRate?, subtotalPrice: Decimal, needsShipping: Bool, totalTax: Decimal, paymentDue: Decimal) {
         
+        self.id              = id
         self.lineItems       = lineItems
         self.shippingAddress = shippingAddress
         self.shippingRate    = shippingRate

--- a/PayTests/Models.swift
+++ b/PayTests/Models.swift
@@ -89,11 +89,11 @@ struct Models {
         ]
         
         return PayCheckout(
+            id:              "123",
             lineItems:       !empty ? lineItems : [],
             discount:        discount,
             shippingAddress: shippingAddress,
             shippingRate:    shippingRate,
-            discountAmount:  0.0,
             subtotalPrice:   44.0,
             needsShipping:   requiresShipping,
             totalTax:        hasTax ? 6.0 : 0.0,

--- a/PayTests/PayCheckoutTests.swift
+++ b/PayTests/PayCheckoutTests.swift
@@ -37,6 +37,7 @@ class PayCheckoutTests: XCTestCase {
         let address  = Models.createAddress()
         let rate     = Models.createShippingRate()
         let checkout = PayCheckout(
+            id: "123",
             lineItems: [
                 PayLineItem(price: 10.0, quantity: 1),
                 PayLineItem(price: 20.0, quantity: 1),
@@ -44,13 +45,13 @@ class PayCheckoutTests: XCTestCase {
             discount:        discount,
             shippingAddress: address,
             shippingRate:    rate,
-            discountAmount:  10.0,
             subtotalPrice:   30.0,
             needsShipping:   true,
             totalTax:        15.0,
             paymentDue:      35.0
         )
         
+        XCTAssertEqual(checkout.id,              "123")
         XCTAssertEqual(checkout.lineItems.count, 2)
         XCTAssertEqual(checkout.shippingAddress!.city, address.city)
         XCTAssertEqual(checkout.shippingRate!.handle,  rate.handle)


### PR DESCRIPTION
The checkout ID was mistakenly removed because it was thought to be unused. In fact, it's used for updating and completing checkout. So it's back.