### PR TITLE
Input for explicit nil support.

### DIFF
--- a/Buy.xcodeproj/project.pbxproj
+++ b/Buy.xcodeproj/project.pbxproj
@@ -325,6 +325,7 @@
 		9AC2EFBF1F6818180037E0D7 /* GraphQL+ScalarSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AEF61A01E5F5A190067FA90 /* GraphQL+ScalarSupport.swift */; };
 		9AC2EFC21F6818180037E0D7 /* Buy.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AEF60F61E5F42D90067FA90 /* Buy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9AC2EFC31F6818180037E0D7 /* MD5.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A664D701EF05F97001BFB01 /* MD5.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9AC2EFD71F686DB90037E0D7 /* Optional+Input.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC2EFD61F686DB90037E0D7 /* Optional+Input.swift */; };
 		9AE1F8161F605F8F00147E77 /* ProductVariantSortKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE1F8151F605F8F00147E77 /* ProductVariantSortKeys.swift */; };
 		9AE2A1C21EC6373B00921247 /* Graph.CachePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE2A1C11EC6373B00921247 /* Graph.CachePolicyTests.swift */; };
 		9AE2A1C61EC9EE1D00921247 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE2A1C51EC9EE1D00921247 /* Log.swift */; };
@@ -530,6 +531,7 @@
 		9AAFAB761E6080A500864A17 /* Graph.QueryError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.QueryError.swift; sourceTree = "<group>"; };
 		9AB421B01E93CA45005098C4 /* PayAuthorization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayAuthorization.swift; sourceTree = "<group>"; };
 		9AC2EFC81F6818180037E0D7 /* Buy.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Buy.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9AC2EFD61F686DB90037E0D7 /* Optional+Input.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Input.swift"; sourceTree = "<group>"; };
 		9AE1F8151F605F8F00147E77 /* ProductVariantSortKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariantSortKeys.swift; sourceTree = "<group>"; };
 		9AE2A1C11EC6373B00921247 /* Graph.CachePolicyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Graph.CachePolicyTests.swift; sourceTree = "<group>"; };
 		9AE2A1C51EC9EE1D00921247 /* Log.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
@@ -917,6 +919,7 @@
 			isa = PBXGroup;
 			children = (
 				9AEF61A01E5F5A190067FA90 /* GraphQL+ScalarSupport.swift */,
+				9AC2EFD61F686DB90037E0D7 /* Optional+Input.swift */,
 			);
 			path = Custom;
 			sourceTree = "<group>";
@@ -1459,6 +1462,7 @@
 				9AA416D31EE095B20060029B /* BlogSortKeys.swift in Sources */,
 				9A0C805C1EAA51C50020F187 /* Checkout.swift in Sources */,
 				9A0C806A1EAA51C50020F187 /* CheckoutLineItemConnection.swift in Sources */,
+				9AC2EFD71F686DB90037E0D7 /* Optional+Input.swift in Sources */,
 				9A0C80931EAA51C50020F187 /* MailingAddressEdge.swift in Sources */,
 				9AA416DA1EE095BB0060029B /* CommentConnection.swift in Sources */,
 				9A0C80B21EAA51C50020F187 /* TransactionKind.swift in Sources */,

--- a/Buy/Custom/Optional+Input.swift
+++ b/Buy/Custom/Optional+Input.swift
@@ -1,0 +1,37 @@
+//
+//  Optional+Input.swift
+//  Buy
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+public extension Optional {
+    public var orNull: Input<Wrapped> {
+        return Input(orNull: self)
+    }
+    
+    public var orUndefined: Input<Wrapped> {
+        return Input(orUndefined: self)
+    }
+}

--- a/Buy/Custom/Optional+Input.swift
+++ b/Buy/Custom/Optional+Input.swift
@@ -27,10 +27,13 @@
 import Foundation
 
 public extension Optional {
+    
+    /// Transforms an Optional<T> into Input.value(T), or Input.value(nil) if optional is nil.
     public var orNull: Input<Wrapped> {
         return Input(orNull: self)
     }
     
+    /// Transforms an Optional<T> into Input.value(T), or Input.undefined if optional is nil.
     public var orUndefined: Input<Wrapped> {
         return Input(orUndefined: self)
     }

--- a/Buy/Generated/Storefront/AppliedGiftCard.swift
+++ b/Buy/Generated/Storefront/AppliedGiftCard.swift
@@ -69,30 +69,30 @@ extension Storefront {
 			switch fieldName {
 				case "amountUsed":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: AppliedGiftCard.self, field: fieldName, value: fieldValue)
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
 
 				case "balance":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: AppliedGiftCard.self, field: fieldName, value: fieldValue)
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
 
 				case "id":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: AppliedGiftCard.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.ID(rawValue: value)
 
 				case "lastCharacters":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: AppliedGiftCard.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: AppliedGiftCard.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/Article.swift
+++ b/Buy/Generated/Storefront/Article.swift
@@ -213,87 +213,87 @@ extension Storefront {
 			switch fieldName {
 				case "author":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Article.self, field: fieldName, value: fieldValue)
 				}
 				return try ArticleAuthor(fields: value)
 
 				case "blog":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Article.self, field: fieldName, value: fieldValue)
 				}
 				return try Blog(fields: value)
 
 				case "comments":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Article.self, field: fieldName, value: fieldValue)
 				}
 				return try CommentConnection(fields: value)
 
 				case "content":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Article.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "contentHtml":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Article.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "excerpt":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Article.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "excerptHtml":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Article.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "id":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Article.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.ID(rawValue: value)
 
 				case "image":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Article.self, field: fieldName, value: fieldValue)
 				}
 				return try Image(fields: value)
 
 				case "publishedAt":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Article.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.iso8601DateParser.date(from: value)!
 
 				case "tags":
 				guard let value = value as? [String] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Article.self, field: fieldName, value: fieldValue)
 				}
 				return value.map { return $0 }
 
 				case "title":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Article.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "url":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Article.self, field: fieldName, value: fieldValue)
 				}
 				return URL(string: value)!
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: Article.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/ArticleAuthor.swift
+++ b/Buy/Generated/Storefront/ArticleAuthor.swift
@@ -75,36 +75,36 @@ extension Storefront {
 				case "bio":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ArticleAuthor.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "email":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ArticleAuthor.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "firstName":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ArticleAuthor.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "lastName":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ArticleAuthor.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "name":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ArticleAuthor.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: ArticleAuthor.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/ArticleConnection.swift
+++ b/Buy/Generated/Storefront/ArticleConnection.swift
@@ -59,18 +59,18 @@ extension Storefront {
 			switch fieldName {
 				case "edges":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ArticleConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try ArticleEdge(fields: $0) }
 
 				case "pageInfo":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ArticleConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try PageInfo(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: ArticleConnection.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/ArticleEdge.swift
+++ b/Buy/Generated/Storefront/ArticleEdge.swift
@@ -56,18 +56,18 @@ extension Storefront {
 			switch fieldName {
 				case "cursor":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ArticleEdge.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "node":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ArticleEdge.self, field: fieldName, value: fieldValue)
 				}
 				return try Article(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: ArticleEdge.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/Attribute.swift
+++ b/Buy/Generated/Storefront/Attribute.swift
@@ -55,19 +55,19 @@ extension Storefront {
 			switch fieldName {
 				case "key":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Attribute.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "value":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Attribute.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: Attribute.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/AttributeInput.swift
+++ b/Buy/Generated/Storefront/AttributeInput.swift
@@ -39,6 +39,16 @@ extension Storefront {
 		///     - key: No description
 		///     - value: No description
 		///
+		public static func create(key: String, value: String) -> AttributeInput {
+			return AttributeInput(key: key, value: value)
+		}
+
+		/// Creates the input object.
+		///
+		/// - parameters:
+		///     - key: No description
+		///     - value: No description
+		///
 		public init(key: String, value: String) {
 			self.key = key
 			self.value = value

--- a/Buy/Generated/Storefront/AvailableShippingRates.swift
+++ b/Buy/Generated/Storefront/AvailableShippingRates.swift
@@ -60,19 +60,19 @@ extension Storefront {
 			switch fieldName {
 				case "ready":
 				guard let value = value as? Bool else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: AvailableShippingRates.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "shippingRates":
 				if value is NSNull { return nil }
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: AvailableShippingRates.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try ShippingRate(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: AvailableShippingRates.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/Blog.swift
+++ b/Buy/Generated/Storefront/Blog.swift
@@ -90,30 +90,30 @@ extension Storefront {
 			switch fieldName {
 				case "articles":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Blog.self, field: fieldName, value: fieldValue)
 				}
 				return try ArticleConnection(fields: value)
 
 				case "id":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Blog.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.ID(rawValue: value)
 
 				case "title":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Blog.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "url":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Blog.self, field: fieldName, value: fieldValue)
 				}
 				return URL(string: value)!
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: Blog.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/BlogConnection.swift
+++ b/Buy/Generated/Storefront/BlogConnection.swift
@@ -59,18 +59,18 @@ extension Storefront {
 			switch fieldName {
 				case "edges":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: BlogConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try BlogEdge(fields: $0) }
 
 				case "pageInfo":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: BlogConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try PageInfo(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: BlogConnection.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/BlogEdge.swift
+++ b/Buy/Generated/Storefront/BlogEdge.swift
@@ -56,18 +56,18 @@ extension Storefront {
 			switch fieldName {
 				case "cursor":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: BlogEdge.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "node":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: BlogEdge.self, field: fieldName, value: fieldValue)
 				}
 				return try Blog(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: BlogEdge.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/Checkout.swift
+++ b/Buy/Generated/Storefront/Checkout.swift
@@ -268,165 +268,165 @@ extension Storefront {
 			switch fieldName {
 				case "appliedGiftCards":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try AppliedGiftCard(fields: $0) }
 
 				case "availableShippingRates":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return try AvailableShippingRates(fields: value)
 
 				case "completedAt":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.iso8601DateParser.date(from: value)!
 
 				case "createdAt":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.iso8601DateParser.date(from: value)!
 
 				case "currencyCode":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return CurrencyCode(rawValue: value) ?? .unknownValue
 
 				case "customAttributes":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try Attribute(fields: $0) }
 
 				case "customer":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return try Customer(fields: value)
 
 				case "email":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "id":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.ID(rawValue: value)
 
 				case "lineItems":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return try CheckoutLineItemConnection(fields: value)
 
 				case "note":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "order":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return try Order(fields: value)
 
 				case "orderStatusUrl":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return URL(string: value)!
 
 				case "paymentDue":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
 
 				case "ready":
 				guard let value = value as? Bool else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "requiresShipping":
 				guard let value = value as? Bool else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "shippingAddress":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return try MailingAddress(fields: value)
 
 				case "shippingLine":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return try ShippingRate(fields: value)
 
 				case "subtotalPrice":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
 
 				case "taxExempt":
 				guard let value = value as? Bool else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "taxesIncluded":
 				guard let value = value as? Bool else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "totalPrice":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
 
 				case "totalTax":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
 
 				case "updatedAt":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.iso8601DateParser.date(from: value)!
 
 				case "webUrl":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return URL(string: value)!
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CheckoutAttributesUpdateInput.swift
+++ b/Buy/Generated/Storefront/CheckoutAttributesUpdateInput.swift
@@ -64,7 +64,7 @@ extension Storefront {
 		///     - customAttributes: A list of extra information that is added to the checkout.
 		///     - allowPartialAddresses: Allows setting partial addresses on a Checkout, skipping the full validation of attributes. The required attributes are city, province, and country. Full validation of the addresses is still done at complete time. 
 		///
-		@available(*, deprecated)
+		@available(*, deprecated, message: "Use the static create() method instead.")
 		public convenience init(note: String? = nil, customAttributes: [AttributeInput]? = nil, allowPartialAddresses: Bool? = nil) {
 			self.init(note: note.orNull, customAttributes: customAttributes.orNull, allowPartialAddresses: allowPartialAddresses.orNull)
 		}

--- a/Buy/Generated/Storefront/CheckoutAttributesUpdateInput.swift
+++ b/Buy/Generated/Storefront/CheckoutAttributesUpdateInput.swift
@@ -30,15 +30,15 @@ extension Storefront {
 	/// Specifies the fields required to update a checkout's attributes. 
 	open class CheckoutAttributesUpdateInput {
 		/// The text of an optional note that a shop owner can attach to the checkout. 
-		open var note: String?
+		open var note: Input<String>
 
 		/// A list of extra information that is added to the checkout. 
-		open var customAttributes: [AttributeInput]?
+		open var customAttributes: Input<[AttributeInput]>
 
 		/// Allows setting partial addresses on a Checkout, skipping the full 
 		/// validation of attributes. The required attributes are city, province, and 
 		/// country. Full validation of the addresses is still done at complete time. 
-		open var allowPartialAddresses: Bool?
+		open var allowPartialAddresses: Input<Bool>
 
 		/// Creates the input object.
 		///
@@ -47,25 +47,59 @@ extension Storefront {
 		///     - customAttributes: A list of extra information that is added to the checkout.
 		///     - allowPartialAddresses: Allows setting partial addresses on a Checkout, skipping the full validation of attributes. The required attributes are city, province, and country. Full validation of the addresses is still done at complete time. 
 		///
-		public init(note: String? = nil, customAttributes: [AttributeInput]? = nil, allowPartialAddresses: Bool? = nil) {
+		public static func create(note: Input<String> = .undefined, customAttributes: Input<[AttributeInput]> = .undefined, allowPartialAddresses: Input<Bool> = .undefined) -> CheckoutAttributesUpdateInput {
+			return CheckoutAttributesUpdateInput(note: note, customAttributes: customAttributes, allowPartialAddresses: allowPartialAddresses)
+		}
+
+		private init(note: Input<String> = .undefined, customAttributes: Input<[AttributeInput]> = .undefined, allowPartialAddresses: Input<Bool> = .undefined) {
 			self.note = note
 			self.customAttributes = customAttributes
 			self.allowPartialAddresses = allowPartialAddresses
 		}
 
+		/// Creates the input object.
+		///
+		/// - parameters:
+		///     - note: The text of an optional note that a shop owner can attach to the checkout.
+		///     - customAttributes: A list of extra information that is added to the checkout.
+		///     - allowPartialAddresses: Allows setting partial addresses on a Checkout, skipping the full validation of attributes. The required attributes are city, province, and country. Full validation of the addresses is still done at complete time. 
+		///
+		@available(*, deprecated)
+		public convenience init(note: String? = nil, customAttributes: [AttributeInput]? = nil, allowPartialAddresses: Bool? = nil) {
+			self.init(note: note.orNull, customAttributes: customAttributes.orNull, allowPartialAddresses: allowPartialAddresses.orNull)
+		}
+
 		internal func serialize() -> String {
 			var fields: [String] = []
 
-			if let note = note {
+			switch note {
+				case .value(let note): 
+				guard let note = note else {
+					fields.append("note:null")
+					break
+				}
 				fields.append("note:\(GraphQL.quoteString(input: note))")
+				case .undefined: break
 			}
 
-			if let customAttributes = customAttributes {
+			switch customAttributes {
+				case .value(let customAttributes): 
+				guard let customAttributes = customAttributes else {
+					fields.append("customAttributes:null")
+					break
+				}
 				fields.append("customAttributes:[\(customAttributes.map{ "\($0.serialize())" }.joined(separator: ","))]")
+				case .undefined: break
 			}
 
-			if let allowPartialAddresses = allowPartialAddresses {
+			switch allowPartialAddresses {
+				case .value(let allowPartialAddresses): 
+				guard let allowPartialAddresses = allowPartialAddresses else {
+					fields.append("allowPartialAddresses:null")
+					break
+				}
 				fields.append("allowPartialAddresses:\(allowPartialAddresses)")
+				case .undefined: break
 			}
 
 			return "{\(fields.joined(separator: ","))}"

--- a/Buy/Generated/Storefront/CheckoutAttributesUpdatePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutAttributesUpdatePayload.swift
@@ -59,18 +59,18 @@ extension Storefront {
 			switch fieldName {
 				case "checkout":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutAttributesUpdatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try Checkout(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutAttributesUpdatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CheckoutAttributesUpdatePayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CheckoutCompleteFreePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutCompleteFreePayload.swift
@@ -60,18 +60,18 @@ extension Storefront {
 				case "checkout":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutCompleteFreePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try Checkout(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutCompleteFreePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CheckoutCompleteFreePayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CheckoutCompleteWithCreditCardPayload.swift
+++ b/Buy/Generated/Storefront/CheckoutCompleteWithCreditCardPayload.swift
@@ -69,25 +69,25 @@ extension Storefront {
 			switch fieldName {
 				case "checkout":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutCompleteWithCreditCardPayload.self, field: fieldName, value: fieldValue)
 				}
 				return try Checkout(fields: value)
 
 				case "payment":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutCompleteWithCreditCardPayload.self, field: fieldName, value: fieldValue)
 				}
 				return try Payment(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutCompleteWithCreditCardPayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CheckoutCompleteWithCreditCardPayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CheckoutCompleteWithTokenizedPaymentPayload.swift
+++ b/Buy/Generated/Storefront/CheckoutCompleteWithTokenizedPaymentPayload.swift
@@ -69,25 +69,25 @@ extension Storefront {
 			switch fieldName {
 				case "checkout":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutCompleteWithTokenizedPaymentPayload.self, field: fieldName, value: fieldValue)
 				}
 				return try Checkout(fields: value)
 
 				case "payment":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutCompleteWithTokenizedPaymentPayload.self, field: fieldName, value: fieldValue)
 				}
 				return try Payment(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutCompleteWithTokenizedPaymentPayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CheckoutCompleteWithTokenizedPaymentPayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CheckoutCreateInput.swift
+++ b/Buy/Generated/Storefront/CheckoutCreateInput.swift
@@ -83,7 +83,7 @@ extension Storefront {
 		///     - customAttributes: A list of extra information that is added to the checkout.
 		///     - allowPartialAddresses: Allows setting partial addresses on a Checkout, skipping the full validation of attributes. The required attributes are city, province, and country. Full validation of addresses is still done at complete time. 
 		///
-		@available(*, deprecated)
+		@available(*, deprecated, message: "Use the static create() method instead.")
 		public convenience init(email: String? = nil, lineItems: [CheckoutLineItemInput]? = nil, shippingAddress: MailingAddressInput? = nil, note: String? = nil, customAttributes: [AttributeInput]? = nil, allowPartialAddresses: Bool? = nil) {
 			self.init(email: email.orNull, lineItems: lineItems.orNull, shippingAddress: shippingAddress.orNull, note: note.orNull, customAttributes: customAttributes.orNull, allowPartialAddresses: allowPartialAddresses.orNull)
 		}

--- a/Buy/Generated/Storefront/CheckoutCreateInput.swift
+++ b/Buy/Generated/Storefront/CheckoutCreateInput.swift
@@ -30,25 +30,25 @@ extension Storefront {
 	/// Specifies the fields required to create a checkout. 
 	open class CheckoutCreateInput {
 		/// The email with which the customer wants to checkout. 
-		open var email: String?
+		open var email: Input<String>
 
 		/// A list of line item objects, each one containing information about an item 
 		/// in the checkout. 
-		open var lineItems: [CheckoutLineItemInput]?
+		open var lineItems: Input<[CheckoutLineItemInput]>
 
 		/// The shipping address to where the line items will be shipped. 
-		open var shippingAddress: MailingAddressInput?
+		open var shippingAddress: Input<MailingAddressInput>
 
 		/// The text of an optional note that a shop owner can attach to the checkout. 
-		open var note: String?
+		open var note: Input<String>
 
 		/// A list of extra information that is added to the checkout. 
-		open var customAttributes: [AttributeInput]?
+		open var customAttributes: Input<[AttributeInput]>
 
 		/// Allows setting partial addresses on a Checkout, skipping the full 
 		/// validation of attributes. The required attributes are city, province, and 
 		/// country. Full validation of addresses is still done at complete time. 
-		open var allowPartialAddresses: Bool?
+		open var allowPartialAddresses: Input<Bool>
 
 		/// Creates the input object.
 		///
@@ -60,7 +60,11 @@ extension Storefront {
 		///     - customAttributes: A list of extra information that is added to the checkout.
 		///     - allowPartialAddresses: Allows setting partial addresses on a Checkout, skipping the full validation of attributes. The required attributes are city, province, and country. Full validation of addresses is still done at complete time. 
 		///
-		public init(email: String? = nil, lineItems: [CheckoutLineItemInput]? = nil, shippingAddress: MailingAddressInput? = nil, note: String? = nil, customAttributes: [AttributeInput]? = nil, allowPartialAddresses: Bool? = nil) {
+		public static func create(email: Input<String> = .undefined, lineItems: Input<[CheckoutLineItemInput]> = .undefined, shippingAddress: Input<MailingAddressInput> = .undefined, note: Input<String> = .undefined, customAttributes: Input<[AttributeInput]> = .undefined, allowPartialAddresses: Input<Bool> = .undefined) -> CheckoutCreateInput {
+			return CheckoutCreateInput(email: email, lineItems: lineItems, shippingAddress: shippingAddress, note: note, customAttributes: customAttributes, allowPartialAddresses: allowPartialAddresses)
+		}
+
+		private init(email: Input<String> = .undefined, lineItems: Input<[CheckoutLineItemInput]> = .undefined, shippingAddress: Input<MailingAddressInput> = .undefined, note: Input<String> = .undefined, customAttributes: Input<[AttributeInput]> = .undefined, allowPartialAddresses: Input<Bool> = .undefined) {
 			self.email = email
 			self.lineItems = lineItems
 			self.shippingAddress = shippingAddress
@@ -69,31 +73,82 @@ extension Storefront {
 			self.allowPartialAddresses = allowPartialAddresses
 		}
 
+		/// Creates the input object.
+		///
+		/// - parameters:
+		///     - email: The email with which the customer wants to checkout.
+		///     - lineItems: A list of line item objects, each one containing information about an item in the checkout.
+		///     - shippingAddress: The shipping address to where the line items will be shipped.
+		///     - note: The text of an optional note that a shop owner can attach to the checkout.
+		///     - customAttributes: A list of extra information that is added to the checkout.
+		///     - allowPartialAddresses: Allows setting partial addresses on a Checkout, skipping the full validation of attributes. The required attributes are city, province, and country. Full validation of addresses is still done at complete time. 
+		///
+		@available(*, deprecated)
+		public convenience init(email: String? = nil, lineItems: [CheckoutLineItemInput]? = nil, shippingAddress: MailingAddressInput? = nil, note: String? = nil, customAttributes: [AttributeInput]? = nil, allowPartialAddresses: Bool? = nil) {
+			self.init(email: email.orNull, lineItems: lineItems.orNull, shippingAddress: shippingAddress.orNull, note: note.orNull, customAttributes: customAttributes.orNull, allowPartialAddresses: allowPartialAddresses.orNull)
+		}
+
 		internal func serialize() -> String {
 			var fields: [String] = []
 
-			if let email = email {
+			switch email {
+				case .value(let email): 
+				guard let email = email else {
+					fields.append("email:null")
+					break
+				}
 				fields.append("email:\(GraphQL.quoteString(input: email))")
+				case .undefined: break
 			}
 
-			if let lineItems = lineItems {
+			switch lineItems {
+				case .value(let lineItems): 
+				guard let lineItems = lineItems else {
+					fields.append("lineItems:null")
+					break
+				}
 				fields.append("lineItems:[\(lineItems.map{ "\($0.serialize())" }.joined(separator: ","))]")
+				case .undefined: break
 			}
 
-			if let shippingAddress = shippingAddress {
+			switch shippingAddress {
+				case .value(let shippingAddress): 
+				guard let shippingAddress = shippingAddress else {
+					fields.append("shippingAddress:null")
+					break
+				}
 				fields.append("shippingAddress:\(shippingAddress.serialize())")
+				case .undefined: break
 			}
 
-			if let note = note {
+			switch note {
+				case .value(let note): 
+				guard let note = note else {
+					fields.append("note:null")
+					break
+				}
 				fields.append("note:\(GraphQL.quoteString(input: note))")
+				case .undefined: break
 			}
 
-			if let customAttributes = customAttributes {
+			switch customAttributes {
+				case .value(let customAttributes): 
+				guard let customAttributes = customAttributes else {
+					fields.append("customAttributes:null")
+					break
+				}
 				fields.append("customAttributes:[\(customAttributes.map{ "\($0.serialize())" }.joined(separator: ","))]")
+				case .undefined: break
 			}
 
-			if let allowPartialAddresses = allowPartialAddresses {
+			switch allowPartialAddresses {
+				case .value(let allowPartialAddresses): 
+				guard let allowPartialAddresses = allowPartialAddresses else {
+					fields.append("allowPartialAddresses:null")
+					break
+				}
 				fields.append("allowPartialAddresses:\(allowPartialAddresses)")
+				case .undefined: break
 			}
 
 			return "{\(fields.joined(separator: ","))}"

--- a/Buy/Generated/Storefront/CheckoutCreatePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutCreatePayload.swift
@@ -60,18 +60,18 @@ extension Storefront {
 				case "checkout":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutCreatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try Checkout(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutCreatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CheckoutCreatePayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CheckoutCustomerAssociatePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutCustomerAssociatePayload.swift
@@ -59,18 +59,18 @@ extension Storefront {
 			switch fieldName {
 				case "checkout":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutCustomerAssociatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try Checkout(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutCustomerAssociatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CheckoutCustomerAssociatePayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CheckoutCustomerDisassociatePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutCustomerDisassociatePayload.swift
@@ -59,18 +59,18 @@ extension Storefront {
 			switch fieldName {
 				case "checkout":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutCustomerDisassociatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try Checkout(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutCustomerDisassociatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CheckoutCustomerDisassociatePayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CheckoutEmailUpdatePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutEmailUpdatePayload.swift
@@ -59,18 +59,18 @@ extension Storefront {
 			switch fieldName {
 				case "checkout":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutEmailUpdatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try Checkout(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutEmailUpdatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CheckoutEmailUpdatePayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CheckoutGiftCardApplyPayload.swift
+++ b/Buy/Generated/Storefront/CheckoutGiftCardApplyPayload.swift
@@ -59,18 +59,18 @@ extension Storefront {
 			switch fieldName {
 				case "checkout":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutGiftCardApplyPayload.self, field: fieldName, value: fieldValue)
 				}
 				return try Checkout(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutGiftCardApplyPayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CheckoutGiftCardApplyPayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CheckoutGiftCardRemovePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutGiftCardRemovePayload.swift
@@ -59,18 +59,18 @@ extension Storefront {
 			switch fieldName {
 				case "checkout":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutGiftCardRemovePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try Checkout(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutGiftCardRemovePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CheckoutGiftCardRemovePayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CheckoutLineItem.swift
+++ b/Buy/Generated/Storefront/CheckoutLineItem.swift
@@ -83,37 +83,37 @@ extension Storefront {
 			switch fieldName {
 				case "customAttributes":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutLineItem.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try Attribute(fields: $0) }
 
 				case "id":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutLineItem.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.ID(rawValue: value)
 
 				case "quantity":
 				guard let value = value as? Int else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutLineItem.self, field: fieldName, value: fieldValue)
 				}
 				return Int32(value)
 
 				case "title":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutLineItem.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "variant":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutLineItem.self, field: fieldName, value: fieldValue)
 				}
 				return try ProductVariant(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CheckoutLineItem.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CheckoutLineItemConnection.swift
+++ b/Buy/Generated/Storefront/CheckoutLineItemConnection.swift
@@ -59,18 +59,18 @@ extension Storefront {
 			switch fieldName {
 				case "edges":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutLineItemConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try CheckoutLineItemEdge(fields: $0) }
 
 				case "pageInfo":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutLineItemConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try PageInfo(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CheckoutLineItemConnection.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CheckoutLineItemEdge.swift
+++ b/Buy/Generated/Storefront/CheckoutLineItemEdge.swift
@@ -56,18 +56,18 @@ extension Storefront {
 			switch fieldName {
 				case "cursor":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutLineItemEdge.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "node":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutLineItemEdge.self, field: fieldName, value: fieldValue)
 				}
 				return try CheckoutLineItem(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CheckoutLineItemEdge.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CheckoutLineItemInput.swift
+++ b/Buy/Generated/Storefront/CheckoutLineItemInput.swift
@@ -63,8 +63,8 @@ extension Storefront {
 		///     - quantity: The quantity of the line item.
 		///     - variantId: The identifier of the product variant for the line item.
 		///
-		@available(*, deprecated)
-		public convenience init(variantId: GraphQL.ID, quantity: Int32, customAttributes: [AttributeInput]? = nil) {
+		@available(*, deprecated, message: "Use the static create() method instead.")
+		public convenience init(quantity: Int32, variantId: GraphQL.ID, customAttributes: [AttributeInput]? = nil) {
 			self.init(quantity: quantity, variantId: variantId, customAttributes: customAttributes.orNull)
 		}
 

--- a/Buy/Generated/Storefront/CheckoutLineItemUpdateInput.swift
+++ b/Buy/Generated/Storefront/CheckoutLineItemUpdateInput.swift
@@ -68,7 +68,7 @@ extension Storefront {
 		///     - quantity: The quantity of the line item.
 		///     - customAttributes: Extra information in the form of an array of Key-Value pairs about the line item.
 		///
-		@available(*, deprecated)
+		@available(*, deprecated, message: "Use the static create() method instead.")
 		public convenience init(id: GraphQL.ID? = nil, variantId: GraphQL.ID? = nil, quantity: Int32? = nil, customAttributes: [AttributeInput]? = nil) {
 			self.init(id: id.orNull, variantId: variantId.orNull, quantity: quantity.orNull, customAttributes: customAttributes.orNull)
 		}

--- a/Buy/Generated/Storefront/CheckoutLineItemUpdateInput.swift
+++ b/Buy/Generated/Storefront/CheckoutLineItemUpdateInput.swift
@@ -29,17 +29,17 @@ import Foundation
 extension Storefront {
 	/// Specifies the input fields to update a line item on the checkout. 
 	open class CheckoutLineItemUpdateInput {
-		open var id: GraphQL.ID?
+		open var id: Input<GraphQL.ID>
 
 		/// The variant identifier of the line item. 
-		open var variantId: GraphQL.ID?
+		open var variantId: Input<GraphQL.ID>
 
 		/// The quantity of the line item. 
-		open var quantity: Int32?
+		open var quantity: Input<Int32>
 
 		/// Extra information in the form of an array of Key-Value pairs about the line 
 		/// item. 
-		open var customAttributes: [AttributeInput]?
+		open var customAttributes: Input<[AttributeInput]>
 
 		/// Creates the input object.
 		///
@@ -49,30 +49,71 @@ extension Storefront {
 		///     - quantity: The quantity of the line item.
 		///     - customAttributes: Extra information in the form of an array of Key-Value pairs about the line item.
 		///
-		public init(id: GraphQL.ID? = nil, variantId: GraphQL.ID? = nil, quantity: Int32? = nil, customAttributes: [AttributeInput]? = nil) {
+		public static func create(id: Input<GraphQL.ID> = .undefined, variantId: Input<GraphQL.ID> = .undefined, quantity: Input<Int32> = .undefined, customAttributes: Input<[AttributeInput]> = .undefined) -> CheckoutLineItemUpdateInput {
+			return CheckoutLineItemUpdateInput(id: id, variantId: variantId, quantity: quantity, customAttributes: customAttributes)
+		}
+
+		private init(id: Input<GraphQL.ID> = .undefined, variantId: Input<GraphQL.ID> = .undefined, quantity: Input<Int32> = .undefined, customAttributes: Input<[AttributeInput]> = .undefined) {
 			self.id = id
 			self.variantId = variantId
 			self.quantity = quantity
 			self.customAttributes = customAttributes
 		}
 
+		/// Creates the input object.
+		///
+		/// - parameters:
+		///     - id: No description
+		///     - variantId: The variant identifier of the line item.
+		///     - quantity: The quantity of the line item.
+		///     - customAttributes: Extra information in the form of an array of Key-Value pairs about the line item.
+		///
+		@available(*, deprecated)
+		public convenience init(id: GraphQL.ID? = nil, variantId: GraphQL.ID? = nil, quantity: Int32? = nil, customAttributes: [AttributeInput]? = nil) {
+			self.init(id: id.orNull, variantId: variantId.orNull, quantity: quantity.orNull, customAttributes: customAttributes.orNull)
+		}
+
 		internal func serialize() -> String {
 			var fields: [String] = []
 
-			if let id = id {
+			switch id {
+				case .value(let id): 
+				guard let id = id else {
+					fields.append("id:null")
+					break
+				}
 				fields.append("id:\(GraphQL.quoteString(input: "\(id.rawValue)"))")
+				case .undefined: break
 			}
 
-			if let variantId = variantId {
+			switch variantId {
+				case .value(let variantId): 
+				guard let variantId = variantId else {
+					fields.append("variantId:null")
+					break
+				}
 				fields.append("variantId:\(GraphQL.quoteString(input: "\(variantId.rawValue)"))")
+				case .undefined: break
 			}
 
-			if let quantity = quantity {
+			switch quantity {
+				case .value(let quantity): 
+				guard let quantity = quantity else {
+					fields.append("quantity:null")
+					break
+				}
 				fields.append("quantity:\(quantity)")
+				case .undefined: break
 			}
 
-			if let customAttributes = customAttributes {
+			switch customAttributes {
+				case .value(let customAttributes): 
+				guard let customAttributes = customAttributes else {
+					fields.append("customAttributes:null")
+					break
+				}
 				fields.append("customAttributes:[\(customAttributes.map{ "\($0.serialize())" }.joined(separator: ","))]")
+				case .undefined: break
 			}
 
 			return "{\(fields.joined(separator: ","))}"

--- a/Buy/Generated/Storefront/CheckoutLineItemsAddPayload.swift
+++ b/Buy/Generated/Storefront/CheckoutLineItemsAddPayload.swift
@@ -60,18 +60,18 @@ extension Storefront {
 				case "checkout":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutLineItemsAddPayload.self, field: fieldName, value: fieldValue)
 				}
 				return try Checkout(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutLineItemsAddPayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CheckoutLineItemsAddPayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CheckoutLineItemsRemovePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutLineItemsRemovePayload.swift
@@ -59,18 +59,18 @@ extension Storefront {
 				case "checkout":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutLineItemsRemovePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try Checkout(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutLineItemsRemovePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CheckoutLineItemsRemovePayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CheckoutLineItemsUpdatePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutLineItemsUpdatePayload.swift
@@ -60,18 +60,18 @@ extension Storefront {
 				case "checkout":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutLineItemsUpdatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try Checkout(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutLineItemsUpdatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CheckoutLineItemsUpdatePayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CheckoutShippingAddressUpdatePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutShippingAddressUpdatePayload.swift
@@ -59,18 +59,18 @@ extension Storefront {
 			switch fieldName {
 				case "checkout":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutShippingAddressUpdatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try Checkout(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutShippingAddressUpdatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CheckoutShippingAddressUpdatePayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CheckoutShippingLineUpdatePayload.swift
+++ b/Buy/Generated/Storefront/CheckoutShippingLineUpdatePayload.swift
@@ -60,18 +60,18 @@ extension Storefront {
 				case "checkout":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutShippingLineUpdatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try Checkout(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CheckoutShippingLineUpdatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CheckoutShippingLineUpdatePayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/Collection.swift
+++ b/Buy/Generated/Storefront/Collection.swift
@@ -115,8 +115,8 @@ extension Storefront {
 		/// - parameters:
 		///     - first: No description
 		///     - after: No description
-		///     - sortKey: No description
 		///     - reverse: No description
+		///     - sortKey: No description
 		///
 		@discardableResult
 		open func products(alias: String? = nil, first: Int32, after: String? = nil, sortKey: ProductCollectionSortKeys? = nil, reverse: Bool? = nil, _ subfields: (ProductConnectionQuery) -> Void) -> CollectionQuery {
@@ -128,12 +128,12 @@ extension Storefront {
 				args.append("after:\(GraphQL.quoteString(input: after))")
 			}
 
-			if let sortKey = sortKey {
-				args.append("sortKey:\(sortKey.rawValue)")
-			}
-
 			if let reverse = reverse {
 				args.append("reverse:\(reverse)")
+			}
+
+			if let sortKey = sortKey {
+				args.append("sortKey:\(sortKey.rawValue)")
 			}
 
 			let argsString: String? = args.isEmpty ? nil : "(\(args.joined(separator: ",")))"
@@ -170,55 +170,55 @@ extension Storefront {
 			switch fieldName {
 				case "description":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Collection.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "descriptionHtml":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Collection.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "handle":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Collection.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "id":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Collection.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.ID(rawValue: value)
 
 				case "image":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Collection.self, field: fieldName, value: fieldValue)
 				}
 				return try Image(fields: value)
 
 				case "products":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Collection.self, field: fieldName, value: fieldValue)
 				}
 				return try ProductConnection(fields: value)
 
 				case "title":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Collection.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "updatedAt":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Collection.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.iso8601DateParser.date(from: value)!
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: Collection.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CollectionConnection.swift
+++ b/Buy/Generated/Storefront/CollectionConnection.swift
@@ -59,18 +59,18 @@ extension Storefront {
 			switch fieldName {
 				case "edges":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CollectionConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try CollectionEdge(fields: $0) }
 
 				case "pageInfo":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CollectionConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try PageInfo(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CollectionConnection.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CollectionEdge.swift
+++ b/Buy/Generated/Storefront/CollectionEdge.swift
@@ -56,18 +56,18 @@ extension Storefront {
 			switch fieldName {
 				case "cursor":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CollectionEdge.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "node":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CollectionEdge.self, field: fieldName, value: fieldValue)
 				}
 				return try Collection(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CollectionEdge.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/Comment.swift
+++ b/Buy/Generated/Storefront/Comment.swift
@@ -82,30 +82,30 @@ extension Storefront {
 			switch fieldName {
 				case "author":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Comment.self, field: fieldName, value: fieldValue)
 				}
 				return try CommentAuthor(fields: value)
 
 				case "content":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Comment.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "contentHtml":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Comment.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "id":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Comment.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.ID(rawValue: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: Comment.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CommentAuthor.swift
+++ b/Buy/Generated/Storefront/CommentAuthor.swift
@@ -53,18 +53,18 @@ extension Storefront {
 			switch fieldName {
 				case "email":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CommentAuthor.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "name":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CommentAuthor.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CommentAuthor.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CommentConnection.swift
+++ b/Buy/Generated/Storefront/CommentConnection.swift
@@ -59,18 +59,18 @@ extension Storefront {
 			switch fieldName {
 				case "edges":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CommentConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try CommentEdge(fields: $0) }
 
 				case "pageInfo":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CommentConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try PageInfo(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CommentConnection.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CommentEdge.swift
+++ b/Buy/Generated/Storefront/CommentEdge.swift
@@ -56,18 +56,18 @@ extension Storefront {
 			switch fieldName {
 				case "cursor":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CommentEdge.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "node":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CommentEdge.self, field: fieldName, value: fieldValue)
 				}
 				return try Comment(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CommentEdge.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CreditCard.swift
+++ b/Buy/Generated/Storefront/CreditCard.swift
@@ -91,61 +91,61 @@ extension Storefront {
 				case "brand":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CreditCard.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "expiryMonth":
 				if value is NSNull { return nil }
 				guard let value = value as? Int else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CreditCard.self, field: fieldName, value: fieldValue)
 				}
 				return Int32(value)
 
 				case "expiryYear":
 				if value is NSNull { return nil }
 				guard let value = value as? Int else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CreditCard.self, field: fieldName, value: fieldValue)
 				}
 				return Int32(value)
 
 				case "firstDigits":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CreditCard.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "firstName":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CreditCard.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "lastDigits":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CreditCard.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "lastName":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CreditCard.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "maskedNumber":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CreditCard.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CreditCard.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CreditCardPaymentInput.swift
+++ b/Buy/Generated/Storefront/CreditCardPaymentInput.swift
@@ -77,7 +77,7 @@ extension Storefront {
 		///     - vaultId: The ID returned by Shopify's Card Vault.
 		///     - test: Executes the payment in test mode if possible. Defaults to `false`.
 		///
-		@available(*, deprecated)
+		@available(*, deprecated, message: "Use the static create() method instead.")
 		public convenience init(amount: Decimal, idempotencyKey: String, billingAddress: MailingAddressInput, vaultId: String, test: Bool? = nil) {
 			self.init(amount: amount, idempotencyKey: idempotencyKey, billingAddress: billingAddress, vaultId: vaultId, test: test.orNull)
 		}

--- a/Buy/Generated/Storefront/Customer.swift
+++ b/Buy/Generated/Storefront/Customer.swift
@@ -128,8 +128,8 @@ extension Storefront {
 		/// - parameters:
 		///     - first: No description
 		///     - after: No description
-		///     - sortKey: No description
 		///     - reverse: No description
+		///     - sortKey: No description
 		///     - query: Supported filter parameters:
 		///         - `processed_at`
 		///
@@ -143,12 +143,12 @@ extension Storefront {
 				args.append("after:\(GraphQL.quoteString(input: after))")
 			}
 
-			if let sortKey = sortKey {
-				args.append("sortKey:\(sortKey.rawValue)")
-			}
-
 			if let reverse = reverse {
 				args.append("reverse:\(reverse)")
+			}
+
+			if let sortKey = sortKey {
+				args.append("sortKey:\(sortKey.rawValue)")
 			}
 
 			if let query = query {
@@ -190,83 +190,83 @@ extension Storefront {
 			switch fieldName {
 				case "acceptsMarketing":
 				guard let value = value as? Bool else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Customer.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "addresses":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Customer.self, field: fieldName, value: fieldValue)
 				}
 				return try MailingAddressConnection(fields: value)
 
 				case "createdAt":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Customer.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.iso8601DateParser.date(from: value)!
 
 				case "defaultAddress":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Customer.self, field: fieldName, value: fieldValue)
 				}
 				return try MailingAddress(fields: value)
 
 				case "displayName":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Customer.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "email":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Customer.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "firstName":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Customer.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "id":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Customer.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.ID(rawValue: value)
 
 				case "lastName":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Customer.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "orders":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Customer.self, field: fieldName, value: fieldValue)
 				}
 				return try OrderConnection(fields: value)
 
 				case "phone":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Customer.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "updatedAt":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Customer.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.iso8601DateParser.date(from: value)!
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: Customer.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CustomerAccessToken.swift
+++ b/Buy/Generated/Storefront/CustomerAccessToken.swift
@@ -57,18 +57,18 @@ extension Storefront {
 			switch fieldName {
 				case "accessToken":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerAccessToken.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "expiresAt":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerAccessToken.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.iso8601DateParser.date(from: value)!
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CustomerAccessToken.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CustomerAccessTokenCreateInput.swift
+++ b/Buy/Generated/Storefront/CustomerAccessTokenCreateInput.swift
@@ -41,6 +41,16 @@ extension Storefront {
 		///     - email: The email associated to the customer.
 		///     - password: The login password to be used by the customer.
 		///
+		public static func create(email: String, password: String) -> CustomerAccessTokenCreateInput {
+			return CustomerAccessTokenCreateInput(email: email, password: password)
+		}
+
+		/// Creates the input object.
+		///
+		/// - parameters:
+		///     - email: The email associated to the customer.
+		///     - password: The login password to be used by the customer.
+		///
 		public init(email: String, password: String) {
 			self.email = email
 			self.password = password

--- a/Buy/Generated/Storefront/CustomerAccessTokenCreatePayload.swift
+++ b/Buy/Generated/Storefront/CustomerAccessTokenCreatePayload.swift
@@ -60,18 +60,18 @@ extension Storefront {
 				case "customerAccessToken":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerAccessTokenCreatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try CustomerAccessToken(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerAccessTokenCreatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CustomerAccessTokenCreatePayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CustomerAccessTokenDeletePayload.swift
+++ b/Buy/Generated/Storefront/CustomerAccessTokenDeletePayload.swift
@@ -64,25 +64,25 @@ extension Storefront {
 				case "deletedAccessToken":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerAccessTokenDeletePayload.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "deletedCustomerAccessTokenId":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerAccessTokenDeletePayload.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerAccessTokenDeletePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CustomerAccessTokenDeletePayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CustomerAccessTokenRenewPayload.swift
+++ b/Buy/Generated/Storefront/CustomerAccessTokenRenewPayload.swift
@@ -60,18 +60,18 @@ extension Storefront {
 				case "customerAccessToken":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerAccessTokenRenewPayload.self, field: fieldName, value: fieldValue)
 				}
 				return try CustomerAccessToken(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerAccessTokenRenewPayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CustomerAccessTokenRenewPayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CustomerActivateInput.swift
+++ b/Buy/Generated/Storefront/CustomerActivateInput.swift
@@ -41,6 +41,16 @@ extension Storefront {
 		///     - activationToken: The activation token required to activate the customer
 		///     - password: The login password used by the customer.
 		///
+		public static func create(activationToken: String, password: String) -> CustomerActivateInput {
+			return CustomerActivateInput(activationToken: activationToken, password: password)
+		}
+
+		/// Creates the input object.
+		///
+		/// - parameters:
+		///     - activationToken: The activation token required to activate the customer
+		///     - password: The login password used by the customer.
+		///
 		public init(activationToken: String, password: String) {
 			self.activationToken = activationToken
 			self.password = password

--- a/Buy/Generated/Storefront/CustomerActivatePayload.swift
+++ b/Buy/Generated/Storefront/CustomerActivatePayload.swift
@@ -60,18 +60,18 @@ extension Storefront {
 				case "customer":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerActivatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try Customer(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerActivatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CustomerActivatePayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CustomerAddressCreatePayload.swift
+++ b/Buy/Generated/Storefront/CustomerAddressCreatePayload.swift
@@ -60,18 +60,18 @@ extension Storefront {
 				case "customerAddress":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerAddressCreatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try MailingAddress(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerAddressCreatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CustomerAddressCreatePayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CustomerAddressDeletePayload.swift
+++ b/Buy/Generated/Storefront/CustomerAddressDeletePayload.swift
@@ -57,18 +57,18 @@ extension Storefront {
 				case "deletedCustomerAddressId":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerAddressDeletePayload.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerAddressDeletePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CustomerAddressDeletePayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CustomerAddressUpdatePayload.swift
+++ b/Buy/Generated/Storefront/CustomerAddressUpdatePayload.swift
@@ -60,18 +60,18 @@ extension Storefront {
 				case "customerAddress":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerAddressUpdatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try MailingAddress(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerAddressUpdatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CustomerAddressUpdatePayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CustomerCreateInput.swift
+++ b/Buy/Generated/Storefront/CustomerCreateInput.swift
@@ -81,7 +81,7 @@ extension Storefront {
 		///     - password: The login password used by the customer.
 		///     - acceptsMarketing: Indicates whether the customer has consented to be sent marketing material via email.
 		///
-		@available(*, deprecated)
+		@available(*, deprecated, message: "Use the static create() method instead.")
 		public convenience init(email: String, password: String, firstName: String? = nil, lastName: String? = nil, phone: String? = nil, acceptsMarketing: Bool? = nil) {
 			self.init(email: email, password: password, firstName: firstName.orNull, lastName: lastName.orNull, phone: phone.orNull, acceptsMarketing: acceptsMarketing.orNull)
 		}

--- a/Buy/Generated/Storefront/CustomerCreateInput.swift
+++ b/Buy/Generated/Storefront/CustomerCreateInput.swift
@@ -30,23 +30,23 @@ extension Storefront {
 	/// Specifies the fields required to create a new Customer. 
 	open class CustomerCreateInput {
 		/// The customer’s first name. 
-		open var firstName: String?
+		open var firstName: Input<String>
 
 		/// The customer’s last name. 
-		open var lastName: String?
+		open var lastName: Input<String>
 
 		/// The customer’s email. 
 		open var email: String
 
 		/// The customer’s phone number. 
-		open var phone: String?
+		open var phone: Input<String>
 
 		/// The login password used by the customer. 
 		open var password: String
 
 		/// Indicates whether the customer has consented to be sent marketing material 
 		/// via email. 
-		open var acceptsMarketing: Bool?
+		open var acceptsMarketing: Input<Bool>
 
 		/// Creates the input object.
 		///
@@ -58,7 +58,11 @@ extension Storefront {
 		///     - password: The login password used by the customer.
 		///     - acceptsMarketing: Indicates whether the customer has consented to be sent marketing material via email.
 		///
-		public init(email: String, password: String, firstName: String? = nil, lastName: String? = nil, phone: String? = nil, acceptsMarketing: Bool? = nil) {
+		public static func create(email: String, password: String, firstName: Input<String> = .undefined, lastName: Input<String> = .undefined, phone: Input<String> = .undefined, acceptsMarketing: Input<Bool> = .undefined) -> CustomerCreateInput {
+			return CustomerCreateInput(email: email, password: password, firstName: firstName, lastName: lastName, phone: phone, acceptsMarketing: acceptsMarketing)
+		}
+
+		private init(email: String, password: String, firstName: Input<String> = .undefined, lastName: Input<String> = .undefined, phone: Input<String> = .undefined, acceptsMarketing: Input<Bool> = .undefined) {
 			self.firstName = firstName
 			self.lastName = lastName
 			self.email = email
@@ -67,27 +71,66 @@ extension Storefront {
 			self.acceptsMarketing = acceptsMarketing
 		}
 
+		/// Creates the input object.
+		///
+		/// - parameters:
+		///     - firstName: The customer’s first name.
+		///     - lastName: The customer’s last name.
+		///     - email: The customer’s email.
+		///     - phone: The customer’s phone number.
+		///     - password: The login password used by the customer.
+		///     - acceptsMarketing: Indicates whether the customer has consented to be sent marketing material via email.
+		///
+		@available(*, deprecated)
+		public convenience init(email: String, password: String, firstName: String? = nil, lastName: String? = nil, phone: String? = nil, acceptsMarketing: Bool? = nil) {
+			self.init(email: email, password: password, firstName: firstName.orNull, lastName: lastName.orNull, phone: phone.orNull, acceptsMarketing: acceptsMarketing.orNull)
+		}
+
 		internal func serialize() -> String {
 			var fields: [String] = []
 
-			if let firstName = firstName {
+			switch firstName {
+				case .value(let firstName): 
+				guard let firstName = firstName else {
+					fields.append("firstName:null")
+					break
+				}
 				fields.append("firstName:\(GraphQL.quoteString(input: firstName))")
+				case .undefined: break
 			}
 
-			if let lastName = lastName {
+			switch lastName {
+				case .value(let lastName): 
+				guard let lastName = lastName else {
+					fields.append("lastName:null")
+					break
+				}
 				fields.append("lastName:\(GraphQL.quoteString(input: lastName))")
+				case .undefined: break
 			}
 
 			fields.append("email:\(GraphQL.quoteString(input: email))")
 
-			if let phone = phone {
+			switch phone {
+				case .value(let phone): 
+				guard let phone = phone else {
+					fields.append("phone:null")
+					break
+				}
 				fields.append("phone:\(GraphQL.quoteString(input: phone))")
+				case .undefined: break
 			}
 
 			fields.append("password:\(GraphQL.quoteString(input: password))")
 
-			if let acceptsMarketing = acceptsMarketing {
+			switch acceptsMarketing {
+				case .value(let acceptsMarketing): 
+				guard let acceptsMarketing = acceptsMarketing else {
+					fields.append("acceptsMarketing:null")
+					break
+				}
 				fields.append("acceptsMarketing:\(acceptsMarketing)")
+				case .undefined: break
 			}
 
 			return "{\(fields.joined(separator: ","))}"

--- a/Buy/Generated/Storefront/CustomerCreatePayload.swift
+++ b/Buy/Generated/Storefront/CustomerCreatePayload.swift
@@ -60,18 +60,18 @@ extension Storefront {
 				case "customer":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerCreatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try Customer(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerCreatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CustomerCreatePayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CustomerRecoverPayload.swift
+++ b/Buy/Generated/Storefront/CustomerRecoverPayload.swift
@@ -49,12 +49,12 @@ extension Storefront {
 			switch fieldName {
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerRecoverPayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CustomerRecoverPayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CustomerResetInput.swift
+++ b/Buy/Generated/Storefront/CustomerResetInput.swift
@@ -41,6 +41,16 @@ extension Storefront {
 		///     - resetToken: The reset token required to reset the customer’s password.
 		///     - password: New password that will be set as part of the reset password process.
 		///
+		public static func create(resetToken: String, password: String) -> CustomerResetInput {
+			return CustomerResetInput(resetToken: resetToken, password: password)
+		}
+
+		/// Creates the input object.
+		///
+		/// - parameters:
+		///     - resetToken: The reset token required to reset the customer’s password.
+		///     - password: New password that will be set as part of the reset password process.
+		///
 		public init(resetToken: String, password: String) {
 			self.resetToken = resetToken
 			self.password = password

--- a/Buy/Generated/Storefront/CustomerResetPayload.swift
+++ b/Buy/Generated/Storefront/CustomerResetPayload.swift
@@ -60,18 +60,18 @@ extension Storefront {
 				case "customer":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerResetPayload.self, field: fieldName, value: fieldValue)
 				}
 				return try Customer(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerResetPayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CustomerResetPayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/CustomerUpdateInput.swift
+++ b/Buy/Generated/Storefront/CustomerUpdateInput.swift
@@ -81,7 +81,7 @@ extension Storefront {
 		///     - password: The login password used by the customer.
 		///     - acceptsMarketing: Indicates whether the customer has consented to be sent marketing material via email.
 		///
-		@available(*, deprecated)
+		@available(*, deprecated, message: "Use the static create() method instead.")
 		public convenience init(firstName: String? = nil, lastName: String? = nil, email: String? = nil, phone: String? = nil, password: String? = nil, acceptsMarketing: Bool? = nil) {
 			self.init(firstName: firstName.orNull, lastName: lastName.orNull, email: email.orNull, phone: phone.orNull, password: password.orNull, acceptsMarketing: acceptsMarketing.orNull)
 		}

--- a/Buy/Generated/Storefront/CustomerUpdateInput.swift
+++ b/Buy/Generated/Storefront/CustomerUpdateInput.swift
@@ -30,23 +30,23 @@ extension Storefront {
 	/// Specifies the fields required to update the Customer information. 
 	open class CustomerUpdateInput {
 		/// The customer’s first name. 
-		open var firstName: String?
+		open var firstName: Input<String>
 
 		/// The customer’s last name. 
-		open var lastName: String?
+		open var lastName: Input<String>
 
 		/// The customer’s email. 
-		open var email: String?
+		open var email: Input<String>
 
 		/// The customer’s phone number. 
-		open var phone: String?
+		open var phone: Input<String>
 
 		/// The login password used by the customer. 
-		open var password: String?
+		open var password: Input<String>
 
 		/// Indicates whether the customer has consented to be sent marketing material 
 		/// via email. 
-		open var acceptsMarketing: Bool?
+		open var acceptsMarketing: Input<Bool>
 
 		/// Creates the input object.
 		///
@@ -58,7 +58,11 @@ extension Storefront {
 		///     - password: The login password used by the customer.
 		///     - acceptsMarketing: Indicates whether the customer has consented to be sent marketing material via email.
 		///
-		public init(firstName: String? = nil, lastName: String? = nil, email: String? = nil, phone: String? = nil, password: String? = nil, acceptsMarketing: Bool? = nil) {
+		public static func create(firstName: Input<String> = .undefined, lastName: Input<String> = .undefined, email: Input<String> = .undefined, phone: Input<String> = .undefined, password: Input<String> = .undefined, acceptsMarketing: Input<Bool> = .undefined) -> CustomerUpdateInput {
+			return CustomerUpdateInput(firstName: firstName, lastName: lastName, email: email, phone: phone, password: password, acceptsMarketing: acceptsMarketing)
+		}
+
+		private init(firstName: Input<String> = .undefined, lastName: Input<String> = .undefined, email: Input<String> = .undefined, phone: Input<String> = .undefined, password: Input<String> = .undefined, acceptsMarketing: Input<Bool> = .undefined) {
 			self.firstName = firstName
 			self.lastName = lastName
 			self.email = email
@@ -67,31 +71,82 @@ extension Storefront {
 			self.acceptsMarketing = acceptsMarketing
 		}
 
+		/// Creates the input object.
+		///
+		/// - parameters:
+		///     - firstName: The customer’s first name.
+		///     - lastName: The customer’s last name.
+		///     - email: The customer’s email.
+		///     - phone: The customer’s phone number.
+		///     - password: The login password used by the customer.
+		///     - acceptsMarketing: Indicates whether the customer has consented to be sent marketing material via email.
+		///
+		@available(*, deprecated)
+		public convenience init(firstName: String? = nil, lastName: String? = nil, email: String? = nil, phone: String? = nil, password: String? = nil, acceptsMarketing: Bool? = nil) {
+			self.init(firstName: firstName.orNull, lastName: lastName.orNull, email: email.orNull, phone: phone.orNull, password: password.orNull, acceptsMarketing: acceptsMarketing.orNull)
+		}
+
 		internal func serialize() -> String {
 			var fields: [String] = []
 
-			if let firstName = firstName {
+			switch firstName {
+				case .value(let firstName): 
+				guard let firstName = firstName else {
+					fields.append("firstName:null")
+					break
+				}
 				fields.append("firstName:\(GraphQL.quoteString(input: firstName))")
+				case .undefined: break
 			}
 
-			if let lastName = lastName {
+			switch lastName {
+				case .value(let lastName): 
+				guard let lastName = lastName else {
+					fields.append("lastName:null")
+					break
+				}
 				fields.append("lastName:\(GraphQL.quoteString(input: lastName))")
+				case .undefined: break
 			}
 
-			if let email = email {
+			switch email {
+				case .value(let email): 
+				guard let email = email else {
+					fields.append("email:null")
+					break
+				}
 				fields.append("email:\(GraphQL.quoteString(input: email))")
+				case .undefined: break
 			}
 
-			if let phone = phone {
+			switch phone {
+				case .value(let phone): 
+				guard let phone = phone else {
+					fields.append("phone:null")
+					break
+				}
 				fields.append("phone:\(GraphQL.quoteString(input: phone))")
+				case .undefined: break
 			}
 
-			if let password = password {
+			switch password {
+				case .value(let password): 
+				guard let password = password else {
+					fields.append("password:null")
+					break
+				}
 				fields.append("password:\(GraphQL.quoteString(input: password))")
+				case .undefined: break
 			}
 
-			if let acceptsMarketing = acceptsMarketing {
+			switch acceptsMarketing {
+				case .value(let acceptsMarketing): 
+				guard let acceptsMarketing = acceptsMarketing else {
+					fields.append("acceptsMarketing:null")
+					break
+				}
 				fields.append("acceptsMarketing:\(acceptsMarketing)")
+				case .undefined: break
 			}
 
 			return "{\(fields.joined(separator: ","))}"

--- a/Buy/Generated/Storefront/CustomerUpdatePayload.swift
+++ b/Buy/Generated/Storefront/CustomerUpdatePayload.swift
@@ -60,18 +60,18 @@ extension Storefront {
 				case "customer":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerUpdatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try Customer(fields: value)
 
 				case "userErrors":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: CustomerUpdatePayload.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try UserError(fields: $0) }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: CustomerUpdatePayload.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/Domain.swift
+++ b/Buy/Generated/Storefront/Domain.swift
@@ -62,24 +62,24 @@ extension Storefront {
 			switch fieldName {
 				case "host":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Domain.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "sslEnabled":
 				guard let value = value as? Bool else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Domain.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "url":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Domain.self, field: fieldName, value: fieldValue)
 				}
 				return URL(string: value)!
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: Domain.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/Image.swift
+++ b/Buy/Generated/Storefront/Image.swift
@@ -63,25 +63,25 @@ extension Storefront {
 				case "altText":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Image.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "id":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Image.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.ID(rawValue: value)
 
 				case "src":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Image.self, field: fieldName, value: fieldValue)
 				}
 				return URL(string: value)!
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: Image.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/ImageConnection.swift
+++ b/Buy/Generated/Storefront/ImageConnection.swift
@@ -59,18 +59,18 @@ extension Storefront {
 			switch fieldName {
 				case "edges":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ImageConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try ImageEdge(fields: $0) }
 
 				case "pageInfo":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ImageConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try PageInfo(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: ImageConnection.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/ImageEdge.swift
+++ b/Buy/Generated/Storefront/ImageEdge.swift
@@ -56,18 +56,18 @@ extension Storefront {
 			switch fieldName {
 				case "cursor":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ImageEdge.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "node":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ImageEdge.self, field: fieldName, value: fieldValue)
 				}
 				return try Image(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: ImageEdge.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/MailingAddress.swift
+++ b/Buy/Generated/Storefront/MailingAddress.swift
@@ -31,42 +31,49 @@ extension Storefront {
 	open class MailingAddressQuery: GraphQL.AbstractQuery, GraphQLQuery {
 		public typealias Response = MailingAddress
 
+		/// Address line 1 (Street address/PO Box/Company name). 
 		@discardableResult
 		open func address1(alias: String? = nil) -> MailingAddressQuery {
 			addField(field: "address1", aliasSuffix: alias)
 			return self
 		}
 
+		/// Address line 2 (Apartment/Suite/Unit/Building). 
 		@discardableResult
 		open func address2(alias: String? = nil) -> MailingAddressQuery {
 			addField(field: "address2", aliasSuffix: alias)
 			return self
 		}
 
+		/// City/District/Suburb/Town/Village. 
 		@discardableResult
 		open func city(alias: String? = nil) -> MailingAddressQuery {
 			addField(field: "city", aliasSuffix: alias)
 			return self
 		}
 
+		/// Company/Organization/Government. 
 		@discardableResult
 		open func company(alias: String? = nil) -> MailingAddressQuery {
 			addField(field: "company", aliasSuffix: alias)
 			return self
 		}
 
+		/// State/County/Province/Region. 
 		@discardableResult
 		open func country(alias: String? = nil) -> MailingAddressQuery {
 			addField(field: "country", aliasSuffix: alias)
 			return self
 		}
 
+		/// Two-letter country code. For example, US. 
 		@discardableResult
 		open func countryCode(alias: String? = nil) -> MailingAddressQuery {
 			addField(field: "countryCode", aliasSuffix: alias)
 			return self
 		}
 
+		/// First name of the customer. 
 		@discardableResult
 		open func firstName(alias: String? = nil) -> MailingAddressQuery {
 			addField(field: "firstName", aliasSuffix: alias)
@@ -96,6 +103,7 @@ extension Storefront {
 			return self
 		}
 
+		/// Comma-separated list of city, province, and country. 
 		@discardableResult
 		open func formattedArea(alias: String? = nil) -> MailingAddressQuery {
 			addField(field: "formattedArea", aliasSuffix: alias)
@@ -109,48 +117,57 @@ extension Storefront {
 			return self
 		}
 
+		/// Last name of the customer. 
 		@discardableResult
 		open func lastName(alias: String? = nil) -> MailingAddressQuery {
 			addField(field: "lastName", aliasSuffix: alias)
 			return self
 		}
 
+		/// Latitude coordinate of the customer address. 
 		@discardableResult
 		open func latitude(alias: String? = nil) -> MailingAddressQuery {
 			addField(field: "latitude", aliasSuffix: alias)
 			return self
 		}
 
+		/// Longitude coordinate of the customer address. 
 		@discardableResult
 		open func longitude(alias: String? = nil) -> MailingAddressQuery {
 			addField(field: "longitude", aliasSuffix: alias)
 			return self
 		}
 
+		/// Name of the customer, based on first name + last name. 
 		@discardableResult
 		open func name(alias: String? = nil) -> MailingAddressQuery {
 			addField(field: "name", aliasSuffix: alias)
 			return self
 		}
 
+		/// Unique phone number for the customer. Formatted using E.164 standard. For 
+		/// example, _+16135551111_. 
 		@discardableResult
 		open func phone(alias: String? = nil) -> MailingAddressQuery {
 			addField(field: "phone", aliasSuffix: alias)
 			return self
 		}
 
+		/// State/County/Province/Region. 
 		@discardableResult
 		open func province(alias: String? = nil) -> MailingAddressQuery {
 			addField(field: "province", aliasSuffix: alias)
 			return self
 		}
 
+		/// Two-letter province or state code. For example, ON. 
 		@discardableResult
 		open func provinceCode(alias: String? = nil) -> MailingAddressQuery {
 			addField(field: "provinceCode", aliasSuffix: alias)
 			return self
 		}
 
+		/// Zip/Postal Code. 
 		@discardableResult
 		open func zip(alias: String? = nil) -> MailingAddressQuery {
 			addField(field: "zip", aliasSuffix: alias)
@@ -168,132 +185,133 @@ extension Storefront {
 				case "address1":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddress.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "address2":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddress.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "city":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddress.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "company":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddress.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "country":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddress.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "countryCode":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddress.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "firstName":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddress.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "formatted":
 				guard let value = value as? [String] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddress.self, field: fieldName, value: fieldValue)
 				}
 				return value.map { return $0 }
 
 				case "formattedArea":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddress.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "id":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddress.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.ID(rawValue: value)
 
 				case "lastName":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddress.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "latitude":
 				if value is NSNull { return nil }
 				guard let value = value as? Double else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddress.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "longitude":
 				if value is NSNull { return nil }
 				guard let value = value as? Double else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddress.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "name":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddress.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "phone":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddress.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "province":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddress.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "provinceCode":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddress.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "zip":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddress.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: MailingAddress.self, field: fieldName, value: fieldValue)
 			}
 		}
 
+		/// Address line 1 (Street address/PO Box/Company name). 
 		open var address1: String? {
 			return internalGetAddress1()
 		}
@@ -302,6 +320,7 @@ extension Storefront {
 			return field(field: "address1", aliasSuffix: alias) as! String?
 		}
 
+		/// Address line 2 (Apartment/Suite/Unit/Building). 
 		open var address2: String? {
 			return internalGetAddress2()
 		}
@@ -310,6 +329,7 @@ extension Storefront {
 			return field(field: "address2", aliasSuffix: alias) as! String?
 		}
 
+		/// City/District/Suburb/Town/Village. 
 		open var city: String? {
 			return internalGetCity()
 		}
@@ -318,6 +338,7 @@ extension Storefront {
 			return field(field: "city", aliasSuffix: alias) as! String?
 		}
 
+		/// Company/Organization/Government. 
 		open var company: String? {
 			return internalGetCompany()
 		}
@@ -326,6 +347,7 @@ extension Storefront {
 			return field(field: "company", aliasSuffix: alias) as! String?
 		}
 
+		/// State/County/Province/Region. 
 		open var country: String? {
 			return internalGetCountry()
 		}
@@ -334,6 +356,7 @@ extension Storefront {
 			return field(field: "country", aliasSuffix: alias) as! String?
 		}
 
+		/// Two-letter country code. For example, US. 
 		open var countryCode: String? {
 			return internalGetCountryCode()
 		}
@@ -342,6 +365,7 @@ extension Storefront {
 			return field(field: "countryCode", aliasSuffix: alias) as! String?
 		}
 
+		/// First name of the customer. 
 		open var firstName: String? {
 			return internalGetFirstName()
 		}
@@ -362,6 +386,7 @@ extension Storefront {
 			return field(field: "formatted", aliasSuffix: alias) as! [String]
 		}
 
+		/// Comma-separated list of city, province, and country. 
 		open var formattedArea: String? {
 			return internalGetFormattedArea()
 		}
@@ -379,6 +404,7 @@ extension Storefront {
 			return field(field: "id", aliasSuffix: alias) as! GraphQL.ID
 		}
 
+		/// Last name of the customer. 
 		open var lastName: String? {
 			return internalGetLastName()
 		}
@@ -387,6 +413,7 @@ extension Storefront {
 			return field(field: "lastName", aliasSuffix: alias) as! String?
 		}
 
+		/// Latitude coordinate of the customer address. 
 		open var latitude: Double? {
 			return internalGetLatitude()
 		}
@@ -395,6 +422,7 @@ extension Storefront {
 			return field(field: "latitude", aliasSuffix: alias) as! Double?
 		}
 
+		/// Longitude coordinate of the customer address. 
 		open var longitude: Double? {
 			return internalGetLongitude()
 		}
@@ -403,6 +431,7 @@ extension Storefront {
 			return field(field: "longitude", aliasSuffix: alias) as! Double?
 		}
 
+		/// Name of the customer, based on first name + last name. 
 		open var name: String? {
 			return internalGetName()
 		}
@@ -411,6 +440,8 @@ extension Storefront {
 			return field(field: "name", aliasSuffix: alias) as! String?
 		}
 
+		/// Unique phone number for the customer. Formatted using E.164 standard. For 
+		/// example, _+16135551111_. 
 		open var phone: String? {
 			return internalGetPhone()
 		}
@@ -419,6 +450,7 @@ extension Storefront {
 			return field(field: "phone", aliasSuffix: alias) as! String?
 		}
 
+		/// State/County/Province/Region. 
 		open var province: String? {
 			return internalGetProvince()
 		}
@@ -427,6 +459,7 @@ extension Storefront {
 			return field(field: "province", aliasSuffix: alias) as! String?
 		}
 
+		/// Two-letter province or state code. For example, ON. 
 		open var provinceCode: String? {
 			return internalGetProvinceCode()
 		}
@@ -435,6 +468,7 @@ extension Storefront {
 			return field(field: "provinceCode", aliasSuffix: alias) as! String?
 		}
 
+		/// Zip/Postal Code. 
 		open var zip: String? {
 			return internalGetZip()
 		}

--- a/Buy/Generated/Storefront/MailingAddressConnection.swift
+++ b/Buy/Generated/Storefront/MailingAddressConnection.swift
@@ -59,18 +59,18 @@ extension Storefront {
 			switch fieldName {
 				case "edges":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddressConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try MailingAddressEdge(fields: $0) }
 
 				case "pageInfo":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddressConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try PageInfo(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: MailingAddressConnection.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/MailingAddressEdge.swift
+++ b/Buy/Generated/Storefront/MailingAddressEdge.swift
@@ -56,18 +56,18 @@ extension Storefront {
 			switch fieldName {
 				case "cursor":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddressEdge.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "node":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: MailingAddressEdge.self, field: fieldName, value: fieldValue)
 				}
 				return try MailingAddress(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: MailingAddressEdge.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/MailingAddressInput.swift
+++ b/Buy/Generated/Storefront/MailingAddressInput.swift
@@ -94,7 +94,7 @@ extension Storefront {
 		///     - province: No description
 		///     - zip: No description
 		///
-		@available(*, deprecated)
+		@available(*, deprecated, message: "Use the static create() method instead.")
 		public convenience init(address1: String? = nil, address2: String? = nil, city: String? = nil, company: String? = nil, country: String? = nil, firstName: String? = nil, lastName: String? = nil, phone: String? = nil, province: String? = nil, zip: String? = nil) {
 			self.init(address1: address1.orNull, address2: address2.orNull, city: city.orNull, company: company.orNull, country: country.orNull, firstName: firstName.orNull, lastName: lastName.orNull, phone: phone.orNull, province: province.orNull, zip: zip.orNull)
 		}

--- a/Buy/Generated/Storefront/MailingAddressInput.swift
+++ b/Buy/Generated/Storefront/MailingAddressInput.swift
@@ -29,25 +29,25 @@ import Foundation
 extension Storefront {
 	/// Specifies the fields accepted to create or update a mailing address. 
 	open class MailingAddressInput {
-		open var address1: String?
+		open var address1: Input<String>
 
-		open var address2: String?
+		open var address2: Input<String>
 
-		open var city: String?
+		open var city: Input<String>
 
-		open var company: String?
+		open var company: Input<String>
 
-		open var country: String?
+		open var country: Input<String>
 
-		open var firstName: String?
+		open var firstName: Input<String>
 
-		open var lastName: String?
+		open var lastName: Input<String>
 
-		open var phone: String?
+		open var phone: Input<String>
 
-		open var province: String?
+		open var province: Input<String>
 
-		open var zip: String?
+		open var zip: Input<String>
 
 		/// Creates the input object.
 		///
@@ -63,7 +63,11 @@ extension Storefront {
 		///     - province: No description
 		///     - zip: No description
 		///
-		public init(address1: String? = nil, address2: String? = nil, city: String? = nil, company: String? = nil, country: String? = nil, firstName: String? = nil, lastName: String? = nil, phone: String? = nil, province: String? = nil, zip: String? = nil) {
+		public static func create(address1: Input<String> = .undefined, address2: Input<String> = .undefined, city: Input<String> = .undefined, company: Input<String> = .undefined, country: Input<String> = .undefined, firstName: Input<String> = .undefined, lastName: Input<String> = .undefined, phone: Input<String> = .undefined, province: Input<String> = .undefined, zip: Input<String> = .undefined) -> MailingAddressInput {
+			return MailingAddressInput(address1: address1, address2: address2, city: city, company: company, country: country, firstName: firstName, lastName: lastName, phone: phone, province: province, zip: zip)
+		}
+
+		private init(address1: Input<String> = .undefined, address2: Input<String> = .undefined, city: Input<String> = .undefined, company: Input<String> = .undefined, country: Input<String> = .undefined, firstName: Input<String> = .undefined, lastName: Input<String> = .undefined, phone: Input<String> = .undefined, province: Input<String> = .undefined, zip: Input<String> = .undefined) {
 			self.address1 = address1
 			self.address2 = address2
 			self.city = city
@@ -76,47 +80,126 @@ extension Storefront {
 			self.zip = zip
 		}
 
+		/// Creates the input object.
+		///
+		/// - parameters:
+		///     - address1: No description
+		///     - address2: No description
+		///     - city: No description
+		///     - company: No description
+		///     - country: No description
+		///     - firstName: No description
+		///     - lastName: No description
+		///     - phone: No description
+		///     - province: No description
+		///     - zip: No description
+		///
+		@available(*, deprecated)
+		public convenience init(address1: String? = nil, address2: String? = nil, city: String? = nil, company: String? = nil, country: String? = nil, firstName: String? = nil, lastName: String? = nil, phone: String? = nil, province: String? = nil, zip: String? = nil) {
+			self.init(address1: address1.orNull, address2: address2.orNull, city: city.orNull, company: company.orNull, country: country.orNull, firstName: firstName.orNull, lastName: lastName.orNull, phone: phone.orNull, province: province.orNull, zip: zip.orNull)
+		}
+
 		internal func serialize() -> String {
 			var fields: [String] = []
 
-			if let address1 = address1 {
+			switch address1 {
+				case .value(let address1): 
+				guard let address1 = address1 else {
+					fields.append("address1:null")
+					break
+				}
 				fields.append("address1:\(GraphQL.quoteString(input: address1))")
+				case .undefined: break
 			}
 
-			if let address2 = address2 {
+			switch address2 {
+				case .value(let address2): 
+				guard let address2 = address2 else {
+					fields.append("address2:null")
+					break
+				}
 				fields.append("address2:\(GraphQL.quoteString(input: address2))")
+				case .undefined: break
 			}
 
-			if let city = city {
+			switch city {
+				case .value(let city): 
+				guard let city = city else {
+					fields.append("city:null")
+					break
+				}
 				fields.append("city:\(GraphQL.quoteString(input: city))")
+				case .undefined: break
 			}
 
-			if let company = company {
+			switch company {
+				case .value(let company): 
+				guard let company = company else {
+					fields.append("company:null")
+					break
+				}
 				fields.append("company:\(GraphQL.quoteString(input: company))")
+				case .undefined: break
 			}
 
-			if let country = country {
+			switch country {
+				case .value(let country): 
+				guard let country = country else {
+					fields.append("country:null")
+					break
+				}
 				fields.append("country:\(GraphQL.quoteString(input: country))")
+				case .undefined: break
 			}
 
-			if let firstName = firstName {
+			switch firstName {
+				case .value(let firstName): 
+				guard let firstName = firstName else {
+					fields.append("firstName:null")
+					break
+				}
 				fields.append("firstName:\(GraphQL.quoteString(input: firstName))")
+				case .undefined: break
 			}
 
-			if let lastName = lastName {
+			switch lastName {
+				case .value(let lastName): 
+				guard let lastName = lastName else {
+					fields.append("lastName:null")
+					break
+				}
 				fields.append("lastName:\(GraphQL.quoteString(input: lastName))")
+				case .undefined: break
 			}
 
-			if let phone = phone {
+			switch phone {
+				case .value(let phone): 
+				guard let phone = phone else {
+					fields.append("phone:null")
+					break
+				}
 				fields.append("phone:\(GraphQL.quoteString(input: phone))")
+				case .undefined: break
 			}
 
-			if let province = province {
+			switch province {
+				case .value(let province): 
+				guard let province = province else {
+					fields.append("province:null")
+					break
+				}
 				fields.append("province:\(GraphQL.quoteString(input: province))")
+				case .undefined: break
 			}
 
-			if let zip = zip {
+			switch zip {
+				case .value(let zip): 
+				guard let zip = zip else {
+					fields.append("zip:null")
+					break
+				}
 				fields.append("zip:\(GraphQL.quoteString(input: zip))")
+				case .undefined: break
 			}
 
 			return "{\(fields.joined(separator: ","))}"

--- a/Buy/Generated/Storefront/Mutation.swift
+++ b/Buy/Generated/Storefront/Mutation.swift
@@ -626,187 +626,187 @@ extension Storefront {
 				case "checkoutAttributesUpdate":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CheckoutAttributesUpdatePayload(fields: value)
 
 				case "checkoutCompleteFree":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CheckoutCompleteFreePayload(fields: value)
 
 				case "checkoutCompleteWithCreditCard":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CheckoutCompleteWithCreditCardPayload(fields: value)
 
 				case "checkoutCompleteWithTokenizedPayment":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CheckoutCompleteWithTokenizedPaymentPayload(fields: value)
 
 				case "checkoutCreate":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CheckoutCreatePayload(fields: value)
 
 				case "checkoutCustomerAssociate":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CheckoutCustomerAssociatePayload(fields: value)
 
 				case "checkoutCustomerDisassociate":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CheckoutCustomerDisassociatePayload(fields: value)
 
 				case "checkoutEmailUpdate":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CheckoutEmailUpdatePayload(fields: value)
 
 				case "checkoutGiftCardApply":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CheckoutGiftCardApplyPayload(fields: value)
 
 				case "checkoutGiftCardRemove":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CheckoutGiftCardRemovePayload(fields: value)
 
 				case "checkoutLineItemsAdd":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CheckoutLineItemsAddPayload(fields: value)
 
 				case "checkoutLineItemsRemove":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CheckoutLineItemsRemovePayload(fields: value)
 
 				case "checkoutLineItemsUpdate":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CheckoutLineItemsUpdatePayload(fields: value)
 
 				case "checkoutShippingAddressUpdate":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CheckoutShippingAddressUpdatePayload(fields: value)
 
 				case "checkoutShippingLineUpdate":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CheckoutShippingLineUpdatePayload(fields: value)
 
 				case "customerAccessTokenCreate":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CustomerAccessTokenCreatePayload(fields: value)
 
 				case "customerAccessTokenDelete":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CustomerAccessTokenDeletePayload(fields: value)
 
 				case "customerAccessTokenRenew":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CustomerAccessTokenRenewPayload(fields: value)
 
 				case "customerActivate":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CustomerActivatePayload(fields: value)
 
 				case "customerAddressCreate":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CustomerAddressCreatePayload(fields: value)
 
 				case "customerAddressDelete":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CustomerAddressDeletePayload(fields: value)
 
 				case "customerAddressUpdate":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CustomerAddressUpdatePayload(fields: value)
 
 				case "customerCreate":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CustomerCreatePayload(fields: value)
 
 				case "customerRecover":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CustomerRecoverPayload(fields: value)
 
 				case "customerReset":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CustomerResetPayload(fields: value)
 
 				case "customerUpdate":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 				}
 				return try CustomerUpdatePayload(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: Mutation.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/Node.swift
+++ b/Buy/Generated/Storefront/Node.swift
@@ -184,12 +184,12 @@ extension Storefront {
 			switch fieldName {
 				case "id":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: UnknownNode.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.ID(rawValue: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: UnknownNode.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/Order.swift
+++ b/Buy/Generated/Storefront/Order.swift
@@ -182,103 +182,103 @@ extension Storefront {
 			switch fieldName {
 				case "currencyCode":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Order.self, field: fieldName, value: fieldValue)
 				}
 				return CurrencyCode(rawValue: value) ?? .unknownValue
 
 				case "customerLocale":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Order.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "customerUrl":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Order.self, field: fieldName, value: fieldValue)
 				}
 				return URL(string: value)!
 
 				case "email":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Order.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "id":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Order.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.ID(rawValue: value)
 
 				case "lineItems":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Order.self, field: fieldName, value: fieldValue)
 				}
 				return try OrderLineItemConnection(fields: value)
 
 				case "orderNumber":
 				guard let value = value as? Int else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Order.self, field: fieldName, value: fieldValue)
 				}
 				return Int32(value)
 
 				case "phone":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Order.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "processedAt":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Order.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.iso8601DateParser.date(from: value)!
 
 				case "shippingAddress":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Order.self, field: fieldName, value: fieldValue)
 				}
 				return try MailingAddress(fields: value)
 
 				case "subtotalPrice":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Order.self, field: fieldName, value: fieldValue)
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
 
 				case "totalPrice":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Order.self, field: fieldName, value: fieldValue)
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
 
 				case "totalRefunded":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Order.self, field: fieldName, value: fieldValue)
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
 
 				case "totalShippingPrice":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Order.self, field: fieldName, value: fieldValue)
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
 
 				case "totalTax":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Order.self, field: fieldName, value: fieldValue)
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: Order.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/OrderConnection.swift
+++ b/Buy/Generated/Storefront/OrderConnection.swift
@@ -59,18 +59,18 @@ extension Storefront {
 			switch fieldName {
 				case "edges":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: OrderConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try OrderEdge(fields: $0) }
 
 				case "pageInfo":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: OrderConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try PageInfo(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: OrderConnection.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/OrderEdge.swift
+++ b/Buy/Generated/Storefront/OrderEdge.swift
@@ -56,18 +56,18 @@ extension Storefront {
 			switch fieldName {
 				case "cursor":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: OrderEdge.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "node":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: OrderEdge.self, field: fieldName, value: fieldValue)
 				}
 				return try Order(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: OrderEdge.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/OrderLineItem.swift
+++ b/Buy/Generated/Storefront/OrderLineItem.swift
@@ -77,31 +77,31 @@ extension Storefront {
 			switch fieldName {
 				case "customAttributes":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: OrderLineItem.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try Attribute(fields: $0) }
 
 				case "quantity":
 				guard let value = value as? Int else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: OrderLineItem.self, field: fieldName, value: fieldValue)
 				}
 				return Int32(value)
 
 				case "title":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: OrderLineItem.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "variant":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: OrderLineItem.self, field: fieldName, value: fieldValue)
 				}
 				return try ProductVariant(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: OrderLineItem.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/OrderLineItemConnection.swift
+++ b/Buy/Generated/Storefront/OrderLineItemConnection.swift
@@ -59,18 +59,18 @@ extension Storefront {
 			switch fieldName {
 				case "edges":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: OrderLineItemConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try OrderLineItemEdge(fields: $0) }
 
 				case "pageInfo":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: OrderLineItemConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try PageInfo(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: OrderLineItemConnection.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/OrderLineItemEdge.swift
+++ b/Buy/Generated/Storefront/OrderLineItemEdge.swift
@@ -56,18 +56,18 @@ extension Storefront {
 			switch fieldName {
 				case "cursor":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: OrderLineItemEdge.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "node":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: OrderLineItemEdge.self, field: fieldName, value: fieldValue)
 				}
 				return try OrderLineItem(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: OrderLineItemEdge.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/PageInfo.swift
+++ b/Buy/Generated/Storefront/PageInfo.swift
@@ -55,18 +55,18 @@ extension Storefront {
 			switch fieldName {
 				case "hasNextPage":
 				guard let value = value as? Bool else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: PageInfo.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "hasPreviousPage":
 				guard let value = value as? Bool else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: PageInfo.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: PageInfo.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/Payment.swift
+++ b/Buy/Generated/Storefront/Payment.swift
@@ -126,71 +126,71 @@ extension Storefront {
 			switch fieldName {
 				case "amount":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Payment.self, field: fieldName, value: fieldValue)
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
 
 				case "billingAddress":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Payment.self, field: fieldName, value: fieldValue)
 				}
 				return try MailingAddress(fields: value)
 
 				case "checkout":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Payment.self, field: fieldName, value: fieldValue)
 				}
 				return try Checkout(fields: value)
 
 				case "creditCard":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Payment.self, field: fieldName, value: fieldValue)
 				}
 				return try CreditCard(fields: value)
 
 				case "errorMessage":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Payment.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "id":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Payment.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.ID(rawValue: value)
 
 				case "idempotencyKey":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Payment.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "ready":
 				guard let value = value as? Bool else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Payment.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "test":
 				guard let value = value as? Bool else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Payment.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "transaction":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Payment.self, field: fieldName, value: fieldValue)
 				}
 				return try Transaction(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: Payment.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/PaymentSettings.swift
+++ b/Buy/Generated/Storefront/PaymentSettings.swift
@@ -83,43 +83,43 @@ extension Storefront {
 			switch fieldName {
 				case "acceptedCardBrands":
 				guard let value = value as? [String] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: PaymentSettings.self, field: fieldName, value: fieldValue)
 				}
 				return value.map { return CardBrand(rawValue: $0) ?? .unknownValue }
 
 				case "cardVaultUrl":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: PaymentSettings.self, field: fieldName, value: fieldValue)
 				}
 				return URL(string: value)!
 
 				case "countryCode":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: PaymentSettings.self, field: fieldName, value: fieldValue)
 				}
 				return CountryCode(rawValue: value) ?? .unknownValue
 
 				case "currencyCode":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: PaymentSettings.self, field: fieldName, value: fieldValue)
 				}
 				return CurrencyCode(rawValue: value) ?? .unknownValue
 
 				case "shopifyPaymentsAccountId":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: PaymentSettings.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "supportedDigitalWallets":
 				guard let value = value as? [String] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: PaymentSettings.self, field: fieldName, value: fieldValue)
 				}
 				return value.map { return DigitalWallet(rawValue: $0) ?? .unknownValue }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: PaymentSettings.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/Product.swift
+++ b/Buy/Generated/Storefront/Product.swift
@@ -119,8 +119,8 @@ extension Storefront {
 		/// - parameters:
 		///     - first: No description
 		///     - after: No description
-		///     - sortKey: No description
 		///     - reverse: No description
+		///     - sortKey: No description
 		///     - maxWidth: Image width in pixels between 1 and 2048
 		///     - maxHeight: Image height in pixels between 1 and 2048
 		///     - crop: If specified, crop the image keeping the specified region
@@ -136,12 +136,12 @@ extension Storefront {
 				args.append("after:\(GraphQL.quoteString(input: after))")
 			}
 
-			if let sortKey = sortKey {
-				args.append("sortKey:\(sortKey.rawValue)")
-			}
-
 			if let reverse = reverse {
 				args.append("reverse:\(reverse)")
+			}
+
+			if let sortKey = sortKey {
+				args.append("sortKey:\(sortKey.rawValue)")
 			}
 
 			if let maxWidth = maxWidth {
@@ -316,110 +316,110 @@ extension Storefront {
 			switch fieldName {
 				case "collections":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Product.self, field: fieldName, value: fieldValue)
 				}
 				return try CollectionConnection(fields: value)
 
 				case "createdAt":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Product.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.iso8601DateParser.date(from: value)!
 
 				case "description":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Product.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "descriptionHtml":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Product.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "handle":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Product.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "id":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Product.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.ID(rawValue: value)
 
 				case "images":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Product.self, field: fieldName, value: fieldValue)
 				}
 				return try ImageConnection(fields: value)
 
 				case "onlineStoreUrl":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Product.self, field: fieldName, value: fieldValue)
 				}
 				return URL(string: value)!
 
 				case "options":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Product.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try ProductOption(fields: $0) }
 
 				case "productType":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Product.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "publishedAt":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Product.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.iso8601DateParser.date(from: value)!
 
 				case "tags":
 				guard let value = value as? [String] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Product.self, field: fieldName, value: fieldValue)
 				}
 				return value.map { return $0 }
 
 				case "title":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Product.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "updatedAt":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Product.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.iso8601DateParser.date(from: value)!
 
 				case "variantBySelectedOptions":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Product.self, field: fieldName, value: fieldValue)
 				}
 				return try ProductVariant(fields: value)
 
 				case "variants":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Product.self, field: fieldName, value: fieldValue)
 				}
 				return try ProductVariantConnection(fields: value)
 
 				case "vendor":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Product.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: Product.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/ProductConnection.swift
+++ b/Buy/Generated/Storefront/ProductConnection.swift
@@ -59,18 +59,18 @@ extension Storefront {
 			switch fieldName {
 				case "edges":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try ProductEdge(fields: $0) }
 
 				case "pageInfo":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try PageInfo(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: ProductConnection.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/ProductEdge.swift
+++ b/Buy/Generated/Storefront/ProductEdge.swift
@@ -56,18 +56,18 @@ extension Storefront {
 			switch fieldName {
 				case "cursor":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductEdge.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "node":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductEdge.self, field: fieldName, value: fieldValue)
 				}
 				return try Product(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: ProductEdge.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/ProductOption.swift
+++ b/Buy/Generated/Storefront/ProductOption.swift
@@ -66,24 +66,24 @@ extension Storefront {
 			switch fieldName {
 				case "id":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductOption.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.ID(rawValue: value)
 
 				case "name":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductOption.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "values":
 				guard let value = value as? [String] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductOption.self, field: fieldName, value: fieldValue)
 				}
 				return value.map { return $0 }
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: ProductOption.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/ProductVariant.swift
+++ b/Buy/Generated/Storefront/ProductVariant.swift
@@ -167,82 +167,82 @@ extension Storefront {
 				case "available":
 				if value is NSNull { return nil }
 				guard let value = value as? Bool else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "availableForSale":
 				guard let value = value as? Bool else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "compareAtPrice":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
 
 				case "id":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.ID(rawValue: value)
 
 				case "image":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
 				}
 				return try Image(fields: value)
 
 				case "price":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
 
 				case "product":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
 				}
 				return try Product(fields: value)
 
 				case "selectedOptions":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try SelectedOption(fields: $0) }
 
 				case "sku":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "title":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "weight":
 				if value is NSNull { return nil }
 				guard let value = value as? Double else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "weightUnit":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
 				}
 				return WeightUnit(rawValue: value) ?? .unknownValue
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/ProductVariantConnection.swift
+++ b/Buy/Generated/Storefront/ProductVariantConnection.swift
@@ -59,18 +59,18 @@ extension Storefront {
 			switch fieldName {
 				case "edges":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductVariantConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try ProductVariantEdge(fields: $0) }
 
 				case "pageInfo":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductVariantConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try PageInfo(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: ProductVariantConnection.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/ProductVariantEdge.swift
+++ b/Buy/Generated/Storefront/ProductVariantEdge.swift
@@ -56,18 +56,18 @@ extension Storefront {
 			switch fieldName {
 				case "cursor":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductVariantEdge.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "node":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ProductVariantEdge.self, field: fieldName, value: fieldValue)
 				}
 				return try ProductVariant(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: ProductVariantEdge.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/SelectedOption.swift
+++ b/Buy/Generated/Storefront/SelectedOption.swift
@@ -59,18 +59,18 @@ extension Storefront {
 			switch fieldName {
 				case "name":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: SelectedOption.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "value":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: SelectedOption.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: SelectedOption.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/SelectedOptionInput.swift
+++ b/Buy/Generated/Storefront/SelectedOptionInput.swift
@@ -41,6 +41,16 @@ extension Storefront {
 		///     - name: The product option’s name.
 		///     - value: The product option’s value.
 		///
+		public static func create(name: String, value: String) -> SelectedOptionInput {
+			return SelectedOptionInput(name: name, value: value)
+		}
+
+		/// Creates the input object.
+		///
+		/// - parameters:
+		///     - name: The product option’s name.
+		///     - value: The product option’s value.
+		///
 		public init(name: String, value: String) {
 			self.name = name
 			self.value = value

--- a/Buy/Generated/Storefront/ShippingRate.swift
+++ b/Buy/Generated/Storefront/ShippingRate.swift
@@ -62,24 +62,24 @@ extension Storefront {
 			switch fieldName {
 				case "handle":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ShippingRate.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "price":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ShippingRate.self, field: fieldName, value: fieldValue)
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
 
 				case "title":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ShippingRate.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: ShippingRate.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/Shop.swift
+++ b/Buy/Generated/Storefront/Shop.swift
@@ -37,8 +37,8 @@ extension Storefront {
 		/// - parameters:
 		///     - first: No description
 		///     - after: No description
-		///     - sortKey: No description
 		///     - reverse: No description
+		///     - sortKey: No description
 		///     - query: Supported filter parameters:
 		///         - `author`
 		///         - `updated_at`
@@ -56,12 +56,12 @@ extension Storefront {
 				args.append("after:\(GraphQL.quoteString(input: after))")
 			}
 
-			if let sortKey = sortKey {
-				args.append("sortKey:\(sortKey.rawValue)")
-			}
-
 			if let reverse = reverse {
 				args.append("reverse:\(reverse)")
+			}
+
+			if let sortKey = sortKey {
+				args.append("sortKey:\(sortKey.rawValue)")
 			}
 
 			if let query = query {
@@ -82,8 +82,8 @@ extension Storefront {
 		/// - parameters:
 		///     - first: No description
 		///     - after: No description
-		///     - sortKey: No description
 		///     - reverse: No description
+		///     - sortKey: No description
 		///     - query: Supported filter parameters:
 		///         - `handle`
 		///         - `title`
@@ -100,12 +100,12 @@ extension Storefront {
 				args.append("after:\(GraphQL.quoteString(input: after))")
 			}
 
-			if let sortKey = sortKey {
-				args.append("sortKey:\(sortKey.rawValue)")
-			}
-
 			if let reverse = reverse {
 				args.append("reverse:\(reverse)")
+			}
+
+			if let sortKey = sortKey {
+				args.append("sortKey:\(sortKey.rawValue)")
 			}
 
 			if let query = query {
@@ -154,8 +154,8 @@ extension Storefront {
 		/// - parameters:
 		///     - first: No description
 		///     - after: No description
-		///     - sortKey: No description
 		///     - reverse: No description
+		///     - sortKey: No description
 		///     - query: Supported filter parameters:
 		///         - `title`
 		///         - `collection_type`
@@ -171,12 +171,12 @@ extension Storefront {
 				args.append("after:\(GraphQL.quoteString(input: after))")
 			}
 
-			if let sortKey = sortKey {
-				args.append("sortKey:\(sortKey.rawValue)")
-			}
-
 			if let reverse = reverse {
 				args.append("reverse:\(reverse)")
+			}
+
+			if let sortKey = sortKey {
+				args.append("sortKey:\(sortKey.rawValue)")
 			}
 
 			if let query = query {
@@ -297,8 +297,8 @@ extension Storefront {
 		/// - parameters:
 		///     - first: No description
 		///     - after: No description
-		///     - sortKey: No description
 		///     - reverse: No description
+		///     - sortKey: No description
 		///     - query: Supported filter parameters:
 		///         - `title`
 		///         - `product_type`
@@ -317,12 +317,12 @@ extension Storefront {
 				args.append("after:\(GraphQL.quoteString(input: after))")
 			}
 
-			if let sortKey = sortKey {
-				args.append("sortKey:\(sortKey.rawValue)")
-			}
-
 			if let reverse = reverse {
 				args.append("reverse:\(reverse)")
+			}
+
+			if let sortKey = sortKey {
+				args.append("sortKey:\(sortKey.rawValue)")
 			}
 
 			if let query = query {
@@ -377,121 +377,121 @@ extension Storefront {
 			switch fieldName {
 				case "articles":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Shop.self, field: fieldName, value: fieldValue)
 				}
 				return try ArticleConnection(fields: value)
 
 				case "blogs":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Shop.self, field: fieldName, value: fieldValue)
 				}
 				return try BlogConnection(fields: value)
 
 				case "cardVaultUrl":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Shop.self, field: fieldName, value: fieldValue)
 				}
 				return URL(string: value)!
 
 				case "collectionByHandle":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Shop.self, field: fieldName, value: fieldValue)
 				}
 				return try Collection(fields: value)
 
 				case "collections":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Shop.self, field: fieldName, value: fieldValue)
 				}
 				return try CollectionConnection(fields: value)
 
 				case "currencyCode":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Shop.self, field: fieldName, value: fieldValue)
 				}
 				return CurrencyCode(rawValue: value) ?? .unknownValue
 
 				case "description":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Shop.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "moneyFormat":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Shop.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "name":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Shop.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "paymentSettings":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Shop.self, field: fieldName, value: fieldValue)
 				}
 				return try PaymentSettings(fields: value)
 
 				case "primaryDomain":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Shop.self, field: fieldName, value: fieldValue)
 				}
 				return try Domain(fields: value)
 
 				case "privacyPolicy":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Shop.self, field: fieldName, value: fieldValue)
 				}
 				return try ShopPolicy(fields: value)
 
 				case "productByHandle":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Shop.self, field: fieldName, value: fieldValue)
 				}
 				return try Product(fields: value)
 
 				case "productTypes":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Shop.self, field: fieldName, value: fieldValue)
 				}
 				return try StringConnection(fields: value)
 
 				case "products":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Shop.self, field: fieldName, value: fieldValue)
 				}
 				return try ProductConnection(fields: value)
 
 				case "refundPolicy":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Shop.self, field: fieldName, value: fieldValue)
 				}
 				return try ShopPolicy(fields: value)
 
 				case "shopifyPaymentsAccountId":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Shop.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "termsOfService":
 				if value is NSNull { return nil }
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Shop.self, field: fieldName, value: fieldValue)
 				}
 				return try ShopPolicy(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: Shop.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/ShopPolicy.swift
+++ b/Buy/Generated/Storefront/ShopPolicy.swift
@@ -71,30 +71,30 @@ extension Storefront {
 			switch fieldName {
 				case "body":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ShopPolicy.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "id":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ShopPolicy.self, field: fieldName, value: fieldValue)
 				}
 				return GraphQL.ID(rawValue: value)
 
 				case "title":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ShopPolicy.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "url":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: ShopPolicy.self, field: fieldName, value: fieldValue)
 				}
 				return URL(string: value)!
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: ShopPolicy.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/StringConnection.swift
+++ b/Buy/Generated/Storefront/StringConnection.swift
@@ -59,18 +59,18 @@ extension Storefront {
 			switch fieldName {
 				case "edges":
 				guard let value = value as? [[String: Any]] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: StringConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try value.map { return try StringEdge(fields: $0) }
 
 				case "pageInfo":
 				guard let value = value as? [String: Any] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: StringConnection.self, field: fieldName, value: fieldValue)
 				}
 				return try PageInfo(fields: value)
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: StringConnection.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/StringEdge.swift
+++ b/Buy/Generated/Storefront/StringEdge.swift
@@ -53,18 +53,18 @@ extension Storefront {
 			switch fieldName {
 				case "cursor":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: StringEdge.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				case "node":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: StringEdge.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: StringEdge.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/TokenizedPaymentInput.swift
+++ b/Buy/Generated/Storefront/TokenizedPaymentInput.swift
@@ -49,10 +49,10 @@ extension Storefront {
 		open var paymentData: String
 
 		/// Executes the payment in test mode if possible. Defaults to `false`. 
-		open var test: Bool?
+		open var test: Input<Bool>
 
 		/// Public Hash Key used for AndroidPay payments only. 
-		open var identifier: String?
+		open var identifier: Input<String>
 
 		/// Creates the input object.
 		///
@@ -65,7 +65,11 @@ extension Storefront {
 		///     - test: Executes the payment in test mode if possible. Defaults to `false`.
 		///     - identifier: Public Hash Key used for AndroidPay payments only.
 		///
-		public init(amount: Decimal, idempotencyKey: String, billingAddress: MailingAddressInput, type: String, paymentData: String, test: Bool? = nil, identifier: String? = nil) {
+		public static func create(amount: Decimal, idempotencyKey: String, billingAddress: MailingAddressInput, type: String, paymentData: String, test: Input<Bool> = .undefined, identifier: Input<String> = .undefined) -> TokenizedPaymentInput {
+			return TokenizedPaymentInput(amount: amount, idempotencyKey: idempotencyKey, billingAddress: billingAddress, type: type, paymentData: paymentData, test: test, identifier: identifier)
+		}
+
+		private init(amount: Decimal, idempotencyKey: String, billingAddress: MailingAddressInput, type: String, paymentData: String, test: Input<Bool> = .undefined, identifier: Input<String> = .undefined) {
 			self.amount = amount
 			self.idempotencyKey = idempotencyKey
 			self.billingAddress = billingAddress
@@ -73,6 +77,22 @@ extension Storefront {
 			self.paymentData = paymentData
 			self.test = test
 			self.identifier = identifier
+		}
+
+		/// Creates the input object.
+		///
+		/// - parameters:
+		///     - amount: The amount of the payment.
+		///     - idempotencyKey: A unique client generated key used to avoid duplicate charges. When a duplicate payment is found, the original is returned instead of creating a new one.
+		///     - billingAddress: The billing address for the payment.
+		///     - type: The type of payment token.
+		///     - paymentData: A simple string or JSON containing the required payment data for the tokenized payment.
+		///     - test: Executes the payment in test mode if possible. Defaults to `false`.
+		///     - identifier: Public Hash Key used for AndroidPay payments only.
+		///
+		@available(*, deprecated)
+		public convenience init(amount: Decimal, idempotencyKey: String, billingAddress: MailingAddressInput, type: String, paymentData: String, test: Bool? = nil, identifier: String? = nil) {
+			self.init(amount: amount, idempotencyKey: idempotencyKey, billingAddress: billingAddress, type: type, paymentData: paymentData, test: test.orNull, identifier: identifier.orNull)
 		}
 
 		internal func serialize() -> String {
@@ -88,12 +108,24 @@ extension Storefront {
 
 			fields.append("paymentData:\(GraphQL.quoteString(input: paymentData))")
 
-			if let test = test {
+			switch test {
+				case .value(let test): 
+				guard let test = test else {
+					fields.append("test:null")
+					break
+				}
 				fields.append("test:\(test)")
+				case .undefined: break
 			}
 
-			if let identifier = identifier {
+			switch identifier {
+				case .value(let identifier): 
+				guard let identifier = identifier else {
+					fields.append("identifier:null")
+					break
+				}
 				fields.append("identifier:\(GraphQL.quoteString(input: identifier))")
+				case .undefined: break
 			}
 
 			return "{\(fields.joined(separator: ","))}"

--- a/Buy/Generated/Storefront/TokenizedPaymentInput.swift
+++ b/Buy/Generated/Storefront/TokenizedPaymentInput.swift
@@ -90,7 +90,7 @@ extension Storefront {
 		///     - test: Executes the payment in test mode if possible. Defaults to `false`.
 		///     - identifier: Public Hash Key used for AndroidPay payments only.
 		///
-		@available(*, deprecated)
+		@available(*, deprecated, message: "Use the static create() method instead.")
 		public convenience init(amount: Decimal, idempotencyKey: String, billingAddress: MailingAddressInput, type: String, paymentData: String, test: Bool? = nil, identifier: String? = nil) {
 			self.init(amount: amount, idempotencyKey: idempotencyKey, billingAddress: billingAddress, type: type, paymentData: paymentData, test: test.orNull, identifier: identifier.orNull)
 		}

--- a/Buy/Generated/Storefront/Transaction.swift
+++ b/Buy/Generated/Storefront/Transaction.swift
@@ -69,30 +69,30 @@ extension Storefront {
 			switch fieldName {
 				case "amount":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Transaction.self, field: fieldName, value: fieldValue)
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
 
 				case "kind":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Transaction.self, field: fieldName, value: fieldValue)
 				}
 				return TransactionKind(rawValue: value) ?? .unknownValue
 
 				case "status":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Transaction.self, field: fieldName, value: fieldValue)
 				}
 				return TransactionStatus(rawValue: value) ?? .unknownValue
 
 				case "test":
 				guard let value = value as? Bool else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: Transaction.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: Transaction.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Buy/Generated/Storefront/UserError.swift
+++ b/Buy/Generated/Storefront/UserError.swift
@@ -56,18 +56,18 @@ extension Storefront {
 				case "field":
 				if value is NSNull { return nil }
 				guard let value = value as? [String] else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: UserError.self, field: fieldName, value: fieldValue)
 				}
 				return value.map { return $0 }
 
 				case "message":
 				guard let value = value as? String else {
-					throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+					throw SchemaViolationError(type: UserError.self, field: fieldName, value: fieldValue)
 				}
 				return value
 
 				default:
-				throw SchemaViolationError(type: type(of: self), field: fieldName, value: fieldValue)
+				throw SchemaViolationError(type: UserError.self, field: fieldName, value: fieldValue)
 			}
 		}
 

--- a/Sample Apps/Storefront/Storefront/ClientQuery.swift
+++ b/Sample Apps/Storefront/Storefront/ClientQuery.swift
@@ -78,12 +78,12 @@ final class ClientQuery {
     //
     static func mutationForCreateCheckout(with cartItems: [CartItem]) -> Storefront.MutationQuery {
         let lineItems = cartItems.map { item in
-            Storefront.CheckoutLineItemInput(variantId: GraphQL.ID(rawValue: item.variant.id), quantity: Int32(item.quantity))
+            Storefront.CheckoutLineItemInput.create(quantity: Int32(item.quantity), variantId: GraphQL.ID(rawValue: item.variant.id))
         }
         
-        let checkoutInput = Storefront.CheckoutCreateInput(
-            lineItems: lineItems,
-            allowPartialAddresses: true
+        let checkoutInput = Storefront.CheckoutCreateInput.create(
+            lineItems: .value(lineItems),
+            allowPartialAddresses: .value(true)
         )
         
         return Storefront.buildMutation { $0
@@ -98,11 +98,11 @@ final class ClientQuery {
     static func mutationForUpdateCheckout(_ id: String, updatingPartialShippingAddress address: PayPostalAddress) -> Storefront.MutationQuery {
         
         let checkoutID   = GraphQL.ID(rawValue: id)
-        let addressInput = Storefront.MailingAddressInput(
-            city:     address.city,
-            country:  address.country,
-            province: address.province,
-            zip:      address.zip
+        let addressInput = Storefront.MailingAddressInput.create(
+            city:     address.city.orNull,
+            country:  address.country.orNull,
+            province: address.province.orNull,
+            zip:      address.zip.orNull
         )
         
         return Storefront.buildMutation { $0
@@ -121,16 +121,16 @@ final class ClientQuery {
     static func mutationForUpdateCheckout(_ id: String, updatingCompleteShippingAddress address: PayAddress) -> Storefront.MutationQuery {
         
         let checkoutID   = GraphQL.ID(rawValue: id)
-        let addressInput = Storefront.MailingAddressInput(
-            address1:  address.addressLine1,
-            address2:  address.addressLine2,
-            city:      address.city,
-            country:   address.country,
-            firstName: address.firstName,
-            lastName:  address.lastName,
-            phone:     address.phone,
-            province:  address.province,
-            zip:       address.zip
+        let addressInput = Storefront.MailingAddressInput.create(
+            address1:  address.addressLine1.orNull,
+            address2:  address.addressLine2.orNull,
+            city:      address.city.orNull,
+            country:   address.country.orNull,
+            firstName: address.firstName.orNull,
+            lastName:  address.lastName.orNull,
+            phone:     address.phone.orNull,
+            province:  address.province.orNull,
+            zip:       address.zip.orNull
         )
         
         return Storefront.buildMutation { $0
@@ -178,18 +178,18 @@ final class ClientQuery {
     
     static func mutationForCompleteCheckoutUsingApplePay(_ checkout: PayCheckout, billingAddress: PayAddress, token: String, idempotencyToken: String) -> Storefront.MutationQuery {
         
-        let mailingAddress = Storefront.MailingAddressInput(
-            address1:  billingAddress.addressLine1,
-            address2:  billingAddress.addressLine2,
-            city:      billingAddress.city,
-            country:   billingAddress.country,
-            firstName: billingAddress.firstName,
-            lastName:  billingAddress.lastName,
-            province:  billingAddress.province,
-            zip:       billingAddress.zip
+        let mailingAddress = Storefront.MailingAddressInput.create(
+            address1:  billingAddress.addressLine1.orNull,
+            address2:  billingAddress.addressLine2.orNull,
+            city:      billingAddress.city.orNull,
+            country:   billingAddress.country.orNull,
+            firstName: billingAddress.firstName.orNull,
+            lastName:  billingAddress.lastName.orNull,
+            province:  billingAddress.province.orNull,
+            zip:       billingAddress.zip.orNull
         )
         
-        let paymentInput = Storefront.TokenizedPaymentInput(
+        let paymentInput = Storefront.TokenizedPaymentInput.create(
             amount:         checkout.paymentDue,
             idempotencyKey: idempotencyToken,
             billingAddress: mailingAddress,


### PR DESCRIPTION
### What this does

Converts all optional fields on input object to type `Input<FieldType>` where `FieldType` is the type previously used for those fields. Requiring an `Input` forces an explicit decision on whether the values should be set to the following:
- value(T)
- undefined

This change is required to allow update mutation to explicitly send `nil` values in the query, which is particularly useful for nullifying previously non-nil values on the server. Concrete example includes removing a customer's phone number from the server.

### Other changes from updated generation

- support for `.nodes`
- adds descriptions to various fields

#### Philosophy

Other approaches were considered but we ultimately landed on wrapping optional values in a generic `Input` type. The intention is to force the user to make an explicit decision when setting values instead of relying on implicit behaviour that isn't documented.

**This is non-breaking change**. It deprecates initializers on input objects that contain optional fields and introduces a static `create()` method instead.
