### PR TITLE
Update schema (auto-generated)

### DIFF
--- a/Buy.xcodeproj/project.pbxproj
+++ b/Buy.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		9A0C80B41EAA51C50020F187 /* UserError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0C80551EAA51C50020F187 /* UserError.swift */; };
 		9A0C80B51EAA51C50020F187 /* WeightUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0C80561EAA51C50020F187 /* WeightUnit.swift */; };
 		9A0C80B61EAA51C50020F187 /* Storefront.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0C80571EAA51C50020F187 /* Storefront.swift */; };
+		9A0C80FC1EBA27970020F187 /* SelectedOptionInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0C80FB1EBA27970020F187 /* SelectedOptionInput.swift */; };
 		9A4068E51E8E7659000254CD /* Pay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A4068DC1E8E7658000254CD /* Pay.framework */; };
 		9A4068EA1E8E7659000254CD /* PaySessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4068E91E8E7659000254CD /* PaySessionTests.swift */; };
 		9A4068EC1E8E7659000254CD /* Pay.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A4068DE1E8E7659000254CD /* Pay.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -284,6 +285,7 @@
 		9A0C80551EAA51C50020F187 /* UserError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserError.swift; sourceTree = "<group>"; };
 		9A0C80561EAA51C50020F187 /* WeightUnit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeightUnit.swift; sourceTree = "<group>"; };
 		9A0C80571EAA51C50020F187 /* Storefront.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Storefront.swift; sourceTree = "<group>"; };
+		9A0C80FB1EBA27970020F187 /* SelectedOptionInput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectedOptionInput.swift; sourceTree = "<group>"; };
 		9A4068DC1E8E7658000254CD /* Pay.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pay.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A4068DE1E8E7659000254CD /* Pay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Pay.h; sourceTree = "<group>"; };
 		9A4068DF1E8E7659000254CD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -457,6 +459,7 @@
 				9A0C804B1EAA51C50020F187 /* ProductVariantEdge.swift */,
 				9A0C804C1EAA51C50020F187 /* QueryRoot.swift */,
 				9A0C804D1EAA51C50020F187 /* SelectedOption.swift */,
+				9A0C80FB1EBA27970020F187 /* SelectedOptionInput.swift */,
 				9A0C804E1EAA51C50020F187 /* ShippingRate.swift */,
 				9A0C804F1EAA51C50020F187 /* Shop.swift */,
 				9A0C80501EAA51C50020F187 /* ShopPolicy.swift */,
@@ -926,6 +929,7 @@
 				9A0C807E1EAA51C50020F187 /* CustomerAccessTokenCreatePayload.swift in Sources */,
 				9A0C80AE1EAA51C50020F187 /* Shop.swift in Sources */,
 				9A0C80751EAA51C50020F187 /* CollectionEdge.swift in Sources */,
+				9A0C80FC1EBA27970020F187 /* SelectedOptionInput.swift in Sources */,
 				9A0C80951EAA51C50020F187 /* Mutation.swift in Sources */,
 				9A0C80A91EAA51C50020F187 /* ProductVariantConnection.swift in Sources */,
 				9A0C80891EAA51C50020F187 /* CustomerResetInput.swift in Sources */,
@@ -1293,6 +1297,7 @@
 				9A0C80C71EAE73840020F187 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		9A4068F11E8E7659000254CD /* Build configuration list for PBXNativeTarget "Pay" */ = {
 			isa = XCConfigurationList;

--- a/Buy/Generated/Storefront/AppliedGiftCard.swift
+++ b/Buy/Generated/Storefront/AppliedGiftCard.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class AppliedGiftCardQuery: GraphQL.AbstractQuery {
+	open class AppliedGiftCardQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = AppliedGiftCard
+
 		@discardableResult
 		open func amountUsed(aliasSuffix: String? = nil) -> AppliedGiftCardQuery {
 			addField(field: "amountUsed", aliasSuffix: aliasSuffix)
@@ -28,8 +30,9 @@ extension Storefront {
 		}
 	}
 
-	open class AppliedGiftCard: GraphQL.AbstractResponse, Node
-	{
+	open class AppliedGiftCard: GraphQL.AbstractResponse, GraphQLObject, Node {
+		public typealias Query = AppliedGiftCardQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/Attribute.swift
+++ b/Buy/Generated/Storefront/Attribute.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class AttributeQuery: GraphQL.AbstractQuery {
+	open class AttributeQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = Attribute
+
 		@discardableResult
 		open func key(aliasSuffix: String? = nil) -> AttributeQuery {
 			addField(field: "key", aliasSuffix: aliasSuffix)
@@ -16,8 +18,9 @@ extension Storefront {
 		}
 	}
 
-	open class Attribute: GraphQL.AbstractResponse
-	{
+	open class Attribute: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = AttributeQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/AvailableShippingRates.swift
+++ b/Buy/Generated/Storefront/AvailableShippingRates.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class AvailableShippingRatesQuery: GraphQL.AbstractQuery {
+	open class AvailableShippingRatesQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = AvailableShippingRates
+
 		@discardableResult
 		open func ready(aliasSuffix: String? = nil) -> AvailableShippingRatesQuery {
 			addField(field: "ready", aliasSuffix: aliasSuffix)
@@ -19,8 +21,9 @@ extension Storefront {
 		}
 	}
 
-	open class AvailableShippingRates: GraphQL.AbstractResponse
-	{
+	open class AvailableShippingRates: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = AvailableShippingRatesQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/Checkout.swift
+++ b/Buy/Generated/Storefront/Checkout.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CheckoutQuery: GraphQL.AbstractQuery {
+	open class CheckoutQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = Checkout
+
 		@discardableResult
 		open func appliedGiftCards(aliasSuffix: String? = nil, _ subfields: (AppliedGiftCardQuery) -> Void) -> CheckoutQuery {
 			let subquery = AppliedGiftCardQuery()
@@ -198,8 +200,9 @@ extension Storefront {
 		}
 	}
 
-	open class Checkout: GraphQL.AbstractResponse, Node
-	{
+	open class Checkout: GraphQL.AbstractResponse, GraphQLObject, Node {
+		public typealias Query = CheckoutQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CheckoutAttributesUpdatePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutAttributesUpdatePayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CheckoutAttributesUpdatePayloadQuery: GraphQL.AbstractQuery {
+	open class CheckoutAttributesUpdatePayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CheckoutAttributesUpdatePayload
+
 		@discardableResult
 		open func checkout(aliasSuffix: String? = nil, _ subfields: (CheckoutQuery) -> Void) -> CheckoutAttributesUpdatePayloadQuery {
 			let subquery = CheckoutQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CheckoutAttributesUpdatePayload: GraphQL.AbstractResponse
-	{
+	open class CheckoutAttributesUpdatePayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CheckoutAttributesUpdatePayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CheckoutCompleteFreePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutCompleteFreePayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CheckoutCompleteFreePayloadQuery: GraphQL.AbstractQuery {
+	open class CheckoutCompleteFreePayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CheckoutCompleteFreePayload
+
 		@discardableResult
 		open func checkout(aliasSuffix: String? = nil, _ subfields: (CheckoutQuery) -> Void) -> CheckoutCompleteFreePayloadQuery {
 			let subquery = CheckoutQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CheckoutCompleteFreePayload: GraphQL.AbstractResponse
-	{
+	open class CheckoutCompleteFreePayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CheckoutCompleteFreePayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CheckoutCompleteWithCreditCardPayload.swift
+++ b/Buy/Generated/Storefront/CheckoutCompleteWithCreditCardPayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CheckoutCompleteWithCreditCardPayloadQuery: GraphQL.AbstractQuery {
+	open class CheckoutCompleteWithCreditCardPayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CheckoutCompleteWithCreditCardPayload
+
 		@discardableResult
 		open func checkout(aliasSuffix: String? = nil, _ subfields: (CheckoutQuery) -> Void) -> CheckoutCompleteWithCreditCardPayloadQuery {
 			let subquery = CheckoutQuery()
@@ -31,8 +33,9 @@ extension Storefront {
 		}
 	}
 
-	open class CheckoutCompleteWithCreditCardPayload: GraphQL.AbstractResponse
-	{
+	open class CheckoutCompleteWithCreditCardPayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CheckoutCompleteWithCreditCardPayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CheckoutCompleteWithTokenizedPaymentPayload.swift
+++ b/Buy/Generated/Storefront/CheckoutCompleteWithTokenizedPaymentPayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CheckoutCompleteWithTokenizedPaymentPayloadQuery: GraphQL.AbstractQuery {
+	open class CheckoutCompleteWithTokenizedPaymentPayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CheckoutCompleteWithTokenizedPaymentPayload
+
 		@discardableResult
 		open func checkout(aliasSuffix: String? = nil, _ subfields: (CheckoutQuery) -> Void) -> CheckoutCompleteWithTokenizedPaymentPayloadQuery {
 			let subquery = CheckoutQuery()
@@ -31,8 +33,9 @@ extension Storefront {
 		}
 	}
 
-	open class CheckoutCompleteWithTokenizedPaymentPayload: GraphQL.AbstractResponse
-	{
+	open class CheckoutCompleteWithTokenizedPaymentPayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CheckoutCompleteWithTokenizedPaymentPayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CheckoutCreatePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutCreatePayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CheckoutCreatePayloadQuery: GraphQL.AbstractQuery {
+	open class CheckoutCreatePayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CheckoutCreatePayload
+
 		@discardableResult
 		open func checkout(aliasSuffix: String? = nil, _ subfields: (CheckoutQuery) -> Void) -> CheckoutCreatePayloadQuery {
 			let subquery = CheckoutQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CheckoutCreatePayload: GraphQL.AbstractResponse
-	{
+	open class CheckoutCreatePayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CheckoutCreatePayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CheckoutCustomerAssociatePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutCustomerAssociatePayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CheckoutCustomerAssociatePayloadQuery: GraphQL.AbstractQuery {
+	open class CheckoutCustomerAssociatePayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CheckoutCustomerAssociatePayload
+
 		@discardableResult
 		open func checkout(aliasSuffix: String? = nil, _ subfields: (CheckoutQuery) -> Void) -> CheckoutCustomerAssociatePayloadQuery {
 			let subquery = CheckoutQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CheckoutCustomerAssociatePayload: GraphQL.AbstractResponse
-	{
+	open class CheckoutCustomerAssociatePayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CheckoutCustomerAssociatePayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CheckoutCustomerDisassociatePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutCustomerDisassociatePayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CheckoutCustomerDisassociatePayloadQuery: GraphQL.AbstractQuery {
+	open class CheckoutCustomerDisassociatePayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CheckoutCustomerDisassociatePayload
+
 		@discardableResult
 		open func checkout(aliasSuffix: String? = nil, _ subfields: (CheckoutQuery) -> Void) -> CheckoutCustomerDisassociatePayloadQuery {
 			let subquery = CheckoutQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CheckoutCustomerDisassociatePayload: GraphQL.AbstractResponse
-	{
+	open class CheckoutCustomerDisassociatePayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CheckoutCustomerDisassociatePayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CheckoutEmailUpdatePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutEmailUpdatePayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CheckoutEmailUpdatePayloadQuery: GraphQL.AbstractQuery {
+	open class CheckoutEmailUpdatePayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CheckoutEmailUpdatePayload
+
 		@discardableResult
 		open func checkout(aliasSuffix: String? = nil, _ subfields: (CheckoutQuery) -> Void) -> CheckoutEmailUpdatePayloadQuery {
 			let subquery = CheckoutQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CheckoutEmailUpdatePayload: GraphQL.AbstractResponse
-	{
+	open class CheckoutEmailUpdatePayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CheckoutEmailUpdatePayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CheckoutGiftCardApplyPayload.swift
+++ b/Buy/Generated/Storefront/CheckoutGiftCardApplyPayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CheckoutGiftCardApplyPayloadQuery: GraphQL.AbstractQuery {
+	open class CheckoutGiftCardApplyPayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CheckoutGiftCardApplyPayload
+
 		@discardableResult
 		open func checkout(aliasSuffix: String? = nil, _ subfields: (CheckoutQuery) -> Void) -> CheckoutGiftCardApplyPayloadQuery {
 			let subquery = CheckoutQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CheckoutGiftCardApplyPayload: GraphQL.AbstractResponse
-	{
+	open class CheckoutGiftCardApplyPayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CheckoutGiftCardApplyPayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CheckoutGiftCardRemovePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutGiftCardRemovePayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CheckoutGiftCardRemovePayloadQuery: GraphQL.AbstractQuery {
+	open class CheckoutGiftCardRemovePayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CheckoutGiftCardRemovePayload
+
 		@discardableResult
 		open func checkout(aliasSuffix: String? = nil, _ subfields: (CheckoutQuery) -> Void) -> CheckoutGiftCardRemovePayloadQuery {
 			let subquery = CheckoutQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CheckoutGiftCardRemovePayload: GraphQL.AbstractResponse
-	{
+	open class CheckoutGiftCardRemovePayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CheckoutGiftCardRemovePayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CheckoutLineItem.swift
+++ b/Buy/Generated/Storefront/CheckoutLineItem.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CheckoutLineItemQuery: GraphQL.AbstractQuery {
+	open class CheckoutLineItemQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CheckoutLineItem
+
 		@discardableResult
 		open func customAttributes(aliasSuffix: String? = nil, _ subfields: (AttributeQuery) -> Void) -> CheckoutLineItemQuery {
 			let subquery = AttributeQuery()
@@ -40,8 +42,9 @@ extension Storefront {
 		}
 	}
 
-	open class CheckoutLineItem: GraphQL.AbstractResponse, Node
-	{
+	open class CheckoutLineItem: GraphQL.AbstractResponse, GraphQLObject, Node {
+		public typealias Query = CheckoutLineItemQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CheckoutLineItemConnection.swift
+++ b/Buy/Generated/Storefront/CheckoutLineItemConnection.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CheckoutLineItemConnectionQuery: GraphQL.AbstractQuery {
+	open class CheckoutLineItemConnectionQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CheckoutLineItemConnection
+
 		@discardableResult
 		open func edges(aliasSuffix: String? = nil, _ subfields: (CheckoutLineItemEdgeQuery) -> Void) -> CheckoutLineItemConnectionQuery {
 			let subquery = CheckoutLineItemEdgeQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CheckoutLineItemConnection: GraphQL.AbstractResponse
-	{
+	open class CheckoutLineItemConnection: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CheckoutLineItemConnectionQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CheckoutLineItemEdge.swift
+++ b/Buy/Generated/Storefront/CheckoutLineItemEdge.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CheckoutLineItemEdgeQuery: GraphQL.AbstractQuery {
+	open class CheckoutLineItemEdgeQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CheckoutLineItemEdge
+
 		@discardableResult
 		open func cursor(aliasSuffix: String? = nil) -> CheckoutLineItemEdgeQuery {
 			addField(field: "cursor", aliasSuffix: aliasSuffix)
@@ -19,8 +21,9 @@ extension Storefront {
 		}
 	}
 
-	open class CheckoutLineItemEdge: GraphQL.AbstractResponse
-	{
+	open class CheckoutLineItemEdge: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CheckoutLineItemEdgeQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CheckoutLineItemsAddPayload.swift
+++ b/Buy/Generated/Storefront/CheckoutLineItemsAddPayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CheckoutLineItemsAddPayloadQuery: GraphQL.AbstractQuery {
+	open class CheckoutLineItemsAddPayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CheckoutLineItemsAddPayload
+
 		@discardableResult
 		open func checkout(aliasSuffix: String? = nil, _ subfields: (CheckoutQuery) -> Void) -> CheckoutLineItemsAddPayloadQuery {
 			let subquery = CheckoutQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CheckoutLineItemsAddPayload: GraphQL.AbstractResponse
-	{
+	open class CheckoutLineItemsAddPayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CheckoutLineItemsAddPayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CheckoutLineItemsRemovePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutLineItemsRemovePayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CheckoutLineItemsRemovePayloadQuery: GraphQL.AbstractQuery {
+	open class CheckoutLineItemsRemovePayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CheckoutLineItemsRemovePayload
+
 		@discardableResult
 		open func checkout(aliasSuffix: String? = nil, _ subfields: (CheckoutQuery) -> Void) -> CheckoutLineItemsRemovePayloadQuery {
 			let subquery = CheckoutQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CheckoutLineItemsRemovePayload: GraphQL.AbstractResponse
-	{
+	open class CheckoutLineItemsRemovePayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CheckoutLineItemsRemovePayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CheckoutLineItemsUpdatePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutLineItemsUpdatePayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CheckoutLineItemsUpdatePayloadQuery: GraphQL.AbstractQuery {
+	open class CheckoutLineItemsUpdatePayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CheckoutLineItemsUpdatePayload
+
 		@discardableResult
 		open func checkout(aliasSuffix: String? = nil, _ subfields: (CheckoutQuery) -> Void) -> CheckoutLineItemsUpdatePayloadQuery {
 			let subquery = CheckoutQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CheckoutLineItemsUpdatePayload: GraphQL.AbstractResponse
-	{
+	open class CheckoutLineItemsUpdatePayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CheckoutLineItemsUpdatePayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CheckoutShippingAddressUpdatePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutShippingAddressUpdatePayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CheckoutShippingAddressUpdatePayloadQuery: GraphQL.AbstractQuery {
+	open class CheckoutShippingAddressUpdatePayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CheckoutShippingAddressUpdatePayload
+
 		@discardableResult
 		open func checkout(aliasSuffix: String? = nil, _ subfields: (CheckoutQuery) -> Void) -> CheckoutShippingAddressUpdatePayloadQuery {
 			let subquery = CheckoutQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CheckoutShippingAddressUpdatePayload: GraphQL.AbstractResponse
-	{
+	open class CheckoutShippingAddressUpdatePayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CheckoutShippingAddressUpdatePayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CheckoutShippingLineUpdatePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutShippingLineUpdatePayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CheckoutShippingLineUpdatePayloadQuery: GraphQL.AbstractQuery {
+	open class CheckoutShippingLineUpdatePayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CheckoutShippingLineUpdatePayload
+
 		@discardableResult
 		open func checkout(aliasSuffix: String? = nil, _ subfields: (CheckoutQuery) -> Void) -> CheckoutShippingLineUpdatePayloadQuery {
 			let subquery = CheckoutQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CheckoutShippingLineUpdatePayload: GraphQL.AbstractResponse
-	{
+	open class CheckoutShippingLineUpdatePayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CheckoutShippingLineUpdatePayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/Collection.swift
+++ b/Buy/Generated/Storefront/Collection.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CollectionQuery: GraphQL.AbstractQuery {
+	open class CollectionQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = Collection
+
 		@discardableResult
 		open func description(aliasSuffix: String? = nil, truncateAt: Int32? = nil) -> CollectionQuery {
 			var args: [String] = []
@@ -100,8 +102,9 @@ extension Storefront {
 		}
 	}
 
-	open class Collection: GraphQL.AbstractResponse, Node
-	{
+	open class Collection: GraphQL.AbstractResponse, GraphQLObject, Node {
+		public typealias Query = CollectionQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CollectionConnection.swift
+++ b/Buy/Generated/Storefront/CollectionConnection.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CollectionConnectionQuery: GraphQL.AbstractQuery {
+	open class CollectionConnectionQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CollectionConnection
+
 		@discardableResult
 		open func edges(aliasSuffix: String? = nil, _ subfields: (CollectionEdgeQuery) -> Void) -> CollectionConnectionQuery {
 			let subquery = CollectionEdgeQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CollectionConnection: GraphQL.AbstractResponse
-	{
+	open class CollectionConnection: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CollectionConnectionQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CollectionEdge.swift
+++ b/Buy/Generated/Storefront/CollectionEdge.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CollectionEdgeQuery: GraphQL.AbstractQuery {
+	open class CollectionEdgeQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CollectionEdge
+
 		@discardableResult
 		open func cursor(aliasSuffix: String? = nil) -> CollectionEdgeQuery {
 			addField(field: "cursor", aliasSuffix: aliasSuffix)
@@ -19,8 +21,9 @@ extension Storefront {
 		}
 	}
 
-	open class CollectionEdge: GraphQL.AbstractResponse
-	{
+	open class CollectionEdge: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CollectionEdgeQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CreditCard.swift
+++ b/Buy/Generated/Storefront/CreditCard.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CreditCardQuery: GraphQL.AbstractQuery {
+	open class CreditCardQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CreditCard
+
 		@discardableResult
 		open func brand(aliasSuffix: String? = nil) -> CreditCardQuery {
 			addField(field: "brand", aliasSuffix: aliasSuffix)
@@ -52,8 +54,9 @@ extension Storefront {
 		}
 	}
 
-	open class CreditCard: GraphQL.AbstractResponse
-	{
+	open class CreditCard: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CreditCardQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CurrencyCode.swift
+++ b/Buy/Generated/Storefront/CurrencyCode.swift
@@ -215,6 +215,8 @@ extension Storefront {
 
 		case scr = "SCR"
 
+		case sdg = "SDG"
+
 		case sek = "SEK"
 
 		case sgd = "SGD"

--- a/Buy/Generated/Storefront/Customer.swift
+++ b/Buy/Generated/Storefront/Customer.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CustomerQuery: GraphQL.AbstractQuery {
+	open class CustomerQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = Customer
+
 		@discardableResult
 		open func acceptsMarketing(aliasSuffix: String? = nil) -> CustomerQuery {
 			addField(field: "acceptsMarketing", aliasSuffix: aliasSuffix)
@@ -121,8 +123,9 @@ extension Storefront {
 		}
 	}
 
-	open class Customer: GraphQL.AbstractResponse
-	{
+	open class Customer: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CustomerQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CustomerAccessToken.swift
+++ b/Buy/Generated/Storefront/CustomerAccessToken.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CustomerAccessTokenQuery: GraphQL.AbstractQuery {
+	open class CustomerAccessTokenQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CustomerAccessToken
+
 		@discardableResult
 		open func accessToken(aliasSuffix: String? = nil) -> CustomerAccessTokenQuery {
 			addField(field: "accessToken", aliasSuffix: aliasSuffix)
@@ -16,8 +18,9 @@ extension Storefront {
 		}
 	}
 
-	open class CustomerAccessToken: GraphQL.AbstractResponse
-	{
+	open class CustomerAccessToken: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CustomerAccessTokenQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CustomerAccessTokenCreatePayload.swift
+++ b/Buy/Generated/Storefront/CustomerAccessTokenCreatePayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CustomerAccessTokenCreatePayloadQuery: GraphQL.AbstractQuery {
+	open class CustomerAccessTokenCreatePayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CustomerAccessTokenCreatePayload
+
 		@discardableResult
 		open func customerAccessToken(aliasSuffix: String? = nil, _ subfields: (CustomerAccessTokenQuery) -> Void) -> CustomerAccessTokenCreatePayloadQuery {
 			let subquery = CustomerAccessTokenQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CustomerAccessTokenCreatePayload: GraphQL.AbstractResponse
-	{
+	open class CustomerAccessTokenCreatePayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CustomerAccessTokenCreatePayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CustomerAccessTokenDeletePayload.swift
+++ b/Buy/Generated/Storefront/CustomerAccessTokenDeletePayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CustomerAccessTokenDeletePayloadQuery: GraphQL.AbstractQuery {
+	open class CustomerAccessTokenDeletePayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CustomerAccessTokenDeletePayload
+
 		@discardableResult
 		open func deletedAccessToken(aliasSuffix: String? = nil) -> CustomerAccessTokenDeletePayloadQuery {
 			addField(field: "deletedAccessToken", aliasSuffix: aliasSuffix)
@@ -25,8 +27,9 @@ extension Storefront {
 		}
 	}
 
-	open class CustomerAccessTokenDeletePayload: GraphQL.AbstractResponse
-	{
+	open class CustomerAccessTokenDeletePayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CustomerAccessTokenDeletePayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CustomerAccessTokenRenewPayload.swift
+++ b/Buy/Generated/Storefront/CustomerAccessTokenRenewPayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CustomerAccessTokenRenewPayloadQuery: GraphQL.AbstractQuery {
+	open class CustomerAccessTokenRenewPayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CustomerAccessTokenRenewPayload
+
 		@discardableResult
 		open func customerAccessToken(aliasSuffix: String? = nil, _ subfields: (CustomerAccessTokenQuery) -> Void) -> CustomerAccessTokenRenewPayloadQuery {
 			let subquery = CustomerAccessTokenQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CustomerAccessTokenRenewPayload: GraphQL.AbstractResponse
-	{
+	open class CustomerAccessTokenRenewPayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CustomerAccessTokenRenewPayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CustomerActivatePayload.swift
+++ b/Buy/Generated/Storefront/CustomerActivatePayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CustomerActivatePayloadQuery: GraphQL.AbstractQuery {
+	open class CustomerActivatePayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CustomerActivatePayload
+
 		@discardableResult
 		open func customer(aliasSuffix: String? = nil, _ subfields: (CustomerQuery) -> Void) -> CustomerActivatePayloadQuery {
 			let subquery = CustomerQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CustomerActivatePayload: GraphQL.AbstractResponse
-	{
+	open class CustomerActivatePayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CustomerActivatePayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CustomerAddressCreatePayload.swift
+++ b/Buy/Generated/Storefront/CustomerAddressCreatePayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CustomerAddressCreatePayloadQuery: GraphQL.AbstractQuery {
+	open class CustomerAddressCreatePayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CustomerAddressCreatePayload
+
 		@discardableResult
 		open func customerAddress(aliasSuffix: String? = nil, _ subfields: (MailingAddressQuery) -> Void) -> CustomerAddressCreatePayloadQuery {
 			let subquery = MailingAddressQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CustomerAddressCreatePayload: GraphQL.AbstractResponse
-	{
+	open class CustomerAddressCreatePayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CustomerAddressCreatePayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CustomerAddressDeletePayload.swift
+++ b/Buy/Generated/Storefront/CustomerAddressDeletePayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CustomerAddressDeletePayloadQuery: GraphQL.AbstractQuery {
+	open class CustomerAddressDeletePayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CustomerAddressDeletePayload
+
 		@discardableResult
 		open func deletedCustomerAddressId(aliasSuffix: String? = nil) -> CustomerAddressDeletePayloadQuery {
 			addField(field: "deletedCustomerAddressId", aliasSuffix: aliasSuffix)
@@ -19,8 +21,9 @@ extension Storefront {
 		}
 	}
 
-	open class CustomerAddressDeletePayload: GraphQL.AbstractResponse
-	{
+	open class CustomerAddressDeletePayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CustomerAddressDeletePayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CustomerAddressUpdatePayload.swift
+++ b/Buy/Generated/Storefront/CustomerAddressUpdatePayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CustomerAddressUpdatePayloadQuery: GraphQL.AbstractQuery {
+	open class CustomerAddressUpdatePayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CustomerAddressUpdatePayload
+
 		@discardableResult
 		open func customerAddress(aliasSuffix: String? = nil, _ subfields: (MailingAddressQuery) -> Void) -> CustomerAddressUpdatePayloadQuery {
 			let subquery = MailingAddressQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CustomerAddressUpdatePayload: GraphQL.AbstractResponse
-	{
+	open class CustomerAddressUpdatePayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CustomerAddressUpdatePayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CustomerCreatePayload.swift
+++ b/Buy/Generated/Storefront/CustomerCreatePayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CustomerCreatePayloadQuery: GraphQL.AbstractQuery {
+	open class CustomerCreatePayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CustomerCreatePayload
+
 		@discardableResult
 		open func customer(aliasSuffix: String? = nil, _ subfields: (CustomerQuery) -> Void) -> CustomerCreatePayloadQuery {
 			let subquery = CustomerQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CustomerCreatePayload: GraphQL.AbstractResponse
-	{
+	open class CustomerCreatePayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CustomerCreatePayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CustomerRecoverPayload.swift
+++ b/Buy/Generated/Storefront/CustomerRecoverPayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CustomerRecoverPayloadQuery: GraphQL.AbstractQuery {
+	open class CustomerRecoverPayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CustomerRecoverPayload
+
 		@discardableResult
 		open func userErrors(aliasSuffix: String? = nil, _ subfields: (UserErrorQuery) -> Void) -> CustomerRecoverPayloadQuery {
 			let subquery = UserErrorQuery()
@@ -13,8 +15,9 @@ extension Storefront {
 		}
 	}
 
-	open class CustomerRecoverPayload: GraphQL.AbstractResponse
-	{
+	open class CustomerRecoverPayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CustomerRecoverPayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CustomerResetPayload.swift
+++ b/Buy/Generated/Storefront/CustomerResetPayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CustomerResetPayloadQuery: GraphQL.AbstractQuery {
+	open class CustomerResetPayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CustomerResetPayload
+
 		@discardableResult
 		open func customer(aliasSuffix: String? = nil, _ subfields: (CustomerQuery) -> Void) -> CustomerResetPayloadQuery {
 			let subquery = CustomerQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CustomerResetPayload: GraphQL.AbstractResponse
-	{
+	open class CustomerResetPayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CustomerResetPayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/CustomerUpdatePayload.swift
+++ b/Buy/Generated/Storefront/CustomerUpdatePayload.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class CustomerUpdatePayloadQuery: GraphQL.AbstractQuery {
+	open class CustomerUpdatePayloadQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = CustomerUpdatePayload
+
 		@discardableResult
 		open func customer(aliasSuffix: String? = nil, _ subfields: (CustomerQuery) -> Void) -> CustomerUpdatePayloadQuery {
 			let subquery = CustomerQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class CustomerUpdatePayload: GraphQL.AbstractResponse
-	{
+	open class CustomerUpdatePayload: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = CustomerUpdatePayloadQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/Domain.swift
+++ b/Buy/Generated/Storefront/Domain.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class DomainQuery: GraphQL.AbstractQuery {
+	open class DomainQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = Domain
+
 		@discardableResult
 		open func host(aliasSuffix: String? = nil) -> DomainQuery {
 			addField(field: "host", aliasSuffix: aliasSuffix)
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class Domain: GraphQL.AbstractResponse
-	{
+	open class Domain: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = DomainQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/Image.swift
+++ b/Buy/Generated/Storefront/Image.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class ImageQuery: GraphQL.AbstractQuery {
+	open class ImageQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = Image
+
 		@discardableResult
 		open func altText(aliasSuffix: String? = nil) -> ImageQuery {
 			addField(field: "altText", aliasSuffix: aliasSuffix)
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class Image: GraphQL.AbstractResponse
-	{
+	open class Image: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = ImageQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/ImageConnection.swift
+++ b/Buy/Generated/Storefront/ImageConnection.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class ImageConnectionQuery: GraphQL.AbstractQuery {
+	open class ImageConnectionQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = ImageConnection
+
 		@discardableResult
 		open func edges(aliasSuffix: String? = nil, _ subfields: (ImageEdgeQuery) -> Void) -> ImageConnectionQuery {
 			let subquery = ImageEdgeQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class ImageConnection: GraphQL.AbstractResponse
-	{
+	open class ImageConnection: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = ImageConnectionQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/ImageEdge.swift
+++ b/Buy/Generated/Storefront/ImageEdge.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class ImageEdgeQuery: GraphQL.AbstractQuery {
+	open class ImageEdgeQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = ImageEdge
+
 		@discardableResult
 		open func cursor(aliasSuffix: String? = nil) -> ImageEdgeQuery {
 			addField(field: "cursor", aliasSuffix: aliasSuffix)
@@ -19,8 +21,9 @@ extension Storefront {
 		}
 	}
 
-	open class ImageEdge: GraphQL.AbstractResponse
-	{
+	open class ImageEdge: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = ImageEdgeQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/MailingAddress.swift
+++ b/Buy/Generated/Storefront/MailingAddress.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class MailingAddressQuery: GraphQL.AbstractQuery {
+	open class MailingAddressQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = MailingAddress
+
 		@discardableResult
 		open func address1(aliasSuffix: String? = nil) -> MailingAddressQuery {
 			addField(field: "address1", aliasSuffix: aliasSuffix)
@@ -118,8 +120,9 @@ extension Storefront {
 		}
 	}
 
-	open class MailingAddress: GraphQL.AbstractResponse, Node
-	{
+	open class MailingAddress: GraphQL.AbstractResponse, GraphQLObject, Node {
+		public typealias Query = MailingAddressQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/MailingAddressConnection.swift
+++ b/Buy/Generated/Storefront/MailingAddressConnection.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class MailingAddressConnectionQuery: GraphQL.AbstractQuery {
+	open class MailingAddressConnectionQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = MailingAddressConnection
+
 		@discardableResult
 		open func edges(aliasSuffix: String? = nil, _ subfields: (MailingAddressEdgeQuery) -> Void) -> MailingAddressConnectionQuery {
 			let subquery = MailingAddressEdgeQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class MailingAddressConnection: GraphQL.AbstractResponse
-	{
+	open class MailingAddressConnection: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = MailingAddressConnectionQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/MailingAddressEdge.swift
+++ b/Buy/Generated/Storefront/MailingAddressEdge.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class MailingAddressEdgeQuery: GraphQL.AbstractQuery {
+	open class MailingAddressEdgeQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = MailingAddressEdge
+
 		@discardableResult
 		open func cursor(aliasSuffix: String? = nil) -> MailingAddressEdgeQuery {
 			addField(field: "cursor", aliasSuffix: aliasSuffix)
@@ -19,8 +21,9 @@ extension Storefront {
 		}
 	}
 
-	open class MailingAddressEdge: GraphQL.AbstractResponse
-	{
+	open class MailingAddressEdge: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = MailingAddressEdgeQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/Mutation.swift
+++ b/Buy/Generated/Storefront/Mutation.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class MutationQuery: GraphQL.AbstractQuery {
+	open class MutationQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = Mutation
+
 		open override var description: String {
 			return "mutation" + super.description
 		}
@@ -438,8 +440,9 @@ extension Storefront {
 		}
 	}
 
-	open class Mutation: GraphQL.AbstractResponse
-	{
+	open class Mutation: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = MutationQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/Node.swift
+++ b/Buy/Generated/Storefront/Node.swift
@@ -12,7 +12,9 @@ public protocol Node {
 }
 
 extension Storefront {
-	open class NodeQuery: GraphQL.AbstractQuery {
+	open class NodeQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = Node
+
 		@discardableResult
 		open func id(aliasSuffix: String? = nil) -> NodeQuery {
 			addField(field: "id", aliasSuffix: aliasSuffix)
@@ -113,8 +115,9 @@ extension Storefront {
 		}
 	}
 
-	open class UnknownNode: GraphQL.AbstractResponse, Node
-	{
+	open class UnknownNode: GraphQL.AbstractResponse, GraphQLObject, Node {
+		public typealias Query = NodeQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/Order.swift
+++ b/Buy/Generated/Storefront/Order.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class OrderQuery: GraphQL.AbstractQuery {
+	open class OrderQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = Order
+
 		@discardableResult
 		open func cancelReason(aliasSuffix: String? = nil) -> OrderQuery {
 			addField(field: "cancelReason", aliasSuffix: aliasSuffix)
@@ -144,8 +146,9 @@ extension Storefront {
 		}
 	}
 
-	open class Order: GraphQL.AbstractResponse, Node
-	{
+	open class Order: GraphQL.AbstractResponse, GraphQLObject, Node {
+		public typealias Query = OrderQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/OrderConnection.swift
+++ b/Buy/Generated/Storefront/OrderConnection.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class OrderConnectionQuery: GraphQL.AbstractQuery {
+	open class OrderConnectionQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = OrderConnection
+
 		@discardableResult
 		open func edges(aliasSuffix: String? = nil, _ subfields: (OrderEdgeQuery) -> Void) -> OrderConnectionQuery {
 			let subquery = OrderEdgeQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class OrderConnection: GraphQL.AbstractResponse
-	{
+	open class OrderConnection: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = OrderConnectionQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/OrderEdge.swift
+++ b/Buy/Generated/Storefront/OrderEdge.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class OrderEdgeQuery: GraphQL.AbstractQuery {
+	open class OrderEdgeQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = OrderEdge
+
 		@discardableResult
 		open func cursor(aliasSuffix: String? = nil) -> OrderEdgeQuery {
 			addField(field: "cursor", aliasSuffix: aliasSuffix)
@@ -19,8 +21,9 @@ extension Storefront {
 		}
 	}
 
-	open class OrderEdge: GraphQL.AbstractResponse
-	{
+	open class OrderEdge: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = OrderEdgeQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/OrderLineItem.swift
+++ b/Buy/Generated/Storefront/OrderLineItem.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class OrderLineItemQuery: GraphQL.AbstractQuery {
+	open class OrderLineItemQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = OrderLineItem
+
 		@discardableResult
 		open func customAttributes(aliasSuffix: String? = nil, _ subfields: (AttributeQuery) -> Void) -> OrderLineItemQuery {
 			let subquery = AttributeQuery()
@@ -34,8 +36,9 @@ extension Storefront {
 		}
 	}
 
-	open class OrderLineItem: GraphQL.AbstractResponse
-	{
+	open class OrderLineItem: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = OrderLineItemQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/OrderLineItemConnection.swift
+++ b/Buy/Generated/Storefront/OrderLineItemConnection.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class OrderLineItemConnectionQuery: GraphQL.AbstractQuery {
+	open class OrderLineItemConnectionQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = OrderLineItemConnection
+
 		@discardableResult
 		open func edges(aliasSuffix: String? = nil, _ subfields: (OrderLineItemEdgeQuery) -> Void) -> OrderLineItemConnectionQuery {
 			let subquery = OrderLineItemEdgeQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class OrderLineItemConnection: GraphQL.AbstractResponse
-	{
+	open class OrderLineItemConnection: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = OrderLineItemConnectionQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/OrderLineItemEdge.swift
+++ b/Buy/Generated/Storefront/OrderLineItemEdge.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class OrderLineItemEdgeQuery: GraphQL.AbstractQuery {
+	open class OrderLineItemEdgeQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = OrderLineItemEdge
+
 		@discardableResult
 		open func cursor(aliasSuffix: String? = nil) -> OrderLineItemEdgeQuery {
 			addField(field: "cursor", aliasSuffix: aliasSuffix)
@@ -19,8 +21,9 @@ extension Storefront {
 		}
 	}
 
-	open class OrderLineItemEdge: GraphQL.AbstractResponse
-	{
+	open class OrderLineItemEdge: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = OrderLineItemEdgeQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/PageInfo.swift
+++ b/Buy/Generated/Storefront/PageInfo.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class PageInfoQuery: GraphQL.AbstractQuery {
+	open class PageInfoQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = PageInfo
+
 		@discardableResult
 		open func hasNextPage(aliasSuffix: String? = nil) -> PageInfoQuery {
 			addField(field: "hasNextPage", aliasSuffix: aliasSuffix)
@@ -16,8 +18,9 @@ extension Storefront {
 		}
 	}
 
-	open class PageInfo: GraphQL.AbstractResponse
-	{
+	open class PageInfo: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = PageInfoQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/Payment.swift
+++ b/Buy/Generated/Storefront/Payment.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class PaymentQuery: GraphQL.AbstractQuery {
+	open class PaymentQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = Payment
+
 		@discardableResult
 		open func amount(aliasSuffix: String? = nil) -> PaymentQuery {
 			addField(field: "amount", aliasSuffix: aliasSuffix)
@@ -76,8 +78,9 @@ extension Storefront {
 		}
 	}
 
-	open class Payment: GraphQL.AbstractResponse, Node
-	{
+	open class Payment: GraphQL.AbstractResponse, GraphQLObject, Node {
+		public typealias Query = PaymentQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/ProductConnection.swift
+++ b/Buy/Generated/Storefront/ProductConnection.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class ProductConnectionQuery: GraphQL.AbstractQuery {
+	open class ProductConnectionQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = ProductConnection
+
 		@discardableResult
 		open func edges(aliasSuffix: String? = nil, _ subfields: (ProductEdgeQuery) -> Void) -> ProductConnectionQuery {
 			let subquery = ProductEdgeQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class ProductConnection: GraphQL.AbstractResponse
-	{
+	open class ProductConnection: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = ProductConnectionQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/ProductEdge.swift
+++ b/Buy/Generated/Storefront/ProductEdge.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class ProductEdgeQuery: GraphQL.AbstractQuery {
+	open class ProductEdgeQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = ProductEdge
+
 		@discardableResult
 		open func cursor(aliasSuffix: String? = nil) -> ProductEdgeQuery {
 			addField(field: "cursor", aliasSuffix: aliasSuffix)
@@ -19,8 +21,9 @@ extension Storefront {
 		}
 	}
 
-	open class ProductEdge: GraphQL.AbstractResponse
-	{
+	open class ProductEdge: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = ProductEdgeQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/ProductOption.swift
+++ b/Buy/Generated/Storefront/ProductOption.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class ProductOptionQuery: GraphQL.AbstractQuery {
+	open class ProductOptionQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = ProductOption
+
 		@discardableResult
 		open func id(aliasSuffix: String? = nil) -> ProductOptionQuery {
 			addField(field: "id", aliasSuffix: aliasSuffix)
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class ProductOption: GraphQL.AbstractResponse, Node
-	{
+	open class ProductOption: GraphQL.AbstractResponse, GraphQLObject, Node {
+		public typealias Query = ProductOptionQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/ProductVariant.swift
+++ b/Buy/Generated/Storefront/ProductVariant.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class ProductVariantQuery: GraphQL.AbstractQuery {
+	open class ProductVariantQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = ProductVariant
+
 		@discardableResult
 		open func available(aliasSuffix: String? = nil) -> ProductVariantQuery {
 			addField(field: "available", aliasSuffix: aliasSuffix)
@@ -87,8 +89,9 @@ extension Storefront {
 		}
 	}
 
-	open class ProductVariant: GraphQL.AbstractResponse, Node
-	{
+	open class ProductVariant: GraphQL.AbstractResponse, GraphQLObject, Node {
+		public typealias Query = ProductVariantQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/ProductVariantConnection.swift
+++ b/Buy/Generated/Storefront/ProductVariantConnection.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class ProductVariantConnectionQuery: GraphQL.AbstractQuery {
+	open class ProductVariantConnectionQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = ProductVariantConnection
+
 		@discardableResult
 		open func edges(aliasSuffix: String? = nil, _ subfields: (ProductVariantEdgeQuery) -> Void) -> ProductVariantConnectionQuery {
 			let subquery = ProductVariantEdgeQuery()
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class ProductVariantConnection: GraphQL.AbstractResponse
-	{
+	open class ProductVariantConnection: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = ProductVariantConnectionQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/ProductVariantEdge.swift
+++ b/Buy/Generated/Storefront/ProductVariantEdge.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class ProductVariantEdgeQuery: GraphQL.AbstractQuery {
+	open class ProductVariantEdgeQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = ProductVariantEdge
+
 		@discardableResult
 		open func cursor(aliasSuffix: String? = nil) -> ProductVariantEdgeQuery {
 			addField(field: "cursor", aliasSuffix: aliasSuffix)
@@ -19,8 +21,9 @@ extension Storefront {
 		}
 	}
 
-	open class ProductVariantEdge: GraphQL.AbstractResponse
-	{
+	open class ProductVariantEdge: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = ProductVariantEdgeQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/QueryRoot.swift
+++ b/Buy/Generated/Storefront/QueryRoot.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class QueryRootQuery: GraphQL.AbstractQuery {
+	open class QueryRootQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = QueryRoot
+
 		@discardableResult
 		open func customer(aliasSuffix: String? = nil, customerAccessToken: String, _ subfields: (CustomerQuery) -> Void) -> QueryRootQuery {
 			var args: [String] = []
@@ -43,8 +45,9 @@ extension Storefront {
 		}
 	}
 
-	open class QueryRoot: GraphQL.AbstractResponse
-	{
+	open class QueryRoot: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = QueryRootQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/SelectedOption.swift
+++ b/Buy/Generated/Storefront/SelectedOption.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class SelectedOptionQuery: GraphQL.AbstractQuery {
+	open class SelectedOptionQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = SelectedOption
+
 		@discardableResult
 		open func name(aliasSuffix: String? = nil) -> SelectedOptionQuery {
 			addField(field: "name", aliasSuffix: aliasSuffix)
@@ -16,8 +18,9 @@ extension Storefront {
 		}
 	}
 
-	open class SelectedOption: GraphQL.AbstractResponse
-	{
+	open class SelectedOption: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = SelectedOptionQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/SelectedOptionInput.swift
+++ b/Buy/Generated/Storefront/SelectedOptionInput.swift
@@ -1,0 +1,30 @@
+// Generated from graphql_swift_gen gem
+import Foundation
+
+extension Storefront {
+	open class SelectedOptionInput {
+		open var name: String
+
+		open var value: String
+
+		public init(
+			name: String,
+
+			value: String
+		) {
+			self.name = name
+
+			self.value = value
+		}
+
+		func serialize() -> String {
+			var fields: [String] = []
+
+			fields.append("name:\(GraphQL.quoteString(input: name))")
+
+			fields.append("value:\(GraphQL.quoteString(input: value))")
+
+			return "{\(fields.joined(separator: ","))}"
+		}
+	}
+}

--- a/Buy/Generated/Storefront/ShippingRate.swift
+++ b/Buy/Generated/Storefront/ShippingRate.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class ShippingRateQuery: GraphQL.AbstractQuery {
+	open class ShippingRateQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = ShippingRate
+
 		@discardableResult
 		open func handle(aliasSuffix: String? = nil) -> ShippingRateQuery {
 			addField(field: "handle", aliasSuffix: aliasSuffix)
@@ -22,8 +24,9 @@ extension Storefront {
 		}
 	}
 
-	open class ShippingRate: GraphQL.AbstractResponse
-	{
+	open class ShippingRate: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = ShippingRateQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/Shop.swift
+++ b/Buy/Generated/Storefront/Shop.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class ShopQuery: GraphQL.AbstractQuery {
+	open class ShopQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = Shop
+
 		@discardableResult
 		open func collections(aliasSuffix: String? = nil, first: Int32, after: String? = nil, sortKey: CollectionSortKeys? = nil, reverse: Bool? = nil, query: String? = nil, _ subfields: (CollectionConnectionQuery) -> Void) -> ShopQuery {
 			var args: [String] = []
@@ -117,6 +119,12 @@ extension Storefront {
 		}
 
 		@discardableResult
+		open func shopifyPaymentsAccountId(aliasSuffix: String? = nil) -> ShopQuery {
+			addField(field: "shopifyPaymentsAccountId", aliasSuffix: aliasSuffix)
+			return self
+		}
+
+		@discardableResult
 		open func termsOfService(aliasSuffix: String? = nil, _ subfields: (ShopPolicyQuery) -> Void) -> ShopQuery {
 			let subquery = ShopPolicyQuery()
 			subfields(subquery)
@@ -126,8 +134,9 @@ extension Storefront {
 		}
 	}
 
-	open class Shop: GraphQL.AbstractResponse
-	{
+	open class Shop: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = ShopQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {
@@ -187,6 +196,13 @@ extension Storefront {
 					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
 				}
 				return try ShopPolicy(fields: value)
+
+				case "shopifyPaymentsAccountId":
+				if value is NSNull { return nil }
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				}
+				return value
 
 				case "termsOfService":
 				if value is NSNull { return nil }
@@ -282,6 +298,14 @@ extension Storefront {
 			return field(field: "refundPolicy", aliasSuffix: aliasSuffix) as! Storefront.ShopPolicy?
 		}
 
+		open var shopifyPaymentsAccountId: String? {
+			return internalGetShopifyPaymentsAccountId()
+		}
+
+		func internalGetShopifyPaymentsAccountId(aliasSuffix: String? = nil) -> String? {
+			return field(field: "shopifyPaymentsAccountId", aliasSuffix: aliasSuffix) as! String?
+		}
+
 		open var termsOfService: Storefront.ShopPolicy? {
 			return internalGetTermsOfService()
 		}
@@ -327,6 +351,10 @@ extension Storefront {
 				case "refundPolicy":
 
 				return .Object
+
+				case "shopifyPaymentsAccountId":
+
+				return .Scalar
 
 				case "termsOfService":
 

--- a/Buy/Generated/Storefront/ShopPolicy.swift
+++ b/Buy/Generated/Storefront/ShopPolicy.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class ShopPolicyQuery: GraphQL.AbstractQuery {
+	open class ShopPolicyQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = ShopPolicy
+
 		@discardableResult
 		open func body(aliasSuffix: String? = nil) -> ShopPolicyQuery {
 			addField(field: "body", aliasSuffix: aliasSuffix)
@@ -28,8 +30,9 @@ extension Storefront {
 		}
 	}
 
-	open class ShopPolicy: GraphQL.AbstractResponse, Node
-	{
+	open class ShopPolicy: GraphQL.AbstractResponse, GraphQLObject, Node {
+		public typealias Query = ShopPolicyQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/Transaction.swift
+++ b/Buy/Generated/Storefront/Transaction.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class TransactionQuery: GraphQL.AbstractQuery {
+	open class TransactionQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = Transaction
+
 		@discardableResult
 		open func amount(aliasSuffix: String? = nil) -> TransactionQuery {
 			addField(field: "amount", aliasSuffix: aliasSuffix)
@@ -28,8 +30,9 @@ extension Storefront {
 		}
 	}
 
-	open class Transaction: GraphQL.AbstractResponse
-	{
+	open class Transaction: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = TransactionQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Buy/Generated/Storefront/UserError.swift
+++ b/Buy/Generated/Storefront/UserError.swift
@@ -2,7 +2,9 @@
 import Foundation
 
 extension Storefront {
-	open class UserErrorQuery: GraphQL.AbstractQuery {
+	open class UserErrorQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = UserError
+
 		@discardableResult
 		open func field(aliasSuffix: String? = nil) -> UserErrorQuery {
 			addField(field: "field", aliasSuffix: aliasSuffix)
@@ -16,8 +18,9 @@ extension Storefront {
 		}
 	}
 
-	open class UserError: GraphQL.AbstractResponse
-	{
+	open class UserError: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = UserErrorQuery
+
 		open override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
 			let fieldValue = value
 			switch fieldName {

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'graphql_swift_gen'
+gem 'graphql_swift_gen', path: 'Dependencies/Swift Gen'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,19 @@
+PATH
+  remote: Dependencies/Swift Gen
+  specs:
+    graphql_swift_gen (0.1.0)
+      graphql_schema (~> 0.1.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
     graphql_schema (0.1.1)
-    graphql_swift_gen (0.1.0)
-      graphql_schema (~> 0.1.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  graphql_swift_gen
+  graphql_swift_gen!
 
 BUNDLED WITH
    1.14.3


### PR DESCRIPTION
Updates schema and migrates to using a local version of `graphql_swift_gen` using a custom `buy-sdk` branch. Doing so allows us to declare most internal implementation methods as `internal` instead of `public`, keeping the interface of generated classes nice and neat.