### PR TITLE
remove variant from cart

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYCart.h
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYCart.h
@@ -61,9 +61,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  Removes the BUYCartLineItem from the BUYCart associated with the given BUYProductVariant object.
- *  If the associated BUYCartLineItem exists, that BUYCartLineItem's quantity is decreased by one.
- *
- *  @param variant The BUYProductVariant to remove from the BUYCart or decrease by one quantity
+
+ *  @param variant The BUYProductVariant to remove from the BUYCart 
  */
 - (void)removeVariant:(BUYProductVariant *)variant;
 

--- a/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYCart.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Models/Persistent/BUYCart.m
@@ -78,7 +78,7 @@
 	[self willChangeValueForKey:BUYCartRelationships.lineItems];
 	
 	BUYCartLineItem *lineItem = [self linetItemForVariant:variant];
-	if (lineItem && [lineItem decrementQuantity].integerValue <= 0) {
+	if (lineItem) {
 		[self.lineItemsSet removeObject:lineItem];
 	}
 	


### PR DESCRIPTION
Shopify is already giving option to decrease the quantity. If there would be product quantity of three now it would be easy to delete product from cart only by one call. 