### PR TITLE
Improved support for checkouts that don't ship

### DIFF
--- a/Pay/PayAddress.swift
+++ b/Pay/PayAddress.swift
@@ -139,15 +139,25 @@ internal extension PayPostalAddress {
 internal extension PayAddress {
 
     init(with contact: PKContact) {
-        let street = contact.postalAddress!.street
-        let lines  = street.components(separatedBy: .newlines)
+        
+        var line1: String?
+        var line2: String?
+        
+        if let address = contact.postalAddress {
+            let street = address.street
+            let lines  = street.components(separatedBy: .newlines)
+            
+            line1      = lines.count > 0 ? lines[0] : nil
+            line2      = lines.count > 1 ? lines[1] : nil
+        }
+        
         self.init(
-            addressLine1: !street.isEmpty && lines.count > 0 ? lines[0] : nil,
-            addressLine2: !street.isEmpty && lines.count > 1 ? lines[1] : nil,
-            city:         contact.postalAddress!.city,
-            country:      contact.postalAddress!.country,
-            province:     contact.postalAddress!.state,
-            zip:          contact.postalAddress!.postalCode,
+            addressLine1: line1,
+            addressLine2: line2,
+            city:         contact.postalAddress?.city,
+            country:      contact.postalAddress?.country,
+            province:     contact.postalAddress?.state,
+            zip:          contact.postalAddress?.postalCode,
             firstName:    contact.name?.givenName,
             lastName:     contact.name?.familyName,
             phone:        contact.phoneNumber?.stringValue,

--- a/Pay/PayAddress.swift
+++ b/Pay/PayAddress.swift
@@ -145,10 +145,11 @@ internal extension PayAddress {
         
         if let address = contact.postalAddress {
             let street = address.street
-            let lines  = street.components(separatedBy: .newlines)
-            
-            line1      = lines.count > 0 ? lines[0] : nil
-            line2      = lines.count > 1 ? lines[1] : nil
+            if !street.isEmpty {
+                let lines  = street.components(separatedBy: .newlines)
+                line1      = lines.count > 0 ? lines[0] : nil
+                line2      = lines.count > 1 ? lines[1] : nil
+            }
         }
         
         self.init(

--- a/PayTests/Mocks/MockSessionDelegate.swift
+++ b/PayTests/Mocks/MockSessionDelegate.swift
@@ -29,10 +29,11 @@ import Pay
 
 final class MockSessionDelegate: PaySessionDelegate {
     
-    var didSelectShippingRate:   ((PaySession, PayShippingRate, PayCheckout, (PayCheckout?) -> Void) -> Void)?
-    var didAuthorizePayment:     ((PaySession, PayAuthorization, PayCheckout, (PaySession.TransactionStatus) -> Void) -> Void)?
-    var didRequestShippingRates: ((PaySession, PayPostalAddress, PayCheckout, (PayCheckout?, [PayShippingRate]) -> Void) -> Void)?
-    var didFinish: ((PaySession) -> Void)?
+    var didSelectShippingRate:    ((PaySession, PayShippingRate, PayCheckout, (PayCheckout?) -> Void) -> Void)?
+    var didAuthorizePayment:      ((PaySession, PayAuthorization, PayCheckout, (PaySession.TransactionStatus) -> Void) -> Void)?
+    var didRequestShippingRates:  ((PaySession, PayPostalAddress, PayCheckout, (PayCheckout?, [PayShippingRate]) -> Void) -> Void)?
+    var didUpdateShippingAddress: ((PaySession, PayPostalAddress, PayCheckout, (PayCheckout?) -> Void) -> Void)?
+    var didFinish:                ((PaySession) -> Void)?
     
     let session: PaySession
     
@@ -57,6 +58,10 @@ final class MockSessionDelegate: PaySessionDelegate {
     
     func paySession(_ paySession: PaySession, didRequestShippingRatesFor address: PayPostalAddress, checkout: PayCheckout, provide: @escaping (PayCheckout?, [PayShippingRate]) -> Void) {
         self.didRequestShippingRates?(paySession, address, checkout, provide)
+    }
+    
+    func paySession(_ paySession: PaySession, didUpdateShippingAddress address: PayPostalAddress, checkout: PayCheckout, provide: @escaping (PayCheckout?) -> Void) {
+        self.didUpdateShippingAddress?(paySession, address, checkout, provide)
     }
     
     func paySessionDidFinish(_ paySession: PaySession) {

--- a/Sample Apps/Storefront/Storefront/CartViewController.swift
+++ b/Sample Apps/Storefront/Storefront/CartViewController.swift
@@ -212,6 +212,20 @@ extension CartViewController: PaySessionDelegate {
         }
     }
     
+    func paySession(_ paySession: PaySession, didUpdateShippingAddress address: PayPostalAddress, checkout: PayCheckout, provide: @escaping (PayCheckout?) -> Void) {
+        
+        print("Updating checkout with shipping address for tax estimate...")
+        Client.shared.updateCheckout(checkout.id, updatingShippingAddress: address) { checkout in
+            
+            if let checkout = checkout {   
+                provide(checkout.payCheckout)
+            } else {
+                print("Update for checkout failed.")
+                provide(nil)
+            }
+        }
+    }
+    
     func paySession(_ paySession: PaySession, didSelectShippingRate shippingRate: PayShippingRate, checkout: PayCheckout, provide: @escaping  (PayCheckout?) -> Void) {
         
         print("Selecting shipping rate...")


### PR DESCRIPTION
### What this does

Adds a new delegate callback for `PaySession` that notifies delegates about shipping address updates. Since billing address isn't available until the end of the Apple Pay flow, we have to require the shipping address even for checkouts that don't require shipping so that we can ask Shopify for relevant tax information to update the subtotal. If we don't do so, the end-user would be authorizing the payment for a subtotal that doesn't include taxes and the amount mismatch would cause the transaction to fail.

Also, allows `PayAddress` to handle a `nil` postal address coming from `PKContact`.

Fixes #696 
