### PR TITLE
Client cache policy

### DIFF
--- a/Buy/Graph.Client.swift
+++ b/Buy/Graph.Client.swift
@@ -59,6 +59,9 @@ extension Graph {
     ///
     public class Client {
         
+        /// Cache policy to use for all `query` operations produced by this instance of `Graph.Client` 
+        public var cachePolicy: CachePolicy = .networkOnly
+        
         /// The `URLSession` backing all `Client` network operations. You can provide your own session when initializing a new `Client`.
         public let session: URLSession
         
@@ -121,10 +124,10 @@ extension Graph {
         /// task.resume()
         /// ````
         ///
-        public func queryGraphWith(_ query: Storefront.QueryRootQuery, cachePolicy: CachePolicy = .networkOnly, retryHandler: RetryHandler<Storefront.QueryRoot>? = nil, completionHandler: @escaping QueryCompletion) -> Task {
+        public func queryGraphWith(_ query: Storefront.QueryRootQuery, cachePolicy: CachePolicy? = nil, retryHandler: RetryHandler<Storefront.QueryRoot>? = nil, completionHandler: @escaping QueryCompletion) -> Task {
             return self.graphRequestTask(
                 query:             query,
-                cachePolicy:       cachePolicy,
+                cachePolicy:       cachePolicy ?? self.cachePolicy,
                 retryHandler:      retryHandler,
                 completionHandler: completionHandler
             )

--- a/BuyTests/Graph.ClientTests.swift
+++ b/BuyTests/Graph.ClientTests.swift
@@ -39,6 +39,7 @@ class Graph_ClientTests: XCTestCase {
         let client = self.defaultClient()
         
         XCTAssertEqual(client.apiURL.absoluteString, "https://\(self.shopDomain)/api/graphql")
+        XCTAssertEqual(client.cachePolicy, .networkOnly)
     }
     
     func testDomainGeneration() {
@@ -87,15 +88,23 @@ class Graph_ClientTests: XCTestCase {
         let payload = self.defaultQueryPayload()
         let request = client.graphRequestFor(query: payload.query)
         
-        let task = client.queryGraphWith(payload.query, cachePolicy: .networkFirst(expireIn: 20)) { query, error in
-            
-        } as! Graph.InternalTask<Storefront.QueryRoot>
+        let task = client.queryGraphWith(payload.query, cachePolicy: .networkFirst(expireIn: 20)) { query, error in } as! Graph.InternalTask<Storefront.QueryRoot>
         
         XCTAssertTrue(task.session === client.session)
         XCTAssertTrue(task.cache   === client.cache)
         XCTAssertEqual(task.request, request)
         XCTAssertEqual(task.cachePolicy, .networkFirst(expireIn: 20))
         XCTAssertNil(task.retryHandler)
+    }
+    
+    func testDefaultClientCachePolicyForQuery() {
+        let client         = self.defaultClient()
+        client.cachePolicy = .cacheOnly
+        
+        let payload = self.defaultQueryPayload()
+        let task    = client.queryGraphWith(payload.query) { query, error in } as! Graph.InternalTask<Storefront.QueryRoot>
+        
+        XCTAssertEqual(task.cachePolicy, .cacheOnly)
     }
     
     func testMutation() {


### PR DESCRIPTION
### What this does

Adds a default client-wide `CachePolicy` that will be extended to each `query` operation if no cache policy is provided. Add tests for this behaviour.