### PR TITLE
Update README to fix incorrect reference to `cardUrl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,7 +585,7 @@ The Buy SDK support native checkout via GraphQL, which lets you complete a check
 Like `Graph.Client`, the `Card.Client` manages your interactions with the card server that provides opaque credit card tokens. The tokens are used to complete checkouts. After collecting the user's credit card information in a secure manner, create a credit card representation and submit a vault request:
 
 ```swift
-// let checkout: Storefront.Checkout
+// let shop: Storefront.Shop
 // let cardClient: Card.Client
 
 let creditCard = Card.CreditCard(
@@ -598,7 +598,7 @@ let creditCard = Card.CreditCard(
 	verificationCode: "1234"
 )
 
-let task = cardClient.vault(creditCard, to: checkout.vaultUrl) { token, error in
+let task = cardClient.vault(creditCard, to: shop.cardVaultUrl) { token, error in
     if let token = token {
         // proceed to complete checkout with `token`
     } else {


### PR DESCRIPTION
### What this does

Updates README to fix incorrect reference to `cardUrl`.

Fixes #680
