### PR TITLE
Invalidate cache across version bumps.

### DIFF
--- a/Buy/Client/Graph.Cache.swift
+++ b/Buy/Client/Graph.Cache.swift
@@ -32,7 +32,7 @@ internal extension Graph {
     
     internal class Cache {
         
-        static let cacheName = "com.buy.graph.cache"
+        static let cacheName = "com.buy.graph.cache-\(Global.frameworkVersion)"
         
         private static let fileManager = FileManager.default
         


### PR DESCRIPTION
### What this does

Assigns a framework version to the cache directory. Doing so pins each set of cached queries to the framework version, effectively eliminating any cached data from leaking across releases.

Fixes #719 
