### PR TITLE
Card brands

### DIFF
--- a/Buy.xcodeproj/project.pbxproj
+++ b/Buy.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		9A52D3A21F3CA58E00C093C8 /* ProductImageSortKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A52D3A01F3CA58E00C093C8 /* ProductImageSortKeys.swift */; };
 		9A52D3A31F3CA58E00C093C8 /* CardBrand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A52D3A11F3CA58E00C093C8 /* CardBrand.swift */; };
 		9A52D3A51F3CA5DB00C093C8 /* DigitalWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A52D3A41F3CA5DB00C093C8 /* DigitalWallet.swift */; };
+		9A52D3B21F3CE99900C093C8 /* PayCardBrand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A52D3B11F3CE99900C093C8 /* PayCardBrand.swift */; };
 		9A6F3BA91EBB6A7500B149F4 /* Graph.CacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6F3BA81EBB6A7500B149F4 /* Graph.CacheTests.swift */; };
 		9A9C513C1F02A5D6003363E7 /* MD5.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A664D701EF05F97001BFB01 /* MD5.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9A9C513D1F02A5DB003363E7 /* MD5.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A664D711EF05F97001BFB01 /* MD5.m */; };
@@ -352,6 +353,7 @@
 		9A52D3A01F3CA58E00C093C8 /* ProductImageSortKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageSortKeys.swift; sourceTree = "<group>"; };
 		9A52D3A11F3CA58E00C093C8 /* CardBrand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBrand.swift; sourceTree = "<group>"; };
 		9A52D3A41F3CA5DB00C093C8 /* DigitalWallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DigitalWallet.swift; sourceTree = "<group>"; };
+		9A52D3B11F3CE99900C093C8 /* PayCardBrand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayCardBrand.swift; sourceTree = "<group>"; };
 		9A664D701EF05F97001BFB01 /* MD5.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MD5.h; sourceTree = "<group>"; };
 		9A664D711EF05F97001BFB01 /* MD5.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MD5.m; sourceTree = "<group>"; };
 		9A664D7F1EF159F8001BFB01 /* MD5Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MD5Tests.swift; sourceTree = "<group>"; };
@@ -565,6 +567,7 @@
 				9A4068DE1E8E7659000254CD /* Pay.h */,
 				9A4068F51E8E767B000254CD /* PaySession.swift */,
 				9A4068F41E8E767B000254CD /* PayCheckout.swift */,
+				9A52D3B11F3CE99900C093C8 /* PayCardBrand.swift */,
 				9A0C7FD01EA669C80020F187 /* PayDiscount.swift */,
 				9A4068F71E8E767B000254CD /* PayLineItem.swift */,
 				9A4068F61E8E767B000254CD /* PayCurrency.swift */,
@@ -998,6 +1001,7 @@
 				9A4068FE1E8E767B000254CD /* PayShippingRate.swift in Sources */,
 				9AB421B11E93CA45005098C4 /* PayAuthorization.swift in Sources */,
 				9A4068F91E8E767B000254CD /* PayAddress.swift in Sources */,
+				9A52D3B21F3CE99900C093C8 /* PayCardBrand.swift in Sources */,
 				9A4068FB1E8E767B000254CD /* PaySession.swift in Sources */,
 				9A0C7FD11EA669C80020F187 /* PayDiscount.swift in Sources */,
 				9A4068FD1E8E767B000254CD /* PayLineItem.swift in Sources */,

--- a/Buy.xcodeproj/project.pbxproj
+++ b/Buy.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 		9A9C513C1F02A5D6003363E7 /* MD5.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A664D701EF05F97001BFB01 /* MD5.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9A9C513D1F02A5DB003363E7 /* MD5.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A664D711EF05F97001BFB01 /* MD5.m */; };
 		9AA01A5F1F3DEBF6007F5380 /* PassKit+PayCardBrand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA01A5E1F3DEBF6007F5380 /* PassKit+PayCardBrand.swift */; };
+		9AA01A621F3E2035007F5380 /* PayCardBrandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA01A611F3E2035007F5380 /* PayCardBrandTests.swift */; };
 		9AA416C71EE095AA0060029B /* Article.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA416C21EE095AA0060029B /* Article.swift */; };
 		9AA416C81EE095AA0060029B /* ArticleAuthor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA416C31EE095AA0060029B /* ArticleAuthor.swift */; };
 		9AA416C91EE095AA0060029B /* ArticleConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA416C41EE095AA0060029B /* ArticleConnection.swift */; };
@@ -360,6 +361,7 @@
 		9A664D7F1EF159F8001BFB01 /* MD5Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MD5Tests.swift; sourceTree = "<group>"; };
 		9A6F3BA81EBB6A7500B149F4 /* Graph.CacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.CacheTests.swift; sourceTree = "<group>"; };
 		9AA01A5E1F3DEBF6007F5380 /* PassKit+PayCardBrand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PassKit+PayCardBrand.swift"; sourceTree = "<group>"; };
+		9AA01A611F3E2035007F5380 /* PayCardBrandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayCardBrandTests.swift; sourceTree = "<group>"; };
 		9AA416C21EE095AA0060029B /* Article.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Article.swift; sourceTree = "<group>"; };
 		9AA416C31EE095AA0060029B /* ArticleAuthor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArticleAuthor.swift; sourceTree = "<group>"; };
 		9AA416C41EE095AA0060029B /* ArticleConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArticleConnection.swift; sourceTree = "<group>"; };
@@ -590,6 +592,7 @@
 				9A4666121EF191B600A41625 /* Mocks */,
 				9A4068E91E8E7659000254CD /* PaySessionTests.swift */,
 				9AADF1CC1EA6618800D22740 /* PayCheckoutTests.swift */,
+				9AA01A611F3E2035007F5380 /* PayCardBrandTests.swift */,
 				9A0C7FD21EA66DF70020F187 /* PayDiscountTests.swift */,
 				9A0C7FD41EA682640020F187 /* PayLineItemTests.swift */,
 				9A0C7FD61EA686240020F187 /* PayCurrencyTests.swift */,
@@ -1016,6 +1019,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9AA01A621F3E2035007F5380 /* PayCardBrandTests.swift in Sources */,
 				9AADF1C91EA63FB900D22740 /* MockPaymentToken.swift in Sources */,
 				9A0C7FE51EA79EA70020F187 /* PassKit+SummaryItemTests.swift in Sources */,
 				9AADF1CD1EA6618800D22740 /* PayCheckoutTests.swift in Sources */,

--- a/Buy.xcodeproj/project.pbxproj
+++ b/Buy.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		9A6F3BA91EBB6A7500B149F4 /* Graph.CacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6F3BA81EBB6A7500B149F4 /* Graph.CacheTests.swift */; };
 		9A9C513C1F02A5D6003363E7 /* MD5.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A664D701EF05F97001BFB01 /* MD5.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9A9C513D1F02A5DB003363E7 /* MD5.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A664D711EF05F97001BFB01 /* MD5.m */; };
+		9AA01A5F1F3DEBF6007F5380 /* PassKit+PayCardBrand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA01A5E1F3DEBF6007F5380 /* PassKit+PayCardBrand.swift */; };
 		9AA416C71EE095AA0060029B /* Article.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA416C21EE095AA0060029B /* Article.swift */; };
 		9AA416C81EE095AA0060029B /* ArticleAuthor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA416C31EE095AA0060029B /* ArticleAuthor.swift */; };
 		9AA416C91EE095AA0060029B /* ArticleConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA416C41EE095AA0060029B /* ArticleConnection.swift */; };
@@ -358,6 +359,7 @@
 		9A664D711EF05F97001BFB01 /* MD5.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MD5.m; sourceTree = "<group>"; };
 		9A664D7F1EF159F8001BFB01 /* MD5Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MD5Tests.swift; sourceTree = "<group>"; };
 		9A6F3BA81EBB6A7500B149F4 /* Graph.CacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.CacheTests.swift; sourceTree = "<group>"; };
+		9AA01A5E1F3DEBF6007F5380 /* PassKit+PayCardBrand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PassKit+PayCardBrand.swift"; sourceTree = "<group>"; };
 		9AA416C21EE095AA0060029B /* Article.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Article.swift; sourceTree = "<group>"; };
 		9AA416C31EE095AA0060029B /* ArticleAuthor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArticleAuthor.swift; sourceTree = "<group>"; };
 		9AA416C41EE095AA0060029B /* ArticleConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArticleConnection.swift; sourceTree = "<group>"; };
@@ -575,6 +577,7 @@
 				9A4068F81E8E767B000254CD /* PayShippingRate.swift */,
 				9AB421B01E93CA45005098C4 /* PayAuthorization.swift */,
 				9A4069091E8E82E2000254CD /* PassKit+SummaryItems.swift */,
+				9AA01A5E1F3DEBF6007F5380 /* PassKit+PayCardBrand.swift */,
 				9A4068DF1E8E7659000254CD /* Info.plist */,
 			);
 			path = Pay;
@@ -996,6 +999,7 @@
 			files = (
 				9A4068FA1E8E767B000254CD /* PayCheckout.swift in Sources */,
 				9A4068FC1E8E767B000254CD /* PayCurrency.swift in Sources */,
+				9AA01A5F1F3DEBF6007F5380 /* PassKit+PayCardBrand.swift in Sources */,
 				9AE2A1C71EC9F7FD00921247 /* Log.swift in Sources */,
 				9A40690A1E8E82E2000254CD /* PassKit+SummaryItems.swift in Sources */,
 				9A4068FE1E8E767B000254CD /* PayShippingRate.swift in Sources */,

--- a/Pay/PassKit+PayCardBrand.swift
+++ b/Pay/PassKit+PayCardBrand.swift
@@ -29,28 +29,22 @@ import PassKit
 extension PayCardBrand {
     
     var paymentNetwork: PKPaymentNetwork? {
-        if #available(iOS 10.1, *) {
-            switch self {
-            case .visa:            return .visa
-            case .masterCard:      return .masterCard
-            case .discover:        return .discover
-            case .americanExpress: return .amex
-            case .jcb:             return .JCB
-            default:
-                return nil
-            }
-        } else {
-            switch self {
-            case .visa:            return .visa
-            case .masterCard:      return .masterCard
-            case .discover:        return .discover
-            case .americanExpress: return .amex
-            case .jcb:
+        switch self {
+        case .visa:            return .visa
+        case .masterCard:      return .masterCard
+        case .discover:        return .discover
+        case .americanExpress: return .amex
+        case .jcb:
+            
+            if #available(iOS 10.1, *) {
+                return .JCB
+            } else {
                 Log("WARNING: Attempting to convert PayCardBrand.jcb to PKPaymentNetwork on iOS 10.0 or lower. PKPaymentNetwork.JCB requires iOS 10.1 or higher.")
-                fallthrough
-            default:
                 return nil
             }
+            
+        default:
+            return nil
         }
     }
 }

--- a/Pay/PassKit+PayCardBrand.swift
+++ b/Pay/PassKit+PayCardBrand.swift
@@ -26,25 +26,25 @@
 
 import PassKit
 
-extension PKPaymentNetwork {
+extension PayCardBrand {
     
-    init?(_ cardBrand: PayCardBrand) {
+    var paymentNetwork: PKPaymentNetwork? {
         if #available(iOS 10.1, *) {
-            switch cardBrand {
-            case .visa:            self = .visa
-            case .masterCard:      self = .masterCard
-            case .discover:        self = .discover
-            case .americanExpress: self = .amex
-            case .jcb:             self = .JCB
+            switch self {
+            case .visa:            return .visa
+            case .masterCard:      return .masterCard
+            case .discover:        return .discover
+            case .americanExpress: return .amex
+            case .jcb:             return .JCB
             default:
                 return nil
             }
         } else {
-            switch cardBrand {
-            case .visa:            self = .visa
-            case .masterCard:      self = .masterCard
-            case .discover:        self = .discover
-            case .americanExpress: self = .amex
+            switch self {
+            case .visa:            return .visa
+            case .masterCard:      return .masterCard
+            case .discover:        return .discover
+            case .americanExpress: return .amex
             case .jcb:
                 Log("WARNING: Attempting to convert PayCardBrand.jcb to PKPaymentNetwork on iOS 10.0 or lower. PKPaymentNetwork.JCB requires iOS 10.1 or higher.")
                 fallthrough
@@ -59,7 +59,7 @@ extension Array where Element == PayCardBrand {
     
     var paymentNetworks: [PKPaymentNetwork] {
         return self.flatMap {
-            PKPaymentNetwork($0)
+            $0.paymentNetwork
         }
     }
 }

--- a/Pay/PassKit+PayCardBrand.swift
+++ b/Pay/PassKit+PayCardBrand.swift
@@ -1,5 +1,5 @@
 //
-//  PassKit+SummaryItems.swift
+//  PassKit+PayCardBrand.swift
 //  Pay
 //
 //  Created by Shopify.
@@ -26,22 +26,40 @@
 
 import PassKit
 
-// ----------------------------------
-//  MARK: - Decimal -
-//
-internal extension Decimal {
+extension PKPaymentNetwork {
     
-    func summaryItemNamed(_ name: String) -> PKPaymentSummaryItem {
-        return PKPaymentSummaryItem(label: name, amount: self)
+    init?(_ cardBrand: PayCardBrand) {
+        if #available(iOS 10.1, *) {
+            switch cardBrand {
+            case .visa:            self = .visa
+            case .masterCard:      self = .masterCard
+            case .discover:        self = .discover
+            case .americanExpress: self = .amex
+            case .jcb:             self = .JCB
+            default:
+                return nil
+            }
+        } else {
+            switch cardBrand {
+            case .visa:            self = .visa
+            case .masterCard:      self = .masterCard
+            case .discover:        self = .discover
+            case .americanExpress: self = .amex
+            case .jcb:
+                Log("WARNING: Attempting to convert PayCardBrand.jcb to PKPaymentNetwork on iOS 10.0 or lower. PKPaymentNetwork.JCB requires iOS 10.1 or higher.")
+                fallthrough
+            default:
+                return nil
+            }
+        }
     }
 }
 
-// ----------------------------------
-//  MARK: - PKPaymentSummaryItem -
-//
-internal extension PKPaymentSummaryItem {
+extension Array where Element == PayCardBrand {
     
-    convenience init(label: String, amount: Decimal) {
-        self.init(label: label, amount: amount as NSDecimalNumber)
+    var paymentNetworks: [PKPaymentNetwork] {
+        return self.flatMap {
+            PKPaymentNetwork($0)
+        }
     }
 }

--- a/Pay/PayCardBrand.swift
+++ b/Pay/PayCardBrand.swift
@@ -1,0 +1,37 @@
+//
+//  PayCardBrand.swift
+//  Pay
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+import PassKit
+
+public enum PayCardBrand: String {
+    case visa            = "VISA"
+    case masterCard      = "MASTERCARD"
+    case discover        = "DISCOVER"
+    case americanExpress = "AMERICAN_EXPRESS"
+    case dinersClub      = "DINERS_CLUB"
+    case jcb             = "JCB"
+}

--- a/Pay/PaySession.swift
+++ b/Pay/PaySession.swift
@@ -121,7 +121,6 @@ public class PaySession: NSObject {
     // ----------------------------------
     //  MARK: - Init -
     //
-
     /// An instance of `PaySession` represents a single transaction using Apple Pay.
     /// To create one requires a `PayCheckout` and `PayCurrency`.
     ///
@@ -142,7 +141,6 @@ public class PaySession: NSObject {
     // ----------------------------------
     //  MARK: - Begin Checkout -
     //
-
     /// Invoking `authorize()` will create a payment request and present the
     /// Apple Pay dialog. The `delegate` will then be called when the user
     /// begins changing billing address, shipping address, and shipping rates.
@@ -164,7 +162,7 @@ public class PaySession: NSObject {
         request.merchantIdentifier            = merchantID
         request.requiredBillingAddressFields  = .all
         request.requiredShippingAddressFields = .all
-        request.supportedNetworks             = [.visa, .masterCard, .amex]
+        request.supportedNetworks             = self.acceptedCardBrands.paymentNetworks
         request.merchantCapabilities          = [.capability3DS]
         request.paymentSummaryItems           = checkout.summaryItems
 

--- a/Pay/PaySession.swift
+++ b/Pay/PaySession.swift
@@ -101,6 +101,8 @@ public class PaySession: NSObject {
 
     /// A delegate for receiving updates from `PaySession`.
     public weak var delegate: PaySessionDelegate?
+    
+    public var acceptedCardBrands: [PayCardBrand] = [.visa, .masterCard, .americanExpress]
 
     /// The currency description that will be used in this Apple Pay transaction.
     public let currency: PayCurrency

--- a/Pay/PaySession.swift
+++ b/Pay/PaySession.swift
@@ -136,6 +136,8 @@ public class PaySession: NSObject {
         self.merchantID     = merchantID
         self.identifier     = UUID().uuidString
         self.controllerType = controllerType
+        
+        super.init()
     }
 
     // ----------------------------------

--- a/PayTests/PayCardBrandTests.swift
+++ b/PayTests/PayCardBrandTests.swift
@@ -1,0 +1,69 @@
+//
+//  PayCardBrandTests.swift
+//  PayTests
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import XCTest
+import PassKit
+@testable import Pay
+
+class PayCardBrandTests: XCTestCase {
+
+    // ----------------------------------
+    //  MARK: - Init -
+    //
+    func testValues() {
+        XCTAssertEqual(PayCardBrand.visa.rawValue,            "VISA")
+        XCTAssertEqual(PayCardBrand.masterCard.rawValue,      "MASTERCARD")
+        XCTAssertEqual(PayCardBrand.discover.rawValue,        "DISCOVER")
+        XCTAssertEqual(PayCardBrand.americanExpress.rawValue, "AMERICAN_EXPRESS")
+        XCTAssertEqual(PayCardBrand.dinersClub.rawValue,      "DINERS_CLUB")
+        XCTAssertEqual(PayCardBrand.jcb.rawValue,             "JCB")
+    }
+    
+    // ----------------------------------
+    //  MARK: - Conversion -
+    //
+    func testPaymentNetworkConversion() {
+        XCTAssertEqual(PayCardBrand.visa.paymentNetwork,            .visa)
+        XCTAssertEqual(PayCardBrand.masterCard.paymentNetwork,      .masterCard)
+        XCTAssertEqual(PayCardBrand.discover.paymentNetwork,        .discover)
+        XCTAssertEqual(PayCardBrand.americanExpress.paymentNetwork, .amex)
+        XCTAssertEqual(PayCardBrand.dinersClub.paymentNetwork,      nil)
+        XCTAssertEqual(PayCardBrand.jcb.paymentNetwork,             .JCB)
+    }
+    
+    func testNetworksConversion() {
+        let cardBrands: [PayCardBrand] = [
+            .visa,
+            .masterCard,
+        ]
+        
+        let networks = cardBrands.paymentNetworks
+        
+        XCTAssertEqual(networks.count, 2)
+        XCTAssertEqual(networks[0], .visa)
+        XCTAssertEqual(networks[1], .masterCard)
+    }
+}


### PR DESCRIPTION
### What this does

Currently, `PaySession` hardcodes supported card types for Apple Pay payment requests. Not all stores will support all card types. This allows `PaySession` to be configured with supported card types for the payment request.
