### PR TITLE
Fix date initialization for 12hour time format in UTC-0 region.

### DIFF
--- a/Mobile Buy SDK/Mobile Buy SDK/Additions/NSDateFormatter+BUYAdditions.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Additions/NSDateFormatter+BUYAdditions.m
@@ -38,29 +38,9 @@
 + (NSDateFormatter*)dateFormatterForPublications
 {
 	NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-	
-	if (![self is24hTimeFormat]) {
-		[dateFormatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_GB"]];
-	}
-	
+	[dateFormatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_GB"]];
 	dateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ssZ";
 	return dateFormatter;
-}
-
-+ (BOOL)is24hTimeFormat
-{
-	NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-	[formatter setLocale:[NSLocale currentLocale]];
-	[formatter setDateStyle:NSDateFormatterNoStyle];
-	[formatter setTimeStyle:NSDateFormatterShortStyle];
-	
-	NSString *dateString = [formatter stringFromDate:[NSDate date]];
-	
-	NSRange amRange = [dateString rangeOfString:[formatter AMSymbol]];
-	NSRange pmRange = [dateString rangeOfString:[formatter PMSymbol]];
-	BOOL is24h = (amRange.location == NSNotFound && pmRange.location == NSNotFound);
-	
-	return is24h;
 }
 
 @end

--- a/Mobile Buy SDK/Mobile Buy SDK/Additions/NSDateFormatter+BUYAdditions.m
+++ b/Mobile Buy SDK/Mobile Buy SDK/Additions/NSDateFormatter+BUYAdditions.m
@@ -38,8 +38,29 @@
 + (NSDateFormatter*)dateFormatterForPublications
 {
 	NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+	
+	if (![self is24hTimeFormat]) {
+		[dateFormatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_GB"]];
+	}
+	
 	dateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ssZ";
 	return dateFormatter;
+}
+
++ (BOOL)is24hTimeFormat
+{
+	NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+	[formatter setLocale:[NSLocale currentLocale]];
+	[formatter setDateStyle:NSDateFormatterNoStyle];
+	[formatter setTimeStyle:NSDateFormatterShortStyle];
+	
+	NSString *dateString = [formatter stringFromDate:[NSDate date]];
+	
+	NSRange amRange = [dateString rangeOfString:[formatter AMSymbol]];
+	NSRange pmRange = [dateString rangeOfString:[formatter PMSymbol]];
+	BOOL is24h = (amRange.location == NSNotFound && pmRange.location == NSNotFound);
+	
+	return is24h;
 }
 
 @end


### PR DESCRIPTION
Fixes date initialization fail for case when user locale is in UTC-0 and time format is set as non 24-hour.

Date formatter locale is set to "us_GB" instead of currentLocale if 12-hour time format is set in user settings.

Fixes #665 