### PR TITLE
UITableView estimated height

### DIFF
--- a/Sample Apps/Storefront/Storefront/CartViewController.swift
+++ b/Sample Apps/Storefront/Storefront/CartViewController.swift
@@ -76,6 +76,7 @@ class CartViewController: ParallaxViewController {
     }
     
     private func configureTableView() {
+        self.tableView.rowHeight = UITableViewAutomaticDimension
         self.tableView.estimatedRowHeight = 100.0
         self.tableView.register(UINib(nibName: "CartCell", bundle: nil), forCellReuseIdentifier: "CartCell")
         

--- a/Sample Apps/Storefront/Storefront/ProductDetailsViewController.swift
+++ b/Sample Apps/Storefront/Storefront/ProductDetailsViewController.swift
@@ -69,6 +69,7 @@ class ProductDetailsViewController: ParallaxViewController {
         self.tableView.register(ProductHeaderCell.self)
         self.tableView.register(ProductDetailsCell.self)
         
+        self.tableView.rowHeight = UITableViewAutomaticDimension
         self.tableView.estimatedRowHeight = 44.0
     }
     


### PR DESCRIPTION
### What this does
Building and running with Xcode 9 revealed some issues surrounding how `UITableView` configures self-sizing cells. Explicit assignments of `UITableViewAutomaticDimension` for `rowHeight` fix the layout issues encountered when building with the new iOS 11 SDK.