### PR TITLE
Update CI configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ osx_image: xcode8.3
 rvm:
   - 2.2
   
+before_install:
+  - gem install xcpretty
+  
 script:
-- set -o pipefail
-- ./Scripts/test_buy
-- ./Scripts/test_pay
+  - set -o pipefail
+  - ./Scripts/test_buy
+  - ./Scripts/test_pay

--- a/Scripts/test_buy
+++ b/Scripts/test_buy
@@ -7,5 +7,5 @@ xcodebuild test \
 -project "Buy.xcodeproj" \
 -scheme "Buy" \
 -sdk iphonesimulator \
--destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3' \
+-destination 'platform=iOS Simulator,name=iPhone 7,OS=latest' \
  | xcpretty -c

--- a/Scripts/test_pay
+++ b/Scripts/test_pay
@@ -7,5 +7,5 @@ xcodebuild test \
 -project "Buy.xcodeproj" \
 -scheme "Pay" \
 -sdk iphonesimulator \
--destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3' \
+-destination 'platform=iOS Simulator,name=iPhone 7,OS=latest' \
  | xcpretty -c


### PR DESCRIPTION
Fixes issues with TravisCI not recognizing `xcpretty` and using incorrect simulator versions. Using  `OS=latest` we can ensure that builds don't brake with a new release of iOS / Xcode / Simulators.