### PR TITLE
Input value for explicit nil support

### DIFF
--- a/Buy/Generated/Storefront/CheckoutAttributesUpdateInput.swift
+++ b/Buy/Generated/Storefront/CheckoutAttributesUpdateInput.swift
@@ -30,15 +30,15 @@ extension Storefront {
 	/// Specifies the fields required to update a checkout's attributes. 
 	open class CheckoutAttributesUpdateInput {
 		/// The text of an optional note that a shop owner can attach to the checkout. 
-		open var note: String?
+		open var note: InputValue<String>
 
 		/// A list of extra information that is added to the checkout. 
-		open var customAttributes: [AttributeInput]?
+		open var customAttributes: InputValue<[AttributeInput]>
 
 		/// Allows setting partial addresses on a Checkout, skipping the full 
 		/// validation of attributes. The required attributes are city, province, and 
 		/// country. Full validation of the addresses is still done at complete time. 
-		open var allowPartialAddresses: Bool?
+		open var allowPartialAddresses: InputValue<Bool>
 
 		/// Creates the input object.
 		///
@@ -47,7 +47,7 @@ extension Storefront {
 		///     - customAttributes: A list of extra information that is added to the checkout.
 		///     - allowPartialAddresses: Allows setting partial addresses on a Checkout, skipping the full validation of attributes. The required attributes are city, province, and country. Full validation of the addresses is still done at complete time. 
 		///
-		public init(note: String? = nil, customAttributes: [AttributeInput]? = nil, allowPartialAddresses: Bool? = nil) {
+		public init(note: InputValue<String> = .undefined, customAttributes: InputValue<[AttributeInput]> = .undefined, allowPartialAddresses: InputValue<Bool> = .undefined) {
 			self.note = note
 			self.customAttributes = customAttributes
 			self.allowPartialAddresses = allowPartialAddresses
@@ -56,16 +56,22 @@ extension Storefront {
 		internal func serialize() -> String {
 			var fields: [String] = []
 
-			if let note = note {
-				fields.append("note:\(GraphQL.quoteString(input: note))")
+			switch note {
+				case .some(let note): fields.append("note:\(GraphQL.quoteString(input: note))")
+				case .null: fields.append("note:null")
+				case .undefined: break
 			}
 
-			if let customAttributes = customAttributes {
-				fields.append("customAttributes:[\(customAttributes.map{ "\($0.serialize())" }.joined(separator: ","))]")
+			switch customAttributes {
+				case .some(let customAttributes): fields.append("customAttributes:[\(customAttributes.map{ "\($0.serialize())" }.joined(separator: ","))]")
+				case .null: fields.append("customAttributes:null")
+				case .undefined: break
 			}
 
-			if let allowPartialAddresses = allowPartialAddresses {
-				fields.append("allowPartialAddresses:\(allowPartialAddresses)")
+			switch allowPartialAddresses {
+				case .some(let allowPartialAddresses): fields.append("allowPartialAddresses:\(allowPartialAddresses)")
+				case .null: fields.append("allowPartialAddresses:null")
+				case .undefined: break
 			}
 
 			return "{\(fields.joined(separator: ","))}"

--- a/Buy/Generated/Storefront/CheckoutCreateInput.swift
+++ b/Buy/Generated/Storefront/CheckoutCreateInput.swift
@@ -30,25 +30,25 @@ extension Storefront {
 	/// Specifies the fields required to create a checkout. 
 	open class CheckoutCreateInput {
 		/// The email with which the customer wants to checkout. 
-		open var email: String?
+		open var email: InputValue<String>
 
 		/// A list of line item objects, each one containing information about an item 
 		/// in the checkout. 
-		open var lineItems: [CheckoutLineItemInput]?
+		open var lineItems: InputValue<[CheckoutLineItemInput]>
 
 		/// The shipping address to where the line items will be shipped. 
-		open var shippingAddress: MailingAddressInput?
+		open var shippingAddress: InputValue<MailingAddressInput>
 
 		/// The text of an optional note that a shop owner can attach to the checkout. 
-		open var note: String?
+		open var note: InputValue<String>
 
 		/// A list of extra information that is added to the checkout. 
-		open var customAttributes: [AttributeInput]?
+		open var customAttributes: InputValue<[AttributeInput]>
 
 		/// Allows setting partial addresses on a Checkout, skipping the full 
 		/// validation of attributes. The required attributes are city, province, and 
 		/// country. Full validation of addresses is still done at complete time. 
-		open var allowPartialAddresses: Bool?
+		open var allowPartialAddresses: InputValue<Bool>
 
 		/// Creates the input object.
 		///
@@ -60,7 +60,7 @@ extension Storefront {
 		///     - customAttributes: A list of extra information that is added to the checkout.
 		///     - allowPartialAddresses: Allows setting partial addresses on a Checkout, skipping the full validation of attributes. The required attributes are city, province, and country. Full validation of addresses is still done at complete time. 
 		///
-		public init(email: String? = nil, lineItems: [CheckoutLineItemInput]? = nil, shippingAddress: MailingAddressInput? = nil, note: String? = nil, customAttributes: [AttributeInput]? = nil, allowPartialAddresses: Bool? = nil) {
+		public init(email: InputValue<String> = .undefined, lineItems: InputValue<[CheckoutLineItemInput]> = .undefined, shippingAddress: InputValue<MailingAddressInput> = .undefined, note: InputValue<String> = .undefined, customAttributes: InputValue<[AttributeInput]> = .undefined, allowPartialAddresses: InputValue<Bool> = .undefined) {
 			self.email = email
 			self.lineItems = lineItems
 			self.shippingAddress = shippingAddress
@@ -72,28 +72,40 @@ extension Storefront {
 		internal func serialize() -> String {
 			var fields: [String] = []
 
-			if let email = email {
-				fields.append("email:\(GraphQL.quoteString(input: email))")
+			switch email {
+				case .some(let email): fields.append("email:\(GraphQL.quoteString(input: email))")
+				case .null: fields.append("email:null")
+				case .undefined: break
 			}
 
-			if let lineItems = lineItems {
-				fields.append("lineItems:[\(lineItems.map{ "\($0.serialize())" }.joined(separator: ","))]")
+			switch lineItems {
+				case .some(let lineItems): fields.append("lineItems:[\(lineItems.map{ "\($0.serialize())" }.joined(separator: ","))]")
+				case .null: fields.append("lineItems:null")
+				case .undefined: break
 			}
 
-			if let shippingAddress = shippingAddress {
-				fields.append("shippingAddress:\(shippingAddress.serialize())")
+			switch shippingAddress {
+				case .some(let shippingAddress): fields.append("shippingAddress:\(shippingAddress.serialize())")
+				case .null: fields.append("shippingAddress:null")
+				case .undefined: break
 			}
 
-			if let note = note {
-				fields.append("note:\(GraphQL.quoteString(input: note))")
+			switch note {
+				case .some(let note): fields.append("note:\(GraphQL.quoteString(input: note))")
+				case .null: fields.append("note:null")
+				case .undefined: break
 			}
 
-			if let customAttributes = customAttributes {
-				fields.append("customAttributes:[\(customAttributes.map{ "\($0.serialize())" }.joined(separator: ","))]")
+			switch customAttributes {
+				case .some(let customAttributes): fields.append("customAttributes:[\(customAttributes.map{ "\($0.serialize())" }.joined(separator: ","))]")
+				case .null: fields.append("customAttributes:null")
+				case .undefined: break
 			}
 
-			if let allowPartialAddresses = allowPartialAddresses {
-				fields.append("allowPartialAddresses:\(allowPartialAddresses)")
+			switch allowPartialAddresses {
+				case .some(let allowPartialAddresses): fields.append("allowPartialAddresses:\(allowPartialAddresses)")
+				case .null: fields.append("allowPartialAddresses:null")
+				case .undefined: break
 			}
 
 			return "{\(fields.joined(separator: ","))}"

--- a/Buy/Generated/Storefront/CheckoutLineItemInput.swift
+++ b/Buy/Generated/Storefront/CheckoutLineItemInput.swift
@@ -29,39 +29,41 @@ import Foundation
 extension Storefront {
 	/// Specifies the input fields to create a line item on a checkout. 
 	open class CheckoutLineItemInput {
-		/// The identifier of the product variant for the line item. 
-		open var variantId: GraphQL.ID
+		/// Extra information in the form of an array of Key-Value pairs about the line 
+		/// item. 
+		open var customAttributes: InputValue<[AttributeInput]>
 
 		/// The quantity of the line item. 
 		open var quantity: Int32
 
-		/// Extra information in the form of an array of Key-Value pairs about the line 
-		/// item. 
-		open var customAttributes: [AttributeInput]?
+		/// The identifier of the product variant for the line item. 
+		open var variantId: GraphQL.ID
 
 		/// Creates the input object.
 		///
 		/// - parameters:
-		///     - variantId: The identifier of the product variant for the line item.
-		///     - quantity: The quantity of the line item.
 		///     - customAttributes: Extra information in the form of an array of Key-Value pairs about the line item.
+		///     - quantity: The quantity of the line item.
+		///     - variantId: The identifier of the product variant for the line item.
 		///
-		public init(variantId: GraphQL.ID, quantity: Int32, customAttributes: [AttributeInput]? = nil) {
-			self.variantId = variantId
-			self.quantity = quantity
+		public init(quantity: Int32, variantId: GraphQL.ID, customAttributes: InputValue<[AttributeInput]> = .undefined) {
 			self.customAttributes = customAttributes
+			self.quantity = quantity
+			self.variantId = variantId
 		}
 
 		internal func serialize() -> String {
 			var fields: [String] = []
 
-			fields.append("variantId:\(GraphQL.quoteString(input: "\(variantId.rawValue)"))")
+			switch customAttributes {
+				case .some(let customAttributes): fields.append("customAttributes:[\(customAttributes.map{ "\($0.serialize())" }.joined(separator: ","))]")
+				case .null: fields.append("customAttributes:null")
+				case .undefined: break
+			}
 
 			fields.append("quantity:\(quantity)")
 
-			if let customAttributes = customAttributes {
-				fields.append("customAttributes:[\(customAttributes.map{ "\($0.serialize())" }.joined(separator: ","))]")
-			}
+			fields.append("variantId:\(GraphQL.quoteString(input: "\(variantId.rawValue)"))")
 
 			return "{\(fields.joined(separator: ","))}"
 		}

--- a/Buy/Generated/Storefront/CheckoutLineItemUpdateInput.swift
+++ b/Buy/Generated/Storefront/CheckoutLineItemUpdateInput.swift
@@ -29,17 +29,17 @@ import Foundation
 extension Storefront {
 	/// Specifies the input fields to update a line item on the checkout. 
 	open class CheckoutLineItemUpdateInput {
-		open var id: GraphQL.ID?
+		open var id: InputValue<GraphQL.ID>
 
 		/// The variant identifier of the line item. 
-		open var variantId: GraphQL.ID?
+		open var variantId: InputValue<GraphQL.ID>
 
 		/// The quantity of the line item. 
-		open var quantity: Int32?
+		open var quantity: InputValue<Int32>
 
 		/// Extra information in the form of an array of Key-Value pairs about the line 
 		/// item. 
-		open var customAttributes: [AttributeInput]?
+		open var customAttributes: InputValue<[AttributeInput]>
 
 		/// Creates the input object.
 		///
@@ -49,7 +49,7 @@ extension Storefront {
 		///     - quantity: The quantity of the line item.
 		///     - customAttributes: Extra information in the form of an array of Key-Value pairs about the line item.
 		///
-		public init(id: GraphQL.ID? = nil, variantId: GraphQL.ID? = nil, quantity: Int32? = nil, customAttributes: [AttributeInput]? = nil) {
+		public init(id: InputValue<GraphQL.ID> = .undefined, variantId: InputValue<GraphQL.ID> = .undefined, quantity: InputValue<Int32> = .undefined, customAttributes: InputValue<[AttributeInput]> = .undefined) {
 			self.id = id
 			self.variantId = variantId
 			self.quantity = quantity
@@ -59,20 +59,28 @@ extension Storefront {
 		internal func serialize() -> String {
 			var fields: [String] = []
 
-			if let id = id {
-				fields.append("id:\(GraphQL.quoteString(input: "\(id.rawValue)"))")
+			switch id {
+				case .some(let id): fields.append("id:\(GraphQL.quoteString(input: "\(id.rawValue)"))")
+				case .null: fields.append("id:null")
+				case .undefined: break
 			}
 
-			if let variantId = variantId {
-				fields.append("variantId:\(GraphQL.quoteString(input: "\(variantId.rawValue)"))")
+			switch variantId {
+				case .some(let variantId): fields.append("variantId:\(GraphQL.quoteString(input: "\(variantId.rawValue)"))")
+				case .null: fields.append("variantId:null")
+				case .undefined: break
 			}
 
-			if let quantity = quantity {
-				fields.append("quantity:\(quantity)")
+			switch quantity {
+				case .some(let quantity): fields.append("quantity:\(quantity)")
+				case .null: fields.append("quantity:null")
+				case .undefined: break
 			}
 
-			if let customAttributes = customAttributes {
-				fields.append("customAttributes:[\(customAttributes.map{ "\($0.serialize())" }.joined(separator: ","))]")
+			switch customAttributes {
+				case .some(let customAttributes): fields.append("customAttributes:[\(customAttributes.map{ "\($0.serialize())" }.joined(separator: ","))]")
+				case .null: fields.append("customAttributes:null")
+				case .undefined: break
 			}
 
 			return "{\(fields.joined(separator: ","))}"

--- a/Buy/Generated/Storefront/Collection.swift
+++ b/Buy/Generated/Storefront/Collection.swift
@@ -115,11 +115,11 @@ extension Storefront {
 		/// - parameters:
 		///     - first: No description
 		///     - after: No description
-		///     - sortKey: No description
 		///     - reverse: No description
+		///     - sortKey: No description
 		///
 		@discardableResult
-		open func products(alias: String? = nil, first: Int32, after: String? = nil, sortKey: ProductCollectionSortKeys? = nil, reverse: Bool? = nil, _ subfields: (ProductConnectionQuery) -> Void) -> CollectionQuery {
+		open func products(alias: String? = nil, first: Int32, after: String? = nil, reverse: Bool? = nil, sortKey: ProductCollectionSortKeys? = nil, _ subfields: (ProductConnectionQuery) -> Void) -> CollectionQuery {
 			var args: [String] = []
 
 			args.append("first:\(first)")
@@ -128,12 +128,12 @@ extension Storefront {
 				args.append("after:\(GraphQL.quoteString(input: after))")
 			}
 
-			if let sortKey = sortKey {
-				args.append("sortKey:\(sortKey.rawValue)")
-			}
-
 			if let reverse = reverse {
 				args.append("reverse:\(reverse)")
+			}
+
+			if let sortKey = sortKey {
+				args.append("sortKey:\(sortKey.rawValue)")
 			}
 
 			let argsString: String? = args.isEmpty ? nil : "(\(args.joined(separator: ",")))"

--- a/Buy/Generated/Storefront/CreditCardPaymentInput.swift
+++ b/Buy/Generated/Storefront/CreditCardPaymentInput.swift
@@ -45,7 +45,7 @@ extension Storefront {
 		open var vaultId: String
 
 		/// Executes the payment in test mode if possible. Defaults to `false`. 
-		open var test: Bool?
+		open var test: InputValue<Bool>
 
 		/// Creates the input object.
 		///
@@ -56,7 +56,7 @@ extension Storefront {
 		///     - vaultId: The ID returned by Shopify's Card Vault.
 		///     - test: Executes the payment in test mode if possible. Defaults to `false`.
 		///
-		public init(amount: Decimal, idempotencyKey: String, billingAddress: MailingAddressInput, vaultId: String, test: Bool? = nil) {
+		public init(amount: Decimal, idempotencyKey: String, billingAddress: MailingAddressInput, vaultId: String, test: InputValue<Bool> = .undefined) {
 			self.amount = amount
 			self.idempotencyKey = idempotencyKey
 			self.billingAddress = billingAddress
@@ -75,8 +75,10 @@ extension Storefront {
 
 			fields.append("vaultId:\(GraphQL.quoteString(input: vaultId))")
 
-			if let test = test {
-				fields.append("test:\(test)")
+			switch test {
+				case .some(let test): fields.append("test:\(test)")
+				case .null: fields.append("test:null")
+				case .undefined: break
 			}
 
 			return "{\(fields.joined(separator: ","))}"

--- a/Buy/Generated/Storefront/Customer.swift
+++ b/Buy/Generated/Storefront/Customer.swift
@@ -128,13 +128,13 @@ extension Storefront {
 		/// - parameters:
 		///     - first: No description
 		///     - after: No description
-		///     - sortKey: No description
 		///     - reverse: No description
+		///     - sortKey: No description
 		///     - query: Supported filter parameters:
 		///         - `processed_at`
 		///
 		@discardableResult
-		open func orders(alias: String? = nil, first: Int32, after: String? = nil, sortKey: OrderSortKeys? = nil, reverse: Bool? = nil, query: String? = nil, _ subfields: (OrderConnectionQuery) -> Void) -> CustomerQuery {
+		open func orders(alias: String? = nil, first: Int32, after: String? = nil, reverse: Bool? = nil, sortKey: OrderSortKeys? = nil, query: String? = nil, _ subfields: (OrderConnectionQuery) -> Void) -> CustomerQuery {
 			var args: [String] = []
 
 			args.append("first:\(first)")
@@ -143,12 +143,12 @@ extension Storefront {
 				args.append("after:\(GraphQL.quoteString(input: after))")
 			}
 
-			if let sortKey = sortKey {
-				args.append("sortKey:\(sortKey.rawValue)")
-			}
-
 			if let reverse = reverse {
 				args.append("reverse:\(reverse)")
+			}
+
+			if let sortKey = sortKey {
+				args.append("sortKey:\(sortKey.rawValue)")
 			}
 
 			if let query = query {

--- a/Buy/Generated/Storefront/CustomerCreateInput.swift
+++ b/Buy/Generated/Storefront/CustomerCreateInput.swift
@@ -30,23 +30,23 @@ extension Storefront {
 	/// Specifies the fields required to create a new Customer. 
 	open class CustomerCreateInput {
 		/// The customer’s first name. 
-		open var firstName: String?
+		open var firstName: InputValue<String>
 
 		/// The customer’s last name. 
-		open var lastName: String?
+		open var lastName: InputValue<String>
 
 		/// The customer’s email. 
 		open var email: String
 
 		/// The customer’s phone number. 
-		open var phone: String?
+		open var phone: InputValue<String>
 
 		/// The login password used by the customer. 
 		open var password: String
 
 		/// Indicates whether the customer has consented to be sent marketing material 
 		/// via email. 
-		open var acceptsMarketing: Bool?
+		open var acceptsMarketing: InputValue<Bool>
 
 		/// Creates the input object.
 		///
@@ -58,7 +58,7 @@ extension Storefront {
 		///     - password: The login password used by the customer.
 		///     - acceptsMarketing: Indicates whether the customer has consented to be sent marketing material via email.
 		///
-		public init(email: String, password: String, firstName: String? = nil, lastName: String? = nil, phone: String? = nil, acceptsMarketing: Bool? = nil) {
+		public init(email: String, password: String, firstName: InputValue<String> = .undefined, lastName: InputValue<String> = .undefined, phone: InputValue<String> = .undefined, acceptsMarketing: InputValue<Bool> = .undefined) {
 			self.firstName = firstName
 			self.lastName = lastName
 			self.email = email
@@ -70,24 +70,32 @@ extension Storefront {
 		internal func serialize() -> String {
 			var fields: [String] = []
 
-			if let firstName = firstName {
-				fields.append("firstName:\(GraphQL.quoteString(input: firstName))")
+			switch firstName {
+				case .some(let firstName): fields.append("firstName:\(GraphQL.quoteString(input: firstName))")
+				case .null: fields.append("firstName:null")
+				case .undefined: break
 			}
 
-			if let lastName = lastName {
-				fields.append("lastName:\(GraphQL.quoteString(input: lastName))")
+			switch lastName {
+				case .some(let lastName): fields.append("lastName:\(GraphQL.quoteString(input: lastName))")
+				case .null: fields.append("lastName:null")
+				case .undefined: break
 			}
 
 			fields.append("email:\(GraphQL.quoteString(input: email))")
 
-			if let phone = phone {
-				fields.append("phone:\(GraphQL.quoteString(input: phone))")
+			switch phone {
+				case .some(let phone): fields.append("phone:\(GraphQL.quoteString(input: phone))")
+				case .null: fields.append("phone:null")
+				case .undefined: break
 			}
 
 			fields.append("password:\(GraphQL.quoteString(input: password))")
 
-			if let acceptsMarketing = acceptsMarketing {
-				fields.append("acceptsMarketing:\(acceptsMarketing)")
+			switch acceptsMarketing {
+				case .some(let acceptsMarketing): fields.append("acceptsMarketing:\(acceptsMarketing)")
+				case .null: fields.append("acceptsMarketing:null")
+				case .undefined: break
 			}
 
 			return "{\(fields.joined(separator: ","))}"

--- a/Buy/Generated/Storefront/CustomerUpdateInput.swift
+++ b/Buy/Generated/Storefront/CustomerUpdateInput.swift
@@ -30,23 +30,23 @@ extension Storefront {
 	/// Specifies the fields required to update the Customer information. 
 	open class CustomerUpdateInput {
 		/// The customer’s first name. 
-		open var firstName: String?
+		open var firstName: InputValue<String>
 
 		/// The customer’s last name. 
-		open var lastName: String?
+		open var lastName: InputValue<String>
 
 		/// The customer’s email. 
-		open var email: String?
+		open var email: InputValue<String>
 
 		/// The customer’s phone number. 
-		open var phone: String?
+		open var phone: InputValue<String>
 
 		/// The login password used by the customer. 
-		open var password: String?
+		open var password: InputValue<String>
 
 		/// Indicates whether the customer has consented to be sent marketing material 
 		/// via email. 
-		open var acceptsMarketing: Bool?
+		open var acceptsMarketing: InputValue<Bool>
 
 		/// Creates the input object.
 		///
@@ -58,7 +58,7 @@ extension Storefront {
 		///     - password: The login password used by the customer.
 		///     - acceptsMarketing: Indicates whether the customer has consented to be sent marketing material via email.
 		///
-		public init(firstName: String? = nil, lastName: String? = nil, email: String? = nil, phone: String? = nil, password: String? = nil, acceptsMarketing: Bool? = nil) {
+		public init(firstName: InputValue<String> = .undefined, lastName: InputValue<String> = .undefined, email: InputValue<String> = .undefined, phone: InputValue<String> = .undefined, password: InputValue<String> = .undefined, acceptsMarketing: InputValue<Bool> = .undefined) {
 			self.firstName = firstName
 			self.lastName = lastName
 			self.email = email
@@ -70,28 +70,40 @@ extension Storefront {
 		internal func serialize() -> String {
 			var fields: [String] = []
 
-			if let firstName = firstName {
-				fields.append("firstName:\(GraphQL.quoteString(input: firstName))")
+			switch firstName {
+				case .some(let firstName): fields.append("firstName:\(GraphQL.quoteString(input: firstName))")
+				case .null: fields.append("firstName:null")
+				case .undefined: break
 			}
 
-			if let lastName = lastName {
-				fields.append("lastName:\(GraphQL.quoteString(input: lastName))")
+			switch lastName {
+				case .some(let lastName): fields.append("lastName:\(GraphQL.quoteString(input: lastName))")
+				case .null: fields.append("lastName:null")
+				case .undefined: break
 			}
 
-			if let email = email {
-				fields.append("email:\(GraphQL.quoteString(input: email))")
+			switch email {
+				case .some(let email): fields.append("email:\(GraphQL.quoteString(input: email))")
+				case .null: fields.append("email:null")
+				case .undefined: break
 			}
 
-			if let phone = phone {
-				fields.append("phone:\(GraphQL.quoteString(input: phone))")
+			switch phone {
+				case .some(let phone): fields.append("phone:\(GraphQL.quoteString(input: phone))")
+				case .null: fields.append("phone:null")
+				case .undefined: break
 			}
 
-			if let password = password {
-				fields.append("password:\(GraphQL.quoteString(input: password))")
+			switch password {
+				case .some(let password): fields.append("password:\(GraphQL.quoteString(input: password))")
+				case .null: fields.append("password:null")
+				case .undefined: break
 			}
 
-			if let acceptsMarketing = acceptsMarketing {
-				fields.append("acceptsMarketing:\(acceptsMarketing)")
+			switch acceptsMarketing {
+				case .some(let acceptsMarketing): fields.append("acceptsMarketing:\(acceptsMarketing)")
+				case .null: fields.append("acceptsMarketing:null")
+				case .undefined: break
 			}
 
 			return "{\(fields.joined(separator: ","))}"

--- a/Buy/Generated/Storefront/MailingAddressInput.swift
+++ b/Buy/Generated/Storefront/MailingAddressInput.swift
@@ -29,25 +29,25 @@ import Foundation
 extension Storefront {
 	/// Specifies the fields accepted to create or update a mailing address. 
 	open class MailingAddressInput {
-		open var address1: String?
+		open var address1: InputValue<String>
 
-		open var address2: String?
+		open var address2: InputValue<String>
 
-		open var city: String?
+		open var city: InputValue<String>
 
-		open var company: String?
+		open var company: InputValue<String>
 
-		open var country: String?
+		open var country: InputValue<String>
 
-		open var firstName: String?
+		open var firstName: InputValue<String>
 
-		open var lastName: String?
+		open var lastName: InputValue<String>
 
-		open var phone: String?
+		open var phone: InputValue<String>
 
-		open var province: String?
+		open var province: InputValue<String>
 
-		open var zip: String?
+		open var zip: InputValue<String>
 
 		/// Creates the input object.
 		///
@@ -63,7 +63,7 @@ extension Storefront {
 		///     - province: No description
 		///     - zip: No description
 		///
-		public init(address1: String? = nil, address2: String? = nil, city: String? = nil, company: String? = nil, country: String? = nil, firstName: String? = nil, lastName: String? = nil, phone: String? = nil, province: String? = nil, zip: String? = nil) {
+		public init(address1: InputValue<String> = .undefined, address2: InputValue<String> = .undefined, city: InputValue<String> = .undefined, company: InputValue<String> = .undefined, country: InputValue<String> = .undefined, firstName: InputValue<String> = .undefined, lastName: InputValue<String> = .undefined, phone: InputValue<String> = .undefined, province: InputValue<String> = .undefined, zip: InputValue<String> = .undefined) {
 			self.address1 = address1
 			self.address2 = address2
 			self.city = city
@@ -79,44 +79,64 @@ extension Storefront {
 		internal func serialize() -> String {
 			var fields: [String] = []
 
-			if let address1 = address1 {
-				fields.append("address1:\(GraphQL.quoteString(input: address1))")
+			switch address1 {
+				case .some(let address1): fields.append("address1:\(GraphQL.quoteString(input: address1))")
+				case .null: fields.append("address1:null")
+				case .undefined: break
 			}
 
-			if let address2 = address2 {
-				fields.append("address2:\(GraphQL.quoteString(input: address2))")
+			switch address2 {
+				case .some(let address2): fields.append("address2:\(GraphQL.quoteString(input: address2))")
+				case .null: fields.append("address2:null")
+				case .undefined: break
 			}
 
-			if let city = city {
-				fields.append("city:\(GraphQL.quoteString(input: city))")
+			switch city {
+				case .some(let city): fields.append("city:\(GraphQL.quoteString(input: city))")
+				case .null: fields.append("city:null")
+				case .undefined: break
 			}
 
-			if let company = company {
-				fields.append("company:\(GraphQL.quoteString(input: company))")
+			switch company {
+				case .some(let company): fields.append("company:\(GraphQL.quoteString(input: company))")
+				case .null: fields.append("company:null")
+				case .undefined: break
 			}
 
-			if let country = country {
-				fields.append("country:\(GraphQL.quoteString(input: country))")
+			switch country {
+				case .some(let country): fields.append("country:\(GraphQL.quoteString(input: country))")
+				case .null: fields.append("country:null")
+				case .undefined: break
 			}
 
-			if let firstName = firstName {
-				fields.append("firstName:\(GraphQL.quoteString(input: firstName))")
+			switch firstName {
+				case .some(let firstName): fields.append("firstName:\(GraphQL.quoteString(input: firstName))")
+				case .null: fields.append("firstName:null")
+				case .undefined: break
 			}
 
-			if let lastName = lastName {
-				fields.append("lastName:\(GraphQL.quoteString(input: lastName))")
+			switch lastName {
+				case .some(let lastName): fields.append("lastName:\(GraphQL.quoteString(input: lastName))")
+				case .null: fields.append("lastName:null")
+				case .undefined: break
 			}
 
-			if let phone = phone {
-				fields.append("phone:\(GraphQL.quoteString(input: phone))")
+			switch phone {
+				case .some(let phone): fields.append("phone:\(GraphQL.quoteString(input: phone))")
+				case .null: fields.append("phone:null")
+				case .undefined: break
 			}
 
-			if let province = province {
-				fields.append("province:\(GraphQL.quoteString(input: province))")
+			switch province {
+				case .some(let province): fields.append("province:\(GraphQL.quoteString(input: province))")
+				case .null: fields.append("province:null")
+				case .undefined: break
 			}
 
-			if let zip = zip {
-				fields.append("zip:\(GraphQL.quoteString(input: zip))")
+			switch zip {
+				case .some(let zip): fields.append("zip:\(GraphQL.quoteString(input: zip))")
+				case .null: fields.append("zip:null")
+				case .undefined: break
 			}
 
 			return "{\(fields.joined(separator: ","))}"

--- a/Buy/Generated/Storefront/Product.swift
+++ b/Buy/Generated/Storefront/Product.swift
@@ -119,15 +119,15 @@ extension Storefront {
 		/// - parameters:
 		///     - first: No description
 		///     - after: No description
-		///     - sortKey: No description
 		///     - reverse: No description
+		///     - sortKey: No description
 		///     - maxWidth: Image width in pixels between 1 and 2048
 		///     - maxHeight: Image height in pixels between 1 and 2048
 		///     - crop: If specified, crop the image keeping the specified region
 		///     - scale: Image size multiplier retina displays. Must be between 1 and 3
 		///
 		@discardableResult
-		open func images(alias: String? = nil, first: Int32, after: String? = nil, sortKey: ProductImageSortKeys? = nil, reverse: Bool? = nil, maxWidth: Int32? = nil, maxHeight: Int32? = nil, crop: CropRegion? = nil, scale: Int32? = nil, _ subfields: (ImageConnectionQuery) -> Void) -> ProductQuery {
+		open func images(alias: String? = nil, first: Int32, after: String? = nil, reverse: Bool? = nil, sortKey: ProductImageSortKeys? = nil, maxWidth: Int32? = nil, maxHeight: Int32? = nil, crop: CropRegion? = nil, scale: Int32? = nil, _ subfields: (ImageConnectionQuery) -> Void) -> ProductQuery {
 			var args: [String] = []
 
 			args.append("first:\(first)")
@@ -136,12 +136,12 @@ extension Storefront {
 				args.append("after:\(GraphQL.quoteString(input: after))")
 			}
 
-			if let sortKey = sortKey {
-				args.append("sortKey:\(sortKey.rawValue)")
-			}
-
 			if let reverse = reverse {
 				args.append("reverse:\(reverse)")
+			}
+
+			if let sortKey = sortKey {
+				args.append("sortKey:\(sortKey.rawValue)")
 			}
 
 			if let maxWidth = maxWidth {

--- a/Buy/Generated/Storefront/Shop.swift
+++ b/Buy/Generated/Storefront/Shop.swift
@@ -37,8 +37,8 @@ extension Storefront {
 		/// - parameters:
 		///     - first: No description
 		///     - after: No description
-		///     - sortKey: No description
 		///     - reverse: No description
+		///     - sortKey: No description
 		///     - query: Supported filter parameters:
 		///         - `author`
 		///         - `updated_at`
@@ -47,7 +47,7 @@ extension Storefront {
 		///         - `tag`
 		///
 		@discardableResult
-		open func articles(alias: String? = nil, first: Int32, after: String? = nil, sortKey: ArticleSortKeys? = nil, reverse: Bool? = nil, query: String? = nil, _ subfields: (ArticleConnectionQuery) -> Void) -> ShopQuery {
+		open func articles(alias: String? = nil, first: Int32, after: String? = nil, reverse: Bool? = nil, sortKey: ArticleSortKeys? = nil, query: String? = nil, _ subfields: (ArticleConnectionQuery) -> Void) -> ShopQuery {
 			var args: [String] = []
 
 			args.append("first:\(first)")
@@ -56,12 +56,12 @@ extension Storefront {
 				args.append("after:\(GraphQL.quoteString(input: after))")
 			}
 
-			if let sortKey = sortKey {
-				args.append("sortKey:\(sortKey.rawValue)")
-			}
-
 			if let reverse = reverse {
 				args.append("reverse:\(reverse)")
+			}
+
+			if let sortKey = sortKey {
+				args.append("sortKey:\(sortKey.rawValue)")
 			}
 
 			if let query = query {
@@ -82,8 +82,8 @@ extension Storefront {
 		/// - parameters:
 		///     - first: No description
 		///     - after: No description
-		///     - sortKey: No description
 		///     - reverse: No description
+		///     - sortKey: No description
 		///     - query: Supported filter parameters:
 		///         - `handle`
 		///         - `title`
@@ -91,7 +91,7 @@ extension Storefront {
 		///         - `created_at`
 		///
 		@discardableResult
-		open func blogs(alias: String? = nil, first: Int32, after: String? = nil, sortKey: BlogSortKeys? = nil, reverse: Bool? = nil, query: String? = nil, _ subfields: (BlogConnectionQuery) -> Void) -> ShopQuery {
+		open func blogs(alias: String? = nil, first: Int32, after: String? = nil, reverse: Bool? = nil, sortKey: BlogSortKeys? = nil, query: String? = nil, _ subfields: (BlogConnectionQuery) -> Void) -> ShopQuery {
 			var args: [String] = []
 
 			args.append("first:\(first)")
@@ -100,12 +100,12 @@ extension Storefront {
 				args.append("after:\(GraphQL.quoteString(input: after))")
 			}
 
-			if let sortKey = sortKey {
-				args.append("sortKey:\(sortKey.rawValue)")
-			}
-
 			if let reverse = reverse {
 				args.append("reverse:\(reverse)")
+			}
+
+			if let sortKey = sortKey {
+				args.append("sortKey:\(sortKey.rawValue)")
 			}
 
 			if let query = query {
@@ -154,15 +154,15 @@ extension Storefront {
 		/// - parameters:
 		///     - first: No description
 		///     - after: No description
-		///     - sortKey: No description
 		///     - reverse: No description
+		///     - sortKey: No description
 		///     - query: Supported filter parameters:
 		///         - `title`
 		///         - `collection_type`
 		///         - `updated_at`
 		///
 		@discardableResult
-		open func collections(alias: String? = nil, first: Int32, after: String? = nil, sortKey: CollectionSortKeys? = nil, reverse: Bool? = nil, query: String? = nil, _ subfields: (CollectionConnectionQuery) -> Void) -> ShopQuery {
+		open func collections(alias: String? = nil, first: Int32, after: String? = nil, reverse: Bool? = nil, sortKey: CollectionSortKeys? = nil, query: String? = nil, _ subfields: (CollectionConnectionQuery) -> Void) -> ShopQuery {
 			var args: [String] = []
 
 			args.append("first:\(first)")
@@ -171,12 +171,12 @@ extension Storefront {
 				args.append("after:\(GraphQL.quoteString(input: after))")
 			}
 
-			if let sortKey = sortKey {
-				args.append("sortKey:\(sortKey.rawValue)")
-			}
-
 			if let reverse = reverse {
 				args.append("reverse:\(reverse)")
+			}
+
+			if let sortKey = sortKey {
+				args.append("sortKey:\(sortKey.rawValue)")
 			}
 
 			if let query = query {
@@ -297,8 +297,8 @@ extension Storefront {
 		/// - parameters:
 		///     - first: No description
 		///     - after: No description
-		///     - sortKey: No description
 		///     - reverse: No description
+		///     - sortKey: No description
 		///     - query: Supported filter parameters:
 		///         - `title`
 		///         - `product_type`
@@ -308,7 +308,7 @@ extension Storefront {
 		///         - `tag`
 		///
 		@discardableResult
-		open func products(alias: String? = nil, first: Int32, after: String? = nil, sortKey: ProductSortKeys? = nil, reverse: Bool? = nil, query: String? = nil, _ subfields: (ProductConnectionQuery) -> Void) -> ShopQuery {
+		open func products(alias: String? = nil, first: Int32, after: String? = nil, reverse: Bool? = nil, sortKey: ProductSortKeys? = nil, query: String? = nil, _ subfields: (ProductConnectionQuery) -> Void) -> ShopQuery {
 			var args: [String] = []
 
 			args.append("first:\(first)")
@@ -317,12 +317,12 @@ extension Storefront {
 				args.append("after:\(GraphQL.quoteString(input: after))")
 			}
 
-			if let sortKey = sortKey {
-				args.append("sortKey:\(sortKey.rawValue)")
-			}
-
 			if let reverse = reverse {
 				args.append("reverse:\(reverse)")
+			}
+
+			if let sortKey = sortKey {
+				args.append("sortKey:\(sortKey.rawValue)")
 			}
 
 			if let query = query {

--- a/Buy/Generated/Storefront/TokenizedPaymentInput.swift
+++ b/Buy/Generated/Storefront/TokenizedPaymentInput.swift
@@ -49,10 +49,10 @@ extension Storefront {
 		open var paymentData: String
 
 		/// Executes the payment in test mode if possible. Defaults to `false`. 
-		open var test: Bool?
+		open var test: InputValue<Bool>
 
 		/// Public Hash Key used for AndroidPay payments only. 
-		open var identifier: String?
+		open var identifier: InputValue<String>
 
 		/// Creates the input object.
 		///
@@ -65,7 +65,7 @@ extension Storefront {
 		///     - test: Executes the payment in test mode if possible. Defaults to `false`.
 		///     - identifier: Public Hash Key used for AndroidPay payments only.
 		///
-		public init(amount: Decimal, idempotencyKey: String, billingAddress: MailingAddressInput, type: String, paymentData: String, test: Bool? = nil, identifier: String? = nil) {
+		public init(amount: Decimal, idempotencyKey: String, billingAddress: MailingAddressInput, type: String, paymentData: String, test: InputValue<Bool> = .undefined, identifier: InputValue<String> = .undefined) {
 			self.amount = amount
 			self.idempotencyKey = idempotencyKey
 			self.billingAddress = billingAddress
@@ -88,12 +88,16 @@ extension Storefront {
 
 			fields.append("paymentData:\(GraphQL.quoteString(input: paymentData))")
 
-			if let test = test {
-				fields.append("test:\(test)")
+			switch test {
+				case .some(let test): fields.append("test:\(test)")
+				case .null: fields.append("test:null")
+				case .undefined: break
 			}
 
-			if let identifier = identifier {
-				fields.append("identifier:\(GraphQL.quoteString(input: identifier))")
+			switch identifier {
+				case .some(let identifier): fields.append("identifier:\(GraphQL.quoteString(input: identifier))")
+				case .null: fields.append("identifier:null")
+				case .undefined: break
 			}
 
 			return "{\(fields.joined(separator: ","))}"

--- a/Sample Apps/Storefront/Storefront/ClientQuery.swift
+++ b/Sample Apps/Storefront/Storefront/ClientQuery.swift
@@ -78,12 +78,12 @@ final class ClientQuery {
     //
     static func mutationForCreateCheckout(with cartItems: [CartItem]) -> Storefront.MutationQuery {
         let lineItems = cartItems.map { item in
-            Storefront.CheckoutLineItemInput(variantId: GraphQL.ID(rawValue: item.variant.id), quantity: Int32(item.quantity))
+            Storefront.CheckoutLineItemInput(quantity: Int32(item.quantity), variantId: GraphQL.ID(rawValue: item.variant.id))
         }
         
         let checkoutInput = Storefront.CheckoutCreateInput(
-            lineItems: lineItems,
-            allowPartialAddresses: true
+            lineItems: .some(lineItems),
+            allowPartialAddresses: .some(true)
         )
         
         return Storefront.buildMutation { $0
@@ -99,10 +99,10 @@ final class ClientQuery {
         
         let checkoutID   = GraphQL.ID(rawValue: id)
         let addressInput = Storefront.MailingAddressInput(
-            city:     address.city,
-            country:  address.country,
-            province: address.province,
-            zip:      address.zip
+            city:     address.city.orNull,
+            country:  address.country.orNull,
+            province: address.province.orNull,
+            zip:      address.zip.orNull
         )
         
         return Storefront.buildMutation { $0
@@ -122,15 +122,15 @@ final class ClientQuery {
         
         let checkoutID   = GraphQL.ID(rawValue: id)
         let addressInput = Storefront.MailingAddressInput(
-            address1:  address.addressLine1,
-            address2:  address.addressLine2,
-            city:      address.city,
-            country:   address.country,
-            firstName: address.firstName,
-            lastName:  address.lastName,
-            phone:     address.phone,
-            province:  address.province,
-            zip:       address.zip
+            address1:  address.addressLine1.orNull,
+            address2:  address.addressLine2.orNull,
+            city:      address.city.orNull,
+            country:   address.country.orNull,
+            firstName: address.firstName.orNull,
+            lastName:  address.lastName.orNull,
+            phone:     address.phone.orNull,
+            province:  address.province.orNull,
+            zip:       address.zip.orNull
         )
         
         return Storefront.buildMutation { $0
@@ -179,14 +179,14 @@ final class ClientQuery {
     static func mutationForCompleteCheckoutUsingApplePay(_ checkout: PayCheckout, billingAddress: PayAddress, token: String, idempotencyToken: String) -> Storefront.MutationQuery {
         
         let mailingAddress = Storefront.MailingAddressInput(
-            address1:  billingAddress.addressLine1,
-            address2:  billingAddress.addressLine2,
-            city:      billingAddress.city,
-            country:   billingAddress.country,
-            firstName: billingAddress.firstName,
-            lastName:  billingAddress.lastName,
-            province:  billingAddress.province,
-            zip:       billingAddress.zip
+            address1:  billingAddress.addressLine1.orNull,
+            address2:  billingAddress.addressLine2.orNull,
+            city:      billingAddress.city.orNull,
+            country:   billingAddress.country.orNull,
+            firstName: billingAddress.firstName.orNull,
+            lastName:  billingAddress.lastName.orNull,
+            province:  billingAddress.province.orNull,
+            zip:       billingAddress.zip.orNull
         )
         
         let paymentInput = Storefront.TokenizedPaymentInput(
@@ -196,7 +196,7 @@ final class ClientQuery {
             type:           CheckoutViewModel.PaymentType.applePay.rawValue,
             paymentData:    token
         )
-        
+
         return Storefront.buildMutation { $0
             .checkoutCompleteWithTokenizedPayment(checkoutId: GraphQL.ID(rawValue: checkout.id), payment: paymentInput) { $0
                 .userErrors { $0


### PR DESCRIPTION
### What this does

Converts all optional fields on input object to type `InputValue<FieldType>` where `FieldType` is the type previously used for those fields. Requiring an `InputValue` forces an explicit decision on whether the values should be set to the following:
- nil
- undefined
- actual value

This change is required to allow update mutation to explicitly send `nil` values in the query, which is particularly useful for nullifying previously non-nil values on the server. Concrete example includes removing a customer's phone number from the server.

#### Philosophy

Other approaches were considered but we ultimately landed on wrapping optional values in a generic `InputValue` type. The intention is to force the user to make an explicit decision when setting values instead of relying on implicit behaviour that isn't documented.

**This is breaking change**. It will be released under a minor version bump - `v3.1`