### PR TITLE
Buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,17 +1,15 @@
+env:
+  TARGET_IMAGE: "macos-xcode83"
+  
 steps:
-
   - label: "Buy Tests"
     command: "./Scripts/test_buy"
     timeout_in_minutes: 10
     agents:
       macstadium-scheduler: true
-    env:
-      TARGET_IMAGE: "macos-xcode83"
     
   - label: "Pay Tests"
     command: "./Scripts/test_pay"
     timeout_in_minutes: 10
     agents:
       macstadium-scheduler: true
-    env:
-      TARGET_IMAGE: "macos-xcode83"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,9 +2,11 @@ steps:
   - label: "Buy Tests"
     command: 
       - "./Scripts/test_buy"
-    macstadium-scheduler: true
+    agents:
+      - macstadium-scheduler: true
     
   - label: "Pay Tests"
     command: 
       - "./Scripts/test_pay"
-    macstadium-scheduler: true
+    agents:
+      - macstadium-scheduler: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,12 +1,19 @@
 steps:
+
   - label: "Buy Tests"
-    command: 
-      - "./Scripts/test_buy"
+    command: "./Scripts/test_buy"
+    timeout_in_minutes: 10
     agents:
-      - macstadium-scheduler: true
+      macstadium-scheduler: true
+    env:
+      TARGET_IMAGE: "macos-xcode83"
+    
+  - wait
     
   - label: "Pay Tests"
-    command: 
-      - "./Scripts/test_pay"
+    command: "./Scripts/test_pay"
+    timeout_in_minutes: 10
     agents:
-      - macstadium-scheduler: true
+      macstadium-scheduler: true
+    env:
+      TARGET_IMAGE: "macos-xcode83"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,10 @@
+steps:
+  - label: "Buy Tests"
+    command: 
+      - "./Scripts/test_buy"
+    macstadium-scheduler: true
+    
+  - label: "Pay Tests"
+    command: 
+      - "./Scripts/test_pay"
+    macstadium-scheduler: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,8 +8,6 @@ steps:
     env:
       TARGET_IMAGE: "macos-xcode83"
     
-  - wait
-    
   - label: "Pay Tests"
     command: "./Scripts/test_pay"
     timeout_in_minutes: 10

--- a/Scripts/run_tests.sh
+++ b/Scripts/run_tests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if [[ -f ".buildkite/pipeline.yml" ]]
+then
+    buildkite-agent pipeline upload --replace
+else
+   echo "Legacy SDK version. Ignoring pipeline upload."
+fi

--- a/Scripts/test_buy
+++ b/Scripts/test_buy
@@ -1,0 +1,11 @@
+ #!/usr/bin/env bash
+
+set -ex
+set -eo pipefail
+
+xcodebuild test \
+-project "Buy.xcodeproj" \
+-scheme "Buy" \
+-sdk iphonesimulator \
+-destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3' \
+ | xcpretty -c

--- a/Scripts/test_pay
+++ b/Scripts/test_pay
@@ -5,13 +5,6 @@ set -eo pipefail
 
 xcodebuild test \
 -project "Buy.xcodeproj" \
--scheme "Buy" \
--sdk iphonesimulator \
--destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3' \
- | xcpretty -c
- 
- xcodebuild test \
--project "Buy.xcodeproj" \
 -scheme "Pay" \
 -sdk iphonesimulator \
 -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3' \


### PR DESCRIPTION
### The problem

Previously, the SDK build process involved a single script that would "run tests". The path to this script along with any required environment variables were hard-coded in Buildkite admin making it very difficult (impossible) to have custom build environments on different branches.

Also, in SDK 3.0 we have two independent targets that needs testing. With a single script, we can't parallelize the builds.

### Solution

Migrate to using a `pipeline.yml` file that would setup the build pipeline dynamically. Doing so, allows us to setup steps and environment as needed on any specific branch, as well as, run multiple target's tests in parallel.

### Notes

Adding the `pipeline.yml` required an addition hard-coded step in Buildkite to ensure backwards compatibility with the previous method. It would upload the pipeline if one was found, or continue test execution as it always has in the past. This step looks like this:

![screen shot 2017-04-24 at 9 05 48 am](https://cloud.githubusercontent.com/assets/5244861/25338442/3c345cc2-28cd-11e7-8d5a-813c41263d3d.png)
