### PR TITLE
Support for partial postal codes.

### DIFF
--- a/Pay/PaySession.swift
+++ b/Pay/PaySession.swift
@@ -43,6 +43,9 @@ public protocol PaySessionDelegate: class {
     ///     - checkout:   The current checkout state.
     ///     - provide:    A completion handler that **must** be invoked with an updated `PayCheckout` and an array of `[PayShippingRate]`. If the `PayPostalAddress` is invalid or you were unable to obtain shipping rates, then returning `nil` or empty shipping rates will result in an invalid address error in Apple Pay.
     ///
+    /// - Important:
+    /// The `address` passed into this method is _partial_, and doesn't include address lines or a complete zip / postal code. It is sufficient for obtaining shipping rates _only_. **You must update the checkout with a full address before completing the payment.** The complete address will be available in `paySession(_:didAuthorizePayment:checkout:completeTransaction:)`.
+    ///
     func paySession(_ paySession: PaySession, didRequestShippingRatesFor address: PayPostalAddress, checkout: PayCheckout, provide: @escaping (PayCheckout?, [PayShippingRate]) -> Void)
 
     /// This callback is invoked if the user updates the `shippingContact` and the current address is invalidated. This method is called *only* for
@@ -54,6 +57,9 @@ public protocol PaySessionDelegate: class {
     ///     - address:    A partial address that you can use to obtain relevant tax information for the checkout. This address is missing `addressLine1` and `addressLine2`. This information is only available after the user has authorized payment.
     ///     - checkout:   The current checkout state.
     ///     - provide:    A completion handler that **must** be invoked with an updated `PayCheckout`. Returning `nil` will result in a generic failure in the Apple Pay dialog.
+    ///
+    /// - Important:
+    /// The `address` passed into this method is _partial_, and doesn't include address lines or a complete zip / postal code. It is sufficient for obtaining shipping rates _only_. **You must update the checkout with a full address before completing the payment.** The complete address will be available in `paySession(_:didAuthorizePayment:checkout:completeTransaction:)`.
     ///
     func paySession(_ paySession: PaySession, didUpdateShippingAddress address: PayPostalAddress, checkout: PayCheckout, provide: @escaping (PayCheckout?) -> Void)
     
@@ -74,6 +80,9 @@ public protocol PaySessionDelegate: class {
     ///     - authorization:       Authorization object that encapsulates the token and other relevant information: billing address, complete shipping address, and shipping rate.
     ///     - checkout:            The current checkout state.
     ///     - completeTransaction: A completion handler that **must** be invoked with the final transaction status.
+    ///
+    /// - Important:
+    /// If you previously set a partial address on checkout (eg: for obtaining shipping rates), you **MUST** update the checkout with the complete address provided by `authorization.shippingAddress`.
     ///
     func paySession(_ paySession: PaySession, didAuthorizePayment authorization: PayAuthorization, checkout: PayCheckout, completeTransaction: @escaping (PaySession.TransactionStatus) -> Void)
 

--- a/PayTests/PayAddressTests.swift
+++ b/PayTests/PayAddressTests.swift
@@ -42,11 +42,12 @@ class PayAddressTests: XCTestCase {
             zip:         "11217"
         )
         
-        XCTAssertEqual(address.city,      "Brooklyn")
-        XCTAssertEqual(address.country,   "United States")
-        XCTAssertEqual(address.province,  "NY")
-        XCTAssertEqual(address.zip,       "11217")
-        XCTAssertEqual(address.paddedZip, "11217")
+        XCTAssertEqual(address.city,        "Brooklyn")
+        XCTAssertEqual(address.country,     "United States")
+        XCTAssertEqual(address.province,    "NY")
+        XCTAssertEqual(address.zip,         "11217")
+        XCTAssertEqual(address.originalZip, "11217")
+        XCTAssertEqual(address.isPadded,    false)
     }
     
     func testInitPostalAddressInUnitedStates() {
@@ -58,11 +59,12 @@ class PayAddressTests: XCTestCase {
             zip:         "112"
         )
         
-        XCTAssertEqual(address.city,      "Brooklyn")
-        XCTAssertEqual(address.country,   "United States")
-        XCTAssertEqual(address.province,  "NY")
-        XCTAssertEqual(address.zip,       "112")
-        XCTAssertEqual(address.paddedZip, "112")
+        XCTAssertEqual(address.city,        "Brooklyn")
+        XCTAssertEqual(address.country,     "United States")
+        XCTAssertEqual(address.province,    "NY")
+        XCTAssertEqual(address.zip,         "112")
+        XCTAssertEqual(address.originalZip, "112")
+        XCTAssertEqual(address.isPadded,    false)
     }
     
     func testInitPartialPostalAddressInCanada() {
@@ -74,11 +76,12 @@ class PayAddressTests: XCTestCase {
             zip:         "L5S "
         )
         
-        XCTAssertEqual(address.city,      "Toronto")
-        XCTAssertEqual(address.country,   "Canada")
-        XCTAssertEqual(address.province,  "ON")
-        XCTAssertEqual(address.zip,       "L5S ")
-        XCTAssertEqual(address.paddedZip, "L5S 0Z0")
+        XCTAssertEqual(address.city,        "Toronto")
+        XCTAssertEqual(address.country,     "Canada")
+        XCTAssertEqual(address.province,    "ON")
+        XCTAssertEqual(address.zip,         "L5S 0Z0")
+        XCTAssertEqual(address.originalZip, "L5S ")
+        XCTAssertEqual(address.isPadded,    true)
     }
     
     func testInitPartialPostalAddressInUnitedKingdom() {
@@ -87,14 +90,32 @@ class PayAddressTests: XCTestCase {
             country:     "United Kingdom",
             countryCode: "gb",
             province:    "ON",
-            zip:         "W1A "
+            zip:         "W1A"
         )
         
-        XCTAssertEqual(address.city,      "London")
-        XCTAssertEqual(address.country,   "United Kingdom")
-        XCTAssertEqual(address.province,  "ON")
-        XCTAssertEqual(address.zip,       "W1A ")
-        XCTAssertEqual(address.paddedZip, "W1A 0ZZ")
+        XCTAssertEqual(address.city,        "London")
+        XCTAssertEqual(address.country,     "United Kingdom")
+        XCTAssertEqual(address.province,    "ON")
+        XCTAssertEqual(address.zip,         "W1A 0ZZ")
+        XCTAssertEqual(address.originalZip, "W1A")
+        XCTAssertEqual(address.isPadded,    true)
+    }
+    
+    func testInitEmptyZipAddress() {
+        let address = PayPostalAddress(
+            city:        "London",
+            country:     "United Kingdom",
+            countryCode: nil,
+            province:    "ON",
+            zip:         nil
+        )
+        
+        XCTAssertEqual(address.city,        "London")
+        XCTAssertEqual(address.country,     "United Kingdom")
+        XCTAssertEqual(address.province,    "ON")
+        XCTAssertEqual(address.zip,         nil)
+        XCTAssertEqual(address.originalZip, nil)
+        XCTAssertEqual(address.isPadded,    false)
     }
     
     func testInitAddress() {
@@ -130,11 +151,12 @@ class PayAddressTests: XCTestCase {
         let passKitAddress = Models.createPostalAddress()
         let address        = PayPostalAddress(with: passKitAddress)
         
-        XCTAssertEqual(address.city,      "Toronto")
-        XCTAssertEqual(address.country,   "Canada")
-        XCTAssertEqual(address.province,  "ON")
-        XCTAssertEqual(address.zip,       "M5V 2J4")
-        XCTAssertEqual(address.paddedZip, "M5V 2J4")
+        XCTAssertEqual(address.city,        "Toronto")
+        XCTAssertEqual(address.country,     "Canada")
+        XCTAssertEqual(address.province,    "ON")
+        XCTAssertEqual(address.zip,         "M5V 2J4")
+        XCTAssertEqual(address.originalZip, "M5V 2J4")
+        XCTAssertEqual(address.isPadded,    false)
     }
     
     // ----------------------------------

--- a/PayTests/PayAddressTests.swift
+++ b/PayTests/PayAddressTests.swift
@@ -35,16 +35,66 @@ class PayAddressTests: XCTestCase {
     //
     func testInitPostalAddress() {
         let address = PayPostalAddress(
-            city:        "Toronto",
-            country:     "Canada",
-            province:    "ON",
-            zip:         "A1B 2C3"
+            city:        "Brooklyn",
+            country:     "United States",
+            countryCode: "US",
+            province:    "NY",
+            zip:         "11217"
         )
         
-        XCTAssertEqual(address.city,     "Toronto")
-        XCTAssertEqual(address.country,  "Canada")
-        XCTAssertEqual(address.province, "ON")
-        XCTAssertEqual(address.zip,      "A1B 2C3")
+        XCTAssertEqual(address.city,      "Brooklyn")
+        XCTAssertEqual(address.country,   "United States")
+        XCTAssertEqual(address.province,  "NY")
+        XCTAssertEqual(address.zip,       "11217")
+        XCTAssertEqual(address.paddedZip, "11217")
+    }
+    
+    func testInitPostalAddressInUnitedStates() {
+        let address = PayPostalAddress(
+            city:        "Brooklyn",
+            country:     "United States",
+            countryCode: "US",
+            province:    "NY",
+            zip:         "112"
+        )
+        
+        XCTAssertEqual(address.city,      "Brooklyn")
+        XCTAssertEqual(address.country,   "United States")
+        XCTAssertEqual(address.province,  "NY")
+        XCTAssertEqual(address.zip,       "112")
+        XCTAssertEqual(address.paddedZip, "112")
+    }
+    
+    func testInitPartialPostalAddressInCanada() {
+        let address = PayPostalAddress(
+            city:        "Toronto",
+            country:     "Canada",
+            countryCode: "CA",
+            province:    "ON",
+            zip:         "L5S "
+        )
+        
+        XCTAssertEqual(address.city,      "Toronto")
+        XCTAssertEqual(address.country,   "Canada")
+        XCTAssertEqual(address.province,  "ON")
+        XCTAssertEqual(address.zip,       "L5S ")
+        XCTAssertEqual(address.paddedZip, "L5S 0Z0")
+    }
+    
+    func testInitPartialPostalAddressInUnitedKingdom() {
+        let address = PayPostalAddress(
+            city:        "London",
+            country:     "United Kingdom",
+            countryCode: "gb",
+            province:    "ON",
+            zip:         "W1A "
+        )
+        
+        XCTAssertEqual(address.city,      "London")
+        XCTAssertEqual(address.country,   "United Kingdom")
+        XCTAssertEqual(address.province,  "ON")
+        XCTAssertEqual(address.zip,       "W1A ")
+        XCTAssertEqual(address.paddedZip, "W1A 0ZZ")
     }
     
     func testInitAddress() {
@@ -80,10 +130,11 @@ class PayAddressTests: XCTestCase {
         let passKitAddress = Models.createPostalAddress()
         let address        = PayPostalAddress(with: passKitAddress)
         
-        XCTAssertEqual(address.city,     "Toronto")
-        XCTAssertEqual(address.country,  "Canada")
-        XCTAssertEqual(address.province, "ON")
-        XCTAssertEqual(address.zip,      "M5V 2J4")
+        XCTAssertEqual(address.city,      "Toronto")
+        XCTAssertEqual(address.country,   "Canada")
+        XCTAssertEqual(address.province,  "ON")
+        XCTAssertEqual(address.zip,       "M5V 2J4")
+        XCTAssertEqual(address.paddedZip, "M5V 2J4")
     }
     
     // ----------------------------------

--- a/README.md
+++ b/README.md
@@ -1205,6 +1205,8 @@ task.resume()
 
 ###### Apple Pay checkout [⤴](#table-of-contents)
 
+**IMPORTANT**: Before completing the checkout with an Apple Pay token you should ensure that your checkout is updated with the latests shipping address provided by `paySession(_:didAuthorizePayment:checkout:completeTransaction:)` delegate callback. If you've previously set a partial shipping address on the checkout for obtaining shipping rates, **the current checkout, as is, will not complete successfully**. You must update the checkout with the full address that includes address lines and a complete zip or postal code.
+
 The Buy SDK makes  Pay integration easy with the provided `Pay.framework`. To learn how to set up and use `PaySession` to obtain a payment token, refer to the [ Pay](#apple-pay-) section. After we have a payment token, we can complete the checkout:
 
 ```swift

--- a/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
+++ b/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
@@ -101,13 +101,6 @@
 			remoteGlobalIDString = 9A4068DB1E8E7658000254CD;
 			remoteInfo = Pay;
 		};
-		9A9C92B21ED488520027F049 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 9AEF61BF1E606C710067FA90 /* Buy.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 9A6F3B971EBB49A000B149F4;
-			remoteInfo = Crypto;
-		};
 		9AEF61C31E606C710067FA90 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9AEF61BF1E606C710067FA90 /* Buy.xcodeproj */;
@@ -503,7 +496,6 @@
 				9AFA3B7B1E6DB6FE0056C5AA /* BuyTests.xctest */,
 				9A4069021E8E76AB000254CD /* Pay.framework */,
 				9A4069041E8E76AB000254CD /* PayTests.xctest */,
-				9A9C92B31ED488520027F049 /* Crypto.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -610,13 +602,6 @@
 			fileType = wrapper.cfbundle;
 			path = PayTests.xctest;
 			remoteRef = 9A4069031E8E76AB000254CD /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		9A9C92B31ED488520027F049 /* Crypto.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Crypto.framework;
-			remoteRef = 9A9C92B21ED488520027F049 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		9AEF61C41E606C710067FA90 /* Buy.framework */ = {

--- a/Sample Apps/Storefront/Storefront/AddressViewModel+PayAddress.swift
+++ b/Sample Apps/Storefront/Storefront/AddressViewModel+PayAddress.swift
@@ -27,17 +27,7 @@
 import Pay
 
 extension AddressViewModel {
-    
-    var payPostalAddress: PayPostalAddress {
         
-        return PayPostalAddress(
-            city:        self.city,
-            country:     self.country,
-            province:    self.province,
-            zip:         self.zip
-        )
-    }
-    
     var payAddress: PayAddress {
         
         return PayAddress(

--- a/Sample Apps/Storefront/Storefront/AddressViewModel.swift
+++ b/Sample Apps/Storefront/Storefront/AddressViewModel.swift
@@ -33,33 +33,35 @@ final class AddressViewModel: ViewModel {
     
     let model:  ModelType
     
-    let firstName: String?
-    let lastName:  String?
-    let phone:     String?
+    let firstName:   String?
+    let lastName:    String?
+    let phone:       String?
     
-    let address1:  String?
-    let address2:  String?
-    let city:      String?
-    let country:   String?
-    let province:  String?
-    let zip:       String?
+    let address1:    String?
+    let address2:    String?
+    let city:        String?
+    let country:     String?
+    let countryCode: String?
+    let province:    String?
+    let zip:         String?
     
     // ----------------------------------
     //  MARK: - Init -
     //
     required init(from model: ModelType) {
-        self.model     = model
+        self.model       = model
         
-        self.firstName = model.firstName
-        self.lastName  = model.lastName
-        self.phone     = model.phone
+        self.firstName   = model.firstName
+        self.lastName    = model.lastName
+        self.phone       = model.phone
         
-        self.address1  = model.address1
-        self.address2  = model.address2
-        self.city      = model.city
-        self.country   = model.country
-        self.province  = model.province
-        self.zip       = model.zip
+        self.address1    = model.address1
+        self.address2    = model.address2
+        self.city        = model.city
+        self.country     = model.country
+        self.countryCode = model.countryCode
+        self.province    = model.province
+        self.zip         = model.zip
     }
 }
 

--- a/Sample Apps/Storefront/Storefront/ClientQuery.swift
+++ b/Sample Apps/Storefront/Storefront/ClientQuery.swift
@@ -102,7 +102,7 @@ final class ClientQuery {
             city:     address.city,
             country:  address.country,
             province: address.province,
-            zip:      address.paddedZip
+            zip:      address.zip
         )
         
         return Storefront.buildMutation { $0

--- a/Sample Apps/Storefront/Storefront/ClientQuery.swift
+++ b/Sample Apps/Storefront/Storefront/ClientQuery.swift
@@ -102,7 +102,7 @@ final class ClientQuery {
             city:     address.city,
             country:  address.country,
             province: address.province,
-            zip:      address.zip
+            zip:      address.paddedZip
         )
         
         return Storefront.buildMutation { $0

--- a/Sample Apps/Storefront/Storefront/Fragment+CheckoutQuery.swift
+++ b/Sample Apps/Storefront/Storefront/Fragment+CheckoutQuery.swift
@@ -44,6 +44,7 @@ extension Storefront.CheckoutQuery {
             .address2()
             .city()
             .country()
+            .countryCode()
             .province()
             .provinceCode()
             .zip()


### PR DESCRIPTION
### What this does

In Canada and United Kingdom, PassKit vends only partial postal codes. Shopify isn't able to yield shipping rates for partial codes in these countries and so we must pad them on the client. This is done **only** for Canada and United Kingdom. Partial zip codes for United States and other countries are left untouched.
