### PR TITLE
Cache

### DIFF
--- a/Buy.xcodeproj/project.pbxproj
+++ b/Buy.xcodeproj/project.pbxproj
@@ -134,6 +134,8 @@
 		9A0C80B51EAA51C50020F187 /* WeightUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0C80561EAA51C50020F187 /* WeightUnit.swift */; };
 		9A0C80B61EAA51C50020F187 /* Storefront.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0C80571EAA51C50020F187 /* Storefront.swift */; };
 		9A0C80FC1EBA27970020F187 /* SelectedOptionInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0C80FB1EBA27970020F187 /* SelectedOptionInput.swift */; };
+		9A0C81051EBA66440020F187 /* Graph.Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0C81041EBA66440020F187 /* Graph.Cache.swift */; };
+		9A0C81071EBA66800020F187 /* Graph.CachePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0C81061EBA66800020F187 /* Graph.CachePolicy.swift */; };
 		9A4068E51E8E7659000254CD /* Pay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A4068DC1E8E7658000254CD /* Pay.framework */; };
 		9A4068EA1E8E7659000254CD /* PaySessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4068E91E8E7659000254CD /* PaySessionTests.swift */; };
 		9A4068EC1E8E7659000254CD /* Pay.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A4068DE1E8E7659000254CD /* Pay.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -149,6 +151,9 @@
 		9A4069CF1E8ED98A000254CD /* Graph.Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4069CE1E8ED98A000254CD /* Graph.Task.swift */; };
 		9A6F3BA41EBB5BD700B149F4 /* DigestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6F3BA31EBB5BD700B149F4 /* DigestTests.swift */; };
 		9A6F3BA61EBB5F2400B149F4 /* Digest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6F3BA51EBB5F2400B149F4 /* Digest.swift */; };
+		9A6F3BA91EBB6A7500B149F4 /* Graph.CacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6F3BA81EBB6A7500B149F4 /* Graph.CacheTests.swift */; };
+		9AA7AC761EBB77660014D95D /* Graph.CacheItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA7AC751EBB77660014D95D /* Graph.CacheItem.swift */; };
+		9AA7AC781EBB78160014D95D /* Graph.CacheItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA7AC771EBB78160014D95D /* Graph.CacheItemTests.swift */; };
 		9AADF1C71EA63ED000D22740 /* MockPaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AADF1C61EA63ED000D22740 /* MockPaymentMethod.swift */; };
 		9AADF1C91EA63FB900D22740 /* MockPaymentToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AADF1C81EA63FB900D22740 /* MockPaymentToken.swift */; };
 		9AADF1CB1EA640C000D22740 /* MockPayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AADF1CA1EA640C000D22740 /* MockPayment.swift */; };
@@ -295,6 +300,8 @@
 		9A0C80561EAA51C50020F187 /* WeightUnit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeightUnit.swift; sourceTree = "<group>"; };
 		9A0C80571EAA51C50020F187 /* Storefront.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Storefront.swift; sourceTree = "<group>"; };
 		9A0C80FB1EBA27970020F187 /* SelectedOptionInput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectedOptionInput.swift; sourceTree = "<group>"; };
+		9A0C81041EBA66440020F187 /* Graph.Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.Cache.swift; sourceTree = "<group>"; };
+		9A0C81061EBA66800020F187 /* Graph.CachePolicy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.CachePolicy.swift; sourceTree = "<group>"; };
 		9A4068DC1E8E7658000254CD /* Pay.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pay.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A4068DE1E8E7659000254CD /* Pay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Pay.h; sourceTree = "<group>"; };
 		9A4068DF1E8E7659000254CD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -315,7 +322,10 @@
 		9A6F3B9A1EBB49A000B149F4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9A6F3BA31EBB5BD700B149F4 /* DigestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DigestTests.swift; sourceTree = "<group>"; };
 		9A6F3BA51EBB5F2400B149F4 /* Digest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Digest.swift; sourceTree = "<group>"; };
+		9A6F3BA81EBB6A7500B149F4 /* Graph.CacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.CacheTests.swift; sourceTree = "<group>"; };
 		9AA6B6D61E9D563C00CE9F18 /* GraphQL+ScalarSupportTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GraphQL+ScalarSupportTests.swift"; sourceTree = "<group>"; };
+		9AA7AC751EBB77660014D95D /* Graph.CacheItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.CacheItem.swift; sourceTree = "<group>"; };
+		9AA7AC771EBB78160014D95D /* Graph.CacheItemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.CacheItemTests.swift; sourceTree = "<group>"; };
 		9AA89E851E9BD8930075AC74 /* Graph.TaskTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.TaskTests.swift; sourceTree = "<group>"; };
 		9AA89E871E9BDB7F0075AC74 /* Graph.ClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.ClientTests.swift; sourceTree = "<group>"; };
 		9AA89E8A1E9BDC590075AC74 /* MockSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockSession.swift; sourceTree = "<group>"; };
@@ -557,6 +567,8 @@
 		9AA89E841E9BD8740075AC74 /* Client */ = {
 			isa = PBXGroup;
 			children = (
+				9A6F3BA81EBB6A7500B149F4 /* Graph.CacheTests.swift */,
+				9AA7AC771EBB78160014D95D /* Graph.CacheItemTests.swift */,
 				9AA89E851E9BD8930075AC74 /* Graph.TaskTests.swift */,
 				9AA89E871E9BDB7F0075AC74 /* Graph.ClientTests.swift */,
 				9AA89E951E9D29B40075AC74 /* Graph.QueryError.swift */,
@@ -587,6 +599,9 @@
 			isa = PBXGroup;
 			children = (
 				9A4069CB1E8EA710000254CD /* Graph.swift */,
+				9A0C81061EBA66800020F187 /* Graph.CachePolicy.swift */,
+				9A0C81041EBA66440020F187 /* Graph.Cache.swift */,
+				9AA7AC751EBB77660014D95D /* Graph.CacheItem.swift */,
 				9A4069CE1E8ED98A000254CD /* Graph.Task.swift */,
 				9AEF61B81E5F64230067FA90 /* Graph.Client.swift */,
 				9AAFAB761E6080A500864A17 /* Graph.QueryError.swift */,
@@ -1010,6 +1025,7 @@
 				9A0C808D1EAA51C50020F187 /* Domain.swift in Sources */,
 				9A0C80B11EAA51C50020F187 /* Transaction.swift in Sources */,
 				9A0C80631EAA51C50020F187 /* CheckoutCreatePayload.swift in Sources */,
+				9A0C81051EBA66440020F187 /* Graph.Cache.swift in Sources */,
 				9A0C80961EAA51C50020F187 /* Node.swift in Sources */,
 				9A0C80711EAA51C50020F187 /* CheckoutShippingAddressUpdatePayload.swift in Sources */,
 				9A0C809F1EAA51C50020F187 /* OrderLineItemEdge.swift in Sources */,
@@ -1036,6 +1052,7 @@
 				9A0C806F1EAA51C50020F187 /* CheckoutLineItemsUpdatePayload.swift in Sources */,
 				9AAFAB721E60766E00864A17 /* Global.swift in Sources */,
 				9A0C808F1EAA51C50020F187 /* ImageConnection.swift in Sources */,
+				9A0C81071EBA66800020F187 /* Graph.CachePolicy.swift in Sources */,
 				9A0C80A81EAA51C50020F187 /* ProductVariant.swift in Sources */,
 				9A0C80B31EAA51C50020F187 /* TransactionStatus.swift in Sources */,
 				9A0C80761EAA51C50020F187 /* CollectionSortKeys.swift in Sources */,
@@ -1043,6 +1060,7 @@
 				9A0C80911EAA51C50020F187 /* MailingAddress.swift in Sources */,
 				9A0C80791EAA51C50020F187 /* CropRegion.swift in Sources */,
 				9A0C806E1EAA51C50020F187 /* CheckoutLineItemsRemovePayload.swift in Sources */,
+				9AA7AC761EBB77660014D95D /* Graph.CacheItem.swift in Sources */,
 				9A0C805C1EAA51C50020F187 /* Checkout.swift in Sources */,
 				9A0C806A1EAA51C50020F187 /* CheckoutLineItemConnection.swift in Sources */,
 				9A0C80931EAA51C50020F187 /* MailingAddressEdge.swift in Sources */,
@@ -1092,12 +1110,14 @@
 			files = (
 				9A0C7FED1EAA3F7E0020F187 /* GraphQL+ScalarSupportTests.swift in Sources */,
 				9A0C7FF01EAA3F7E0020F187 /* Graph.QueryError.swift in Sources */,
+				9A6F3BA91EBB6A7500B149F4 /* Graph.CacheTests.swift in Sources */,
 				9A6F3BA41EBB5BD700B149F4 /* DigestTests.swift in Sources */,
 				9A0C7FEB1EAA3F7E0020F187 /* MockSession.swift in Sources */,
 				9A0C7FEF1EAA3F7E0020F187 /* Graph.ClientTests.swift in Sources */,
 				9A0C7FF21EAA3F7E0020F187 /* BuyTests.swift in Sources */,
 				9A0C7FF11EAA3F7E0020F187 /* Graph.RetryHandlerTests.swift in Sources */,
 				9A0C7FEE1EAA3F7E0020F187 /* Graph.TaskTests.swift in Sources */,
+				9AA7AC781EBB78160014D95D /* Graph.CacheItemTests.swift in Sources */,
 				9A0C7FEC1EAA3F7E0020F187 /* MockSessionDataTask.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1465,6 +1485,7 @@
 				9A6F3B9D1EBB49A000B149F4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		9AEF60ED1E5F42D90067FA90 /* Build configuration list for PBXProject "Buy" */ = {
 			isa = XCConfigurationList;

--- a/Buy.xcodeproj/project.pbxproj
+++ b/Buy.xcodeproj/project.pbxproj
@@ -171,6 +171,13 @@
 			remoteGlobalIDString = 9A4068DB1E8E7658000254CD;
 			remoteInfo = Pay;
 		};
+		9A6F3B9F1EBB4AE800B149F4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9AEF60EA1E5F42D90067FA90 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9A6F3B961EBB49A000B149F4;
+			remoteInfo = Crypto;
+		};
 		9AFA38F01E64850A0056C5AA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9AEF60EA1E5F42D90067FA90 /* Project object */;
@@ -302,6 +309,8 @@
 		9A4069C91E8EA6DB000254CD /* Graph.RetryHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.RetryHandler.swift; sourceTree = "<group>"; };
 		9A4069CB1E8EA710000254CD /* Graph.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.swift; sourceTree = "<group>"; };
 		9A4069CE1E8ED98A000254CD /* Graph.Task.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.Task.swift; sourceTree = "<group>"; };
+		9A6F3B971EBB49A000B149F4 /* Crypto.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Crypto.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A6F3B9A1EBB49A000B149F4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9AA6B6D61E9D563C00CE9F18 /* GraphQL+ScalarSupportTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GraphQL+ScalarSupportTests.swift"; sourceTree = "<group>"; };
 		9AA89E851E9BD8930075AC74 /* Graph.TaskTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.TaskTests.swift; sourceTree = "<group>"; };
 		9AA89E871E9BDB7F0075AC74 /* Graph.ClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.ClientTests.swift; sourceTree = "<group>"; };
@@ -342,6 +351,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				9A4068E51E8E7659000254CD /* Pay.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9A6F3B931EBB49A000B149F4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -510,6 +526,14 @@
 			path = PayTests;
 			sourceTree = "<group>";
 		};
+		9A6F3B981EBB49A000B149F4 /* Crypto */ = {
+			isa = PBXGroup;
+			children = (
+				9A6F3B9A1EBB49A000B149F4 /* Info.plist */,
+			);
+			path = Crypto;
+			sourceTree = "<group>";
+		};
 		9AA6B6D51E9D562200CE9F18 /* Custom */ = {
 			isa = PBXGroup;
 			children = (
@@ -578,6 +602,7 @@
 				9AFA38EB1E64850A0056C5AA /* BuyTests */,
 				9A4068DD1E8E7659000254CD /* Pay */,
 				9A4068E81E8E7659000254CD /* PayTests */,
+				9A6F3B981EBB49A000B149F4 /* Crypto */,
 				9AEF60F41E5F42D90067FA90 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -589,6 +614,7 @@
 				9AFA38EA1E64850A0056C5AA /* BuyTests.xctest */,
 				9A4068DC1E8E7658000254CD /* Pay.framework */,
 				9A4068E41E8E7659000254CD /* PayTests.xctest */,
+				9A6F3B971EBB49A000B149F4 /* Crypto.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -655,6 +681,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9A6F3B941EBB49A000B149F4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9AEF60F01E5F42D90067FA90 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -702,6 +735,24 @@
 			productReference = 9A4068E41E8E7659000254CD /* PayTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		9A6F3B961EBB49A000B149F4 /* Crypto */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9A6F3B9E1EBB49A000B149F4 /* Build configuration list for PBXNativeTarget "Crypto" */;
+			buildPhases = (
+				9A6F3B921EBB49A000B149F4 /* Sources */,
+				9A6F3B931EBB49A000B149F4 /* Frameworks */,
+				9A6F3B941EBB49A000B149F4 /* Headers */,
+				9A6F3B951EBB49A000B149F4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Crypto;
+			productName = Crypto;
+			productReference = 9A6F3B971EBB49A000B149F4 /* Crypto.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		9AEF60F21E5F42D90067FA90 /* Buy */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9AEF60FB1E5F42D90067FA90 /* Build configuration list for PBXNativeTarget "Buy" */;
@@ -714,6 +765,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				9A6F3BA01EBB4AE800B149F4 /* PBXTargetDependency */,
 			);
 			name = Buy;
 			productName = Buy;
@@ -764,6 +816,12 @@
 						DevelopmentTeam = A7XGC83MZE;
 						ProvisioningStyle = Automatic;
 					};
+					9A6F3B961EBB49A000B149F4 = {
+						CreatedOnToolsVersion = 8.3.1;
+						DevelopmentTeam = A7XGC83MZE;
+						LastSwiftMigration = 0830;
+						ProvisioningStyle = Automatic;
+					};
 					9AEF60F21E5F42D90067FA90 = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = A7XGC83MZE;
@@ -793,6 +851,7 @@
 				9A4068DB1E8E7658000254CD /* Pay */,
 				9A4068E31E8E7659000254CD /* PayTests */,
 				9A0C80C51EAE73840020F187 /* Documentation */,
+				9A6F3B961EBB49A000B149F4 /* Crypto */,
 			);
 		};
 /* End PBXProject section */
@@ -806,6 +865,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		9A4068E21E8E7659000254CD /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9A6F3B951EBB49A000B149F4 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -884,6 +950,13 @@
 				9A0C7FD31EA66DF70020F187 /* PayDiscountTests.swift in Sources */,
 				9AADF1C71EA63ED000D22740 /* MockPaymentMethod.swift in Sources */,
 				9A0C7FDD1EA699280020F187 /* PayShippingRateTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9A6F3B921EBB49A000B149F4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1021,6 +1094,11 @@
 			target = 9A4068DB1E8E7658000254CD /* Pay */;
 			targetProxy = 9A4068E61E8E7659000254CD /* PBXContainerItemProxy */;
 		};
+		9A6F3BA01EBB4AE800B149F4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9A6F3B961EBB49A000B149F4 /* Crypto */;
+			targetProxy = 9A6F3B9F1EBB4AE800B149F4 /* PBXContainerItemProxy */;
+		};
 		9AFA38F11E64850A0056C5AA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 9AEF60F21E5F42D90067FA90 /* Buy */;
@@ -1117,6 +1195,53 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.shopify.PayTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
+		9A6F3B9C1EBB49A000B149F4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = A7XGC83MZE;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Crypto/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = Crypto/iphone.modulemap;
+				PRODUCT_BUNDLE_IDENTIFIER = com.shopify.Crypto;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		9A6F3B9D1EBB49A000B149F4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = A7XGC83MZE;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Crypto/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = Crypto/iphone.modulemap;
+				PRODUCT_BUNDLE_IDENTIFIER = com.shopify.Crypto;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
@@ -1316,6 +1441,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		9A6F3B9E1EBB49A000B149F4 /* Build configuration list for PBXNativeTarget "Crypto" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9A6F3B9C1EBB49A000B149F4 /* Debug */,
+				9A6F3B9D1EBB49A000B149F4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 		9AEF60ED1E5F42D90067FA90 /* Build configuration list for PBXProject "Buy" */ = {
 			isa = XCConfigurationList;

--- a/Buy.xcodeproj/project.pbxproj
+++ b/Buy.xcodeproj/project.pbxproj
@@ -147,6 +147,8 @@
 		9A4069CA1E8EA6DB000254CD /* Graph.RetryHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4069C91E8EA6DB000254CD /* Graph.RetryHandler.swift */; };
 		9A4069CC1E8EA710000254CD /* Graph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4069CB1E8EA710000254CD /* Graph.swift */; };
 		9A4069CF1E8ED98A000254CD /* Graph.Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4069CE1E8ED98A000254CD /* Graph.Task.swift */; };
+		9A6F3BA41EBB5BD700B149F4 /* DigestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6F3BA31EBB5BD700B149F4 /* DigestTests.swift */; };
+		9A6F3BA61EBB5F2400B149F4 /* Digest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6F3BA51EBB5F2400B149F4 /* Digest.swift */; };
 		9AADF1C71EA63ED000D22740 /* MockPaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AADF1C61EA63ED000D22740 /* MockPaymentMethod.swift */; };
 		9AADF1C91EA63FB900D22740 /* MockPaymentToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AADF1C81EA63FB900D22740 /* MockPaymentToken.swift */; };
 		9AADF1CB1EA640C000D22740 /* MockPayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AADF1CA1EA640C000D22740 /* MockPayment.swift */; };
@@ -311,6 +313,8 @@
 		9A4069CE1E8ED98A000254CD /* Graph.Task.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.Task.swift; sourceTree = "<group>"; };
 		9A6F3B971EBB49A000B149F4 /* Crypto.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Crypto.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A6F3B9A1EBB49A000B149F4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9A6F3BA31EBB5BD700B149F4 /* DigestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DigestTests.swift; sourceTree = "<group>"; };
+		9A6F3BA51EBB5F2400B149F4 /* Digest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Digest.swift; sourceTree = "<group>"; };
 		9AA6B6D61E9D563C00CE9F18 /* GraphQL+ScalarSupportTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GraphQL+ScalarSupportTests.swift"; sourceTree = "<group>"; };
 		9AA89E851E9BD8930075AC74 /* Graph.TaskTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.TaskTests.swift; sourceTree = "<group>"; };
 		9AA89E871E9BDB7F0075AC74 /* Graph.ClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.ClientTests.swift; sourceTree = "<group>"; };
@@ -534,6 +538,14 @@
 			path = Crypto;
 			sourceTree = "<group>";
 		};
+		9A6F3BA71EBB5F4D00B149F4 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				9A6F3BA31EBB5BD700B149F4 /* DigestTests.swift */,
+			);
+			name = Utilities;
+			sourceTree = "<group>";
+		};
 		9AA6B6D51E9D562200CE9F18 /* Custom */ = {
 			isa = PBXGroup;
 			children = (
@@ -562,12 +574,13 @@
 			name = Mocks;
 			sourceTree = "<group>";
 		};
-		9AAFAB701E60766300864A17 /* Global */ = {
+		9AAFAB701E60766300864A17 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
 				9AAFAB711E60766E00864A17 /* Global.swift */,
+				9A6F3BA51EBB5F2400B149F4 /* Digest.swift */,
 			);
-			name = Global;
+			name = Utilities;
 			sourceTree = "<group>";
 		};
 		9AAFAB731E60804F00864A17 /* Client */ = {
@@ -622,7 +635,7 @@
 		9AEF60F51E5F42D90067FA90 /* Buy */ = {
 			isa = PBXGroup;
 			children = (
-				9AAFAB701E60766300864A17 /* Global */,
+				9AAFAB701E60766300864A17 /* Utilities */,
 				9AAFAB731E60804F00864A17 /* Client */,
 				9AEF619F1E5F5A050067FA90 /* Custom */,
 				9AEF60FE1E5F439D0067FA90 /* Generated */,
@@ -653,6 +666,7 @@
 			isa = PBXGroup;
 			children = (
 				9AA89E891E9BDC4A0075AC74 /* Mocks */,
+				9A6F3BA71EBB5F4D00B149F4 /* Utilities */,
 				9AA6B6D51E9D562200CE9F18 /* Custom */,
 				9AA89E841E9BD8740075AC74 /* Client */,
 				9AFA38EC1E64850A0056C5AA /* BuyTests.swift */,
@@ -983,6 +997,7 @@
 				9A0C807B1EAA51C50020F187 /* Customer.swift in Sources */,
 				9A0C807D1EAA51C50020F187 /* CustomerAccessTokenCreateInput.swift in Sources */,
 				9A0C808B1EAA51C50020F187 /* CustomerUpdateInput.swift in Sources */,
+				9A6F3BA61EBB5F2400B149F4 /* Digest.swift in Sources */,
 				9A0C80991EAA51C50020F187 /* OrderConnection.swift in Sources */,
 				9A4069CA1E8EA6DB000254CD /* Graph.RetryHandler.swift in Sources */,
 				9A0C807A1EAA51C50020F187 /* CurrencyCode.swift in Sources */,
@@ -1077,6 +1092,7 @@
 			files = (
 				9A0C7FED1EAA3F7E0020F187 /* GraphQL+ScalarSupportTests.swift in Sources */,
 				9A0C7FF01EAA3F7E0020F187 /* Graph.QueryError.swift in Sources */,
+				9A6F3BA41EBB5BD700B149F4 /* DigestTests.swift in Sources */,
 				9A0C7FEB1EAA3F7E0020F187 /* MockSession.swift in Sources */,
 				9A0C7FEF1EAA3F7E0020F187 /* Graph.ClientTests.swift in Sources */,
 				9A0C7FF21EAA3F7E0020F187 /* BuyTests.swift in Sources */,

--- a/Buy/Digest.swift
+++ b/Buy/Digest.swift
@@ -1,0 +1,60 @@
+//
+//  Digest.swift
+//  Buy
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+import Crypto
+
+struct Digest {
+    
+    static func md5(_ data: Data) -> [UInt8] {
+        
+        var context = CC_MD5_CTX()
+        var digest  = [UInt8](repeating: 0, count: Int(CC_MD5_DIGEST_LENGTH))
+        
+        CC_MD5_Init(&context)
+        data.forEach { byte in
+            CC_MD5_Update(&context, [byte], 1)
+        }
+        CC_MD5_Final(&digest, &context)
+        
+        return digest
+    }
+}
+
+extension String {
+    
+    var md5: String {
+        let data = self.data(using: .utf8)!
+        return Digest.md5(data).hex
+    }
+}
+
+extension Array where Element == UInt8 {
+    
+    var hex: String {
+        return self.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Buy/Digest.swift
+++ b/Buy/Digest.swift
@@ -47,8 +47,14 @@ struct Digest {
 extension String {
     
     var md5: String {
-        let data = self.data(using: .utf8)!
-        return Digest.md5(data).hex
+        return self.data(using: .utf8)!.md5
+    }
+}
+
+extension Data {
+    
+    var md5: String {
+        return Digest.md5(self).hex
     }
 }
 

--- a/Buy/Digest.swift
+++ b/Buy/Digest.swift
@@ -29,6 +29,8 @@ import Crypto
 
 struct Digest {
     
+    private init() {}
+    
     static func md5(_ data: Data) -> [UInt8] {
         
         var context = CC_MD5_CTX()

--- a/Buy/Graph.Cache.swift
+++ b/Buy/Graph.Cache.swift
@@ -1,0 +1,88 @@
+//
+//  Graph.Cache.swift
+//  Buy
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+internal extension Graph {
+    
+    typealias Hash = String
+    
+    internal class Cache {
+        
+        static let cacheName = "com.buy.graph.cache"
+        
+        private static let fileManager = FileManager.default
+        
+        // ----------------------------------
+        //  MARK: - Init -
+        //
+        init() {
+            self.createCacheDirectoryIfNeeded()
+        }
+        
+        private func createCacheDirectoryIfNeeded() {
+            let cacheDirectory = Cache.cacheDirectory()
+            if !Cache.fileManager.fileExists(atPath: cacheDirectory.path) {
+                try! Cache.fileManager.createDirectory(at: cacheDirectory, withIntermediateDirectories: true, attributes: nil)
+            }
+        }
+        
+        func purge() {
+            try? Cache.fileManager.removeItem(at: Cache.cacheDirectory())
+            self.createCacheDirectoryIfNeeded()
+        }
+        
+        // ----------------------------------
+        //  MARK: - Accessors -
+        //
+        func data(for hash: Hash) -> Data? {
+            let location = Graph.CacheItem.Location(inParent: Cache.cacheDirectory(), hash: hash)
+            if let item = CacheItem(at: location) {
+                return item.data
+            }
+            return nil
+        }
+        
+        func set(_ data: Data, for hash: Hash) {
+            let location  = Graph.CacheItem.Location(inParent: Cache.cacheDirectory(), hash: hash)
+            let cacheItem = CacheItem(hash: hash, data: data)
+                
+            cacheItem.write(to: location)
+        }
+        
+        // ----------------------------------
+        //  MARK: - File System -
+        //
+        static func cacheDirectory() -> URL {
+            let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            let url = tmp.appendingPathComponent(Cache.cacheName)
+            
+            return url
+        }
+    }
+}
+
+

--- a/Buy/Graph.CacheItem.swift
+++ b/Buy/Graph.CacheItem.swift
@@ -90,6 +90,9 @@ internal extension Graph {
     }
 }
 
+// ----------------------------------
+//  MARK: - Location -
+//
 extension Graph.CacheItem {
     internal struct Location {
         
@@ -111,5 +114,19 @@ extension Graph.CacheItem {
             self.dataURL = dataURL
             self.metaURL = metaURL
         }
+    }
+}
+
+// ----------------------------------
+//  MARK: - URLRequest Hash -
+//
+extension URLRequest {
+    
+    var cacheItem: Graph.CacheItem {
+        return Graph.CacheItem(hash: self.hash, data: self.httpBody ?? Data())
+    }
+    
+    var hash: Graph.Hash {
+        return (self.httpBody ?? Data()).md5
     }
 }

--- a/Buy/Graph.CacheItem.swift
+++ b/Buy/Graph.CacheItem.swift
@@ -110,7 +110,7 @@ extension Graph.CacheItem {
             )
         }
         
-        init(dataURL: URL, metaURL: URL) {
+        internal init(dataURL: URL, metaURL: URL) {
             self.dataURL = dataURL
             self.metaURL = metaURL
         }

--- a/Buy/Graph.CacheItem.swift
+++ b/Buy/Graph.CacheItem.swift
@@ -1,0 +1,115 @@
+//
+//  Graph.CacheItem.swift
+//  Buy
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+internal extension Graph {
+    
+    internal class CacheItem {
+        
+        let hash:      Hash
+        let data:      Data
+        let timestamp: Double
+        
+        // ----------------------------------
+        //  MARK: - Init -
+        //
+        init(hash: Hash, data: Data, timestamp: Double = Date().timeIntervalSince1970) {
+            self.hash      = hash
+            self.data      = data
+            self.timestamp = timestamp
+        }
+        
+        init?(at location: Location) {
+            guard let result = CacheItem.read(from: location) else {
+                return nil
+            }
+            
+            self.data      = result.data
+            self.hash      = result.meta["hash"]      as! String
+            self.timestamp = result.meta["timestamp"] as! Double
+        }
+        
+        // ----------------------------------
+        //  MARK: - IO -
+        //
+        private static func read(from location: Location) -> (data: Data, meta: [String : Any])? {
+            guard let data = try? Data(contentsOf: location.dataURL),
+                let meta = try? Data(contentsOf: location.metaURL),
+                let json = (try? JSONSerialization.jsonObject(with: meta, options: [])) as? [String : Any] else {
+                    
+                    return nil
+            }
+            
+            return (data, json)
+        }
+        
+        @discardableResult
+        func write(to location: Location) -> Bool {
+            let metaJson: [String : Any] = [
+                "hash"      : self.hash,
+                "timestamp" : self.timestamp
+            ]
+            
+            do {
+                let metaData = try JSONSerialization.data(withJSONObject: metaJson, options: [])
+                
+                try metaData.write(to: location.metaURL, options: .atomic)
+                try self.data.write(to: location.dataURL, options: .atomic)
+                
+            } catch {
+                print("Failed to flush CacheItem: \(error)")
+                return false
+            }
+            
+            return true
+        }
+    }
+}
+
+extension Graph.CacheItem {
+    internal struct Location {
+        
+        let dataURL: URL
+        let metaURL: URL
+        
+        // ----------------------------------
+        //  MARK: - Init -
+        //
+        init(inParent url: URL, hash: Graph.Hash) {
+            let dataURL = url.appendingPathComponent(hash)
+            self.init(
+                dataURL: dataURL,
+                metaURL: dataURL.appendingPathExtension("meta")
+            )
+        }
+        
+        init(dataURL: URL, metaURL: URL) {
+            self.dataURL = dataURL
+            self.metaURL = metaURL
+        }
+    }
+}

--- a/Buy/Graph.CachePolicy.swift
+++ b/Buy/Graph.CachePolicy.swift
@@ -1,0 +1,50 @@
+//
+//  Graph.CachePolicy.swift
+//  Buy
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+public extension Graph {
+    
+    /// The caching policy defines the method for executing the query.
+    /// Some policies require an `expireIn` parameter that determines
+    /// the time (in seconds) until the cache is invalidated and is
+    /// considered to be stale.
+    ///
+    public enum CachePolicy {
+        
+        /// Load from cache without loading from network
+        case cacheOnly
+        
+        /// Load from network without loading from cache
+        case networkOnly
+        
+        /// Load from cache if staleness interval is not exceeded, otherwise load from network
+        case cacheFirst(expireIn: Int)
+        
+        /// Load from network but fallback to cached data if the request fails
+        case networkFirst(expireIn: Int)
+    }
+}

--- a/Buy/Graph.Client.swift
+++ b/Buy/Graph.Client.swift
@@ -212,6 +212,17 @@ extension Graph {
 }
 
 // ----------------------------------
+//  MARK: - URLRequest Hash -
+//
+extension URLRequest {
+    
+    var hash: Graph.Hash {
+        precondition(self.httpBody != nil, "URLRequest requires a non-empty HTTP body to calculate cache key.")
+        return self.httpBody!.md5
+    }
+}
+
+// ----------------------------------
 //  MARK: - Graph Data Task -
 //
 private extension URLSession {

--- a/Buy/Graph.Client.swift
+++ b/Buy/Graph.Client.swift
@@ -212,17 +212,6 @@ extension Graph {
 }
 
 // ----------------------------------
-//  MARK: - URLRequest Hash -
-//
-extension URLRequest {
-    
-    var hash: Graph.Hash {
-        precondition(self.httpBody != nil, "URLRequest requires a non-empty HTTP body to calculate cache key.")
-        return self.httpBody!.md5
-    }
-}
-
-// ----------------------------------
 //  MARK: - Graph Data Task -
 //
 private extension URLSession {

--- a/BuyTests/DigestTests.swift
+++ b/BuyTests/DigestTests.swift
@@ -71,11 +71,20 @@ class DigestTests: XCTestCase {
     }
     
     // ----------------------------------
-    //  MARK: - Extensions -
+    //  MARK: - String -
     //
     func testStringExtensions() {
         let query = "query { shop { name } }"
         
         XCTAssertEqual(query.md5, "37d3868e50b398dc12ddd14ba1cec315")
+    }
+    
+    // ----------------------------------
+    //  MARK: - Data -
+    //
+    func testDataExtensions() {
+        let data = "query { shop { name } }".data(using: .utf8)!
+        
+        XCTAssertEqual(data.md5, "37d3868e50b398dc12ddd14ba1cec315")
     }
 }

--- a/BuyTests/DigestTests.swift
+++ b/BuyTests/DigestTests.swift
@@ -1,0 +1,81 @@
+//
+//  DigestTests.swift
+//  BuyTests
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import XCTest
+@testable import Buy
+
+class DigestTests: XCTestCase {
+
+    // ----------------------------------
+    //  MARK: - Digest -
+    //
+    func testDigest() {
+        let query = "query { shop { name } }"
+        let bytes = Digest.md5(query.data(using: .utf8)!)
+        
+        XCTAssertEqual(bytes[0], 55)
+        XCTAssertEqual(bytes[1], 211)
+        XCTAssertEqual(bytes[2], 134)
+        XCTAssertEqual(bytes[3], 142)
+        XCTAssertEqual(bytes[4], 80)
+        XCTAssertEqual(bytes[5], 179)
+        XCTAssertEqual(bytes[6], 152)
+        XCTAssertEqual(bytes[7], 220)
+        XCTAssertEqual(bytes[8], 18)
+        XCTAssertEqual(bytes[9], 221)
+        XCTAssertEqual(bytes[10], 209)
+        XCTAssertEqual(bytes[11], 75)
+        XCTAssertEqual(bytes[12], 161)
+        XCTAssertEqual(bytes[13], 206)
+        XCTAssertEqual(bytes[14], 195)
+        XCTAssertEqual(bytes[15], 21)
+    }
+    
+    // ----------------------------------
+    //  MARK: - Hex -
+    //
+    func testHex() {
+        let hex = "f687ae568e"
+        let bytes: [UInt8] = [
+            0xf6,
+            0x87,
+            0xae,
+            0x56,
+            0x8e,
+        ]
+        
+        XCTAssertEqual(bytes.hex, hex)
+    }
+    
+    // ----------------------------------
+    //  MARK: - Extensions -
+    //
+    func testStringExtensions() {
+        let query = "query { shop { name } }"
+        
+        XCTAssertEqual(query.md5, "37d3868e50b398dc12ddd14ba1cec315")
+    }
+}

--- a/BuyTests/Graph.CacheItemTests.swift
+++ b/BuyTests/Graph.CacheItemTests.swift
@@ -90,13 +90,13 @@ class Graph_CacheItemTests: XCTestCase {
         let location = Graph.CacheItem.Location(inParent: self.testDirectory, hash: "test-item")
         
         XCTAssertFalse(self.fileManager.fileExists(atPath: location.dataURL.path))
-        XCTAssertFalse(self.fileManager.fileExists(atPath: location.dataURL.path))
+        XCTAssertFalse(self.fileManager.fileExists(atPath: location.metaURL.path))
         
         let success = item.write(to: location)
         
         XCTAssertTrue(success)
         XCTAssertTrue(self.fileManager.fileExists(atPath: location.dataURL.path))
-        XCTAssertTrue(self.fileManager.fileExists(atPath: location.dataURL.path))
+        XCTAssertTrue(self.fileManager.fileExists(atPath: location.metaURL.path))
     }
     
     func testWriteRestricted() {

--- a/BuyTests/Graph.CacheItemTests.swift
+++ b/BuyTests/Graph.CacheItemTests.swift
@@ -1,0 +1,142 @@
+//
+//  Graph.CacheItemTests.swift
+//  BuyTests
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import XCTest
+@testable import Buy
+
+class Graph_CacheItemTests: XCTestCase {
+
+    let fileManager   = FileManager.default
+    let testDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("com.cache.test")
+    
+    // ----------------------------------
+    //  MARK: - Setup -
+    //
+    override func setUp() {
+        super.setUp()
+        
+        try! self.fileManager.createDirectory(at: self.testDirectory, withIntermediateDirectories: true, attributes: nil)
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        
+        try! self.fileManager.removeItem(at: self.testDirectory)
+    }
+    
+    // ----------------------------------
+    //  MARK: - Init -
+    //
+    func testInit() {
+        let data  = "abc".data(using: .utf8)!
+        let hash  = "123"
+        let stamp = Date().timeIntervalSince1970
+        let item  = Graph.CacheItem(hash: hash, data: data, timestamp: stamp)
+        
+        XCTAssertEqual(item.hash, hash)
+        XCTAssertEqual(item.data, data)
+        XCTAssertEqual(item.timestamp, stamp)
+    }
+    
+    func testInitFromHashEmpty() {
+        let location      = Graph.CacheItem.Location(inParent: self.testDirectory, hash: "abcdefg")
+        let retrievedItem = Graph.CacheItem(at: location)
+        
+        XCTAssertNil(retrievedItem)
+    }
+    
+    func testInitFromHash() {
+        let item     = self.defaultCacheItem()
+        let location = Graph.CacheItem.Location(inParent: self.testDirectory, hash: item.hash)
+        
+        item.write(to: location)
+        
+        let retrievedItem = Graph.CacheItem(at: location)
+        
+        XCTAssertNotNil(retrievedItem)
+        XCTAssertEqual(item.data,      retrievedItem!.data)
+        XCTAssertEqual(item.hash,      retrievedItem!.hash)
+        XCTAssertEqual(item.timestamp, retrievedItem!.timestamp)
+    }
+    
+    // ----------------------------------
+    //  MARK: - Write -
+    //
+    func testWrite() {
+        let item     = self.defaultCacheItem()
+        let location = Graph.CacheItem.Location(inParent: self.testDirectory, hash: "test-item")
+        
+        XCTAssertFalse(self.fileManager.fileExists(atPath: location.dataURL.path))
+        XCTAssertFalse(self.fileManager.fileExists(atPath: location.dataURL.path))
+        
+        let success = item.write(to: location)
+        
+        XCTAssertTrue(success)
+        XCTAssertTrue(self.fileManager.fileExists(atPath: location.dataURL.path))
+        XCTAssertTrue(self.fileManager.fileExists(atPath: location.dataURL.path))
+    }
+    
+    func testWriteRestricted() {
+        let item     = self.defaultCacheItem()
+        let root     = URL(fileURLWithPath: "/") // Shouldn't be able to write to root -> "/"
+        let location = Graph.CacheItem.Location(inParent: root, hash: "test-item-2")
+        
+        let success = item.write(to: location)
+        
+        XCTAssertFalse(success)
+    }
+    
+    // ----------------------------------
+    //  MARK: - Location -
+    //
+    func testLocationInitInParent() {
+        let parentURL = URL(fileURLWithPath: "/root")
+        let location  = Graph.CacheItem.Location(inParent: parentURL, hash: "123")
+        
+        XCTAssertEqual(location.dataURL.absoluteString, "file:///root/123")
+        XCTAssertEqual(location.metaURL.absoluteString, "file:///root/123.meta")
+    }
+    
+    func testLocationInit() {
+        let url1      = URL(fileURLWithPath: "/root")
+        let url2      = URL(fileURLWithPath: "/var")
+        let location  = Graph.CacheItem.Location(dataURL: url1, metaURL: url2)
+        
+        XCTAssertEqual(location.dataURL.absoluteString, url1.absoluteString)
+        XCTAssertEqual(location.metaURL.absoluteString, url2.absoluteString)
+    }
+    
+    // ----------------------------------
+    //  MARK: - Private -
+    //
+    private func defaultCacheItem() -> Graph.CacheItem {
+        let data  = "abc".data(using: .utf8)!
+        let hash  = "123"
+        let stamp = Date().timeIntervalSince1970
+        
+        return Graph.CacheItem(hash: hash, data: data, timestamp: stamp)
+    }
+}

--- a/BuyTests/Graph.CacheItemTests.swift
+++ b/BuyTests/Graph.CacheItemTests.swift
@@ -77,9 +77,9 @@ class Graph_CacheItemTests: XCTestCase {
         let retrievedItem = Graph.CacheItem(at: location)
         
         XCTAssertNotNil(retrievedItem)
-        XCTAssertEqual(item.data,      retrievedItem!.data)
-        XCTAssertEqual(item.hash,      retrievedItem!.hash)
-        XCTAssertEqual(item.timestamp, retrievedItem!.timestamp)
+        XCTAssertEqual(item.data, retrievedItem!.data)
+        XCTAssertEqual(item.hash, retrievedItem!.hash)
+        XCTAssertEqual(Int(item.timestamp * 100.0), Int(retrievedItem!.timestamp * 100.0))
     }
     
     // ----------------------------------

--- a/BuyTests/Graph.CacheTests.swift
+++ b/BuyTests/Graph.CacheTests.swift
@@ -1,0 +1,113 @@
+//
+//  Graph.CacheTests.swift
+//  BuyTests
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import XCTest
+@testable import Buy
+
+class Graph_CacheTests: XCTestCase {
+    
+    enum Query {
+        case one  
+        case two  
+        case three
+        
+        var data: Data {
+            switch self {
+            case .one:   return "query { shop { name } }".data(using: .utf8)!
+            case .two:   return "query { shop { id } }".data(using: .utf8)!
+            case .three: return "query { shop { id name } }".data(using: .utf8)!
+            }
+        }
+    }
+
+    // ----------------------------------
+    //  MARK: - Init -
+    //
+    func testInit() {
+        let cache = Graph.Cache()
+        XCTAssertNotNil(cache)
+    }
+    
+    // ----------------------------------
+    //  MARK: - Purge -
+    //
+    func testPurge() {
+        let cache   = self.defaultCache()
+        let request = self.defaultRequest(query: .two)
+        
+        cache.purge()
+        
+        let data = cache.data(for: request.hash)
+        XCTAssertEqual(data, nil)
+        
+        cache.set(request.httpBody!, for: request.hash)
+        
+        let data2 = cache.data(for: request.hash)
+        XCTAssertEqual(data2, request.httpBody)
+        
+        cache.purge()
+        
+        let data3 = cache.data(for: request.hash)
+        XCTAssertEqual(data3, nil)
+    }
+    
+    // ----------------------------------
+    //  MARK: - Accessors -
+    //
+    func testRetrieveEmpty() {
+        let cache   = self.defaultCache()
+        let request = self.defaultRequest()
+        
+        cache.purge()
+        
+        let data = cache.data(for: request.hash)
+        XCTAssertNil(data)
+    }
+    
+    func testStoreAndRetrieve() {
+        let cache   = self.defaultCache()
+        let request = self.defaultRequest()
+        
+        cache.purge()
+        cache.set(request.httpBody!, for: request.hash)
+        
+        let data = cache.data(for: request.hash)
+        XCTAssertEqual(request.httpBody!, data)
+    }
+    
+    // ----------------------------------
+    //  MARK: - Private -
+    //
+    private func defaultCache() -> Graph.Cache {
+        return Graph.Cache()
+    }
+    
+    private func defaultRequest(query: Query = .one) -> URLRequest {
+        var request      = URLRequest(url: URL(string: "https://www.google.com")!)
+        request.httpBody = query.data
+        return request
+    }
+}

--- a/Crypto/Info.plist
+++ b/Crypto/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Crypto/iphone.modulemap
+++ b/Crypto/iphone.modulemap
@@ -1,0 +1,4 @@
+module Crypto {
+    header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include/CommonCrypto/CommonCrypto.h"
+    export *
+}


### PR DESCRIPTION
### What this does

Adds `Graph.Cache` and `Graph.CacheItem` to facilitate caching responses to disk using the query as the key. The `Graph.Client` doesn't actually do anything with the cache yet. That functionality is coming in a later PR. For now, it's just the cache classes and unit tests.

#### How it works

A `Graph.CacheItem` represents the data of a cacheable response along with a timestamp and hash. Each `Graph.CacheItem` is stored as two separate files on disk:

- `37d3868e50b398dc12ddd14ba1cec315`
- `37d3868e50b398dc12ddd14ba1cec315.meta`

Where the plain hash file contains the response data and the `.meta` file contains a JSON of the remaining meta data, like this:
```json
{
  "hash": "37d3868e50b398dc12ddd14ba1cec315",
  "timestamp": 1493923948,
}
```

The `Graph.Cache` is then able to write and read cached data corresponding to the `Hash` passed in as the key. To speed up reads and writes and avoid hitting the disk for every cache access, `Graph.Cache` also implements an `NSCache` to store the responses in memory. `NSCache` will then automatically purge objects based on memory pressure.

#### What's up with the weird Crypto target?

Since `libCommonCrypto.dylib` is a C-based library and not a module, Swift has a really hard time figuring out what it is. Ideally, we just want to `import Crypto` and go on our merry way. To do this, we introduce a new target with a custom `.modulemap` file that simply maps the `CommonCrypto` header to a module. Having done that, we **can** `import Crypto` as any other framework 🎉 