### PR TITLE
Update shipping address before checkout

### DIFF
--- a/Sample Apps/Storefront/Storefront/Client.swift
+++ b/Sample Apps/Storefront/Storefront/Client.swift
@@ -32,6 +32,7 @@ final class Client {
     
     static let shopDomain = "graphql.myshopify.com"
     static let apiKey     = "8e2fef6daed4b93cf4e731f580799dd1"
+    static let merchantID = "merchant.com.your.id"
     
     static let shared = Client()
     
@@ -116,8 +117,26 @@ final class Client {
     }
     
     @discardableResult
-    func updateCheckout(_ id: String, updatingShippingAddress address: PayPostalAddress, completion: @escaping (CheckoutViewModel?) -> Void) -> Task {
-        let mutation = ClientQuery.mutationForUpdateCheckout(id, updatingShippingAddress: address)
+    func updateCheckout(_ id: String, updatingPartialShippingAddress address: PayPostalAddress, completion: @escaping (CheckoutViewModel?) -> Void) -> Task {
+        let mutation = ClientQuery.mutationForUpdateCheckout(id, updatingPartialShippingAddress: address)
+        let task     = self.client.mutateGraphWith(mutation) { response, error in
+            error.debugPrint()
+            
+            if let checkout = response?.checkoutShippingAddressUpdate?.checkout,
+                let _ = checkout.shippingAddress {
+                completion(checkout.viewModel)
+            } else {
+                completion(nil)
+            }
+        }
+        
+        task.resume()
+        return task
+    }
+    
+    @discardableResult
+    func updateCheckout(_ id: String, updatingCompleteShippingAddress address: PayAddress, completion: @escaping (CheckoutViewModel?) -> Void) -> Task {
+        let mutation = ClientQuery.mutationForUpdateCheckout(id, updatingCompleteShippingAddress: address)
         let task     = self.client.mutateGraphWith(mutation) { response, error in
             error.debugPrint()
             

--- a/Sample Apps/Storefront/Storefront/ClientQuery.swift
+++ b/Sample Apps/Storefront/Storefront/ClientQuery.swift
@@ -95,8 +95,7 @@ final class ClientQuery {
         }
     }
     
-    static func mutationForUpdateCheckout(_ id: String, updatingShippingAddress address: PayPostalAddress) -> Storefront.MutationQuery {
-        
+    static func mutationForUpdateCheckout(_ id: String, updatingPartialShippingAddress address: PayPostalAddress) -> Storefront.MutationQuery {
         
         let checkoutID   = GraphQL.ID(rawValue: id)
         let addressInput = Storefront.MailingAddressInput(
@@ -104,6 +103,34 @@ final class ClientQuery {
             country:  address.country,
             province: address.province,
             zip:      address.zip
+        )
+        
+        return Storefront.buildMutation { $0
+            .checkoutShippingAddressUpdate(shippingAddress: addressInput, checkoutId: checkoutID) { $0
+                .userErrors { $0
+                    .field()
+                    .message()
+                }
+                .checkout { $0
+                    .fragmentForCheckout()
+                }
+            }
+        }
+    }
+    
+    static func mutationForUpdateCheckout(_ id: String, updatingCompleteShippingAddress address: PayAddress) -> Storefront.MutationQuery {
+        
+        let checkoutID   = GraphQL.ID(rawValue: id)
+        let addressInput = Storefront.MailingAddressInput(
+            address1:  address.addressLine1,
+            address2:  address.addressLine2,
+            city:      address.city,
+            country:   address.country,
+            firstName: address.firstName,
+            lastName:  address.lastName,
+            phone:     address.phone,
+            province:  address.province,
+            zip:       address.zip
         )
         
         return Storefront.buildMutation { $0


### PR DESCRIPTION
### What this does

Updates the sample app to fix an issue where the checkout wasn't being updated with the full shipping address before being completed. 

### Discussion

PassKit only provides a partial address sufficient enough to request shipping rates and update the checkout with the preferred shipping method. The complete address containing the name and the first address line isn't provided until the payment is authorized. As a result, we have to update the shipping address twice.

Fixes #705 