### PR TITLE
Undefined values

### DIFF
--- a/Buy/Generated/Storefront/CheckoutAttributesUpdateInput.swift
+++ b/Buy/Generated/Storefront/CheckoutAttributesUpdateInput.swift
@@ -66,7 +66,7 @@ extension Storefront {
 		///
 		@available(*, deprecated, message: "Use the static create() method instead.")
 		public convenience init(note: String? = nil, customAttributes: [AttributeInput]? = nil, allowPartialAddresses: Bool? = nil) {
-			self.init(note: note.orNull, customAttributes: customAttributes.orNull, allowPartialAddresses: allowPartialAddresses.orNull)
+			self.init(note: note.orUndefined, customAttributes: customAttributes.orUndefined, allowPartialAddresses: allowPartialAddresses.orUndefined)
 		}
 
 		internal func serialize() -> String {

--- a/Buy/Generated/Storefront/CheckoutCreateInput.swift
+++ b/Buy/Generated/Storefront/CheckoutCreateInput.swift
@@ -85,7 +85,7 @@ extension Storefront {
 		///
 		@available(*, deprecated, message: "Use the static create() method instead.")
 		public convenience init(email: String? = nil, lineItems: [CheckoutLineItemInput]? = nil, shippingAddress: MailingAddressInput? = nil, note: String? = nil, customAttributes: [AttributeInput]? = nil, allowPartialAddresses: Bool? = nil) {
-			self.init(email: email.orNull, lineItems: lineItems.orNull, shippingAddress: shippingAddress.orNull, note: note.orNull, customAttributes: customAttributes.orNull, allowPartialAddresses: allowPartialAddresses.orNull)
+			self.init(email: email.orUndefined, lineItems: lineItems.orUndefined, shippingAddress: shippingAddress.orUndefined, note: note.orUndefined, customAttributes: customAttributes.orUndefined, allowPartialAddresses: allowPartialAddresses.orUndefined)
 		}
 
 		internal func serialize() -> String {

--- a/Buy/Generated/Storefront/CheckoutLineItemInput.swift
+++ b/Buy/Generated/Storefront/CheckoutLineItemInput.swift
@@ -65,7 +65,7 @@ extension Storefront {
 		///
 		@available(*, deprecated, message: "Use the static create() method instead.")
 		public convenience init(quantity: Int32, variantId: GraphQL.ID, customAttributes: [AttributeInput]? = nil) {
-			self.init(quantity: quantity, variantId: variantId, customAttributes: customAttributes.orNull)
+			self.init(quantity: quantity, variantId: variantId, customAttributes: customAttributes.orUndefined)
 		}
 
 		internal func serialize() -> String {

--- a/Buy/Generated/Storefront/CheckoutLineItemUpdateInput.swift
+++ b/Buy/Generated/Storefront/CheckoutLineItemUpdateInput.swift
@@ -70,7 +70,7 @@ extension Storefront {
 		///
 		@available(*, deprecated, message: "Use the static create() method instead.")
 		public convenience init(id: GraphQL.ID? = nil, variantId: GraphQL.ID? = nil, quantity: Int32? = nil, customAttributes: [AttributeInput]? = nil) {
-			self.init(id: id.orNull, variantId: variantId.orNull, quantity: quantity.orNull, customAttributes: customAttributes.orNull)
+			self.init(id: id.orUndefined, variantId: variantId.orUndefined, quantity: quantity.orUndefined, customAttributes: customAttributes.orUndefined)
 		}
 
 		internal func serialize() -> String {

--- a/Buy/Generated/Storefront/CreditCardPaymentInput.swift
+++ b/Buy/Generated/Storefront/CreditCardPaymentInput.swift
@@ -79,7 +79,7 @@ extension Storefront {
 		///
 		@available(*, deprecated, message: "Use the static create() method instead.")
 		public convenience init(amount: Decimal, idempotencyKey: String, billingAddress: MailingAddressInput, vaultId: String, test: Bool? = nil) {
-			self.init(amount: amount, idempotencyKey: idempotencyKey, billingAddress: billingAddress, vaultId: vaultId, test: test.orNull)
+			self.init(amount: amount, idempotencyKey: idempotencyKey, billingAddress: billingAddress, vaultId: vaultId, test: test.orUndefined)
 		}
 
 		internal func serialize() -> String {

--- a/Buy/Generated/Storefront/CurrencyCode.swift
+++ b/Buy/Generated/Storefront/CurrencyCode.swift
@@ -371,6 +371,9 @@ extension Storefront {
 		/// Syrian Pound (SYP) 
 		case syp = "SYP"
 
+		/// Swazi Lilangeni (SZL) 
+		case szl = "SZL"
+
 		/// Thai baht (THB) 
 		case thb = "THB"
 

--- a/Buy/Generated/Storefront/CustomerCreateInput.swift
+++ b/Buy/Generated/Storefront/CustomerCreateInput.swift
@@ -83,7 +83,7 @@ extension Storefront {
 		///
 		@available(*, deprecated, message: "Use the static create() method instead.")
 		public convenience init(email: String, password: String, firstName: String? = nil, lastName: String? = nil, phone: String? = nil, acceptsMarketing: Bool? = nil) {
-			self.init(email: email, password: password, firstName: firstName.orNull, lastName: lastName.orNull, phone: phone.orNull, acceptsMarketing: acceptsMarketing.orNull)
+			self.init(email: email, password: password, firstName: firstName.orUndefined, lastName: lastName.orUndefined, phone: phone.orUndefined, acceptsMarketing: acceptsMarketing.orUndefined)
 		}
 
 		internal func serialize() -> String {

--- a/Buy/Generated/Storefront/CustomerUpdateInput.swift
+++ b/Buy/Generated/Storefront/CustomerUpdateInput.swift
@@ -83,7 +83,7 @@ extension Storefront {
 		///
 		@available(*, deprecated, message: "Use the static create() method instead.")
 		public convenience init(firstName: String? = nil, lastName: String? = nil, email: String? = nil, phone: String? = nil, password: String? = nil, acceptsMarketing: Bool? = nil) {
-			self.init(firstName: firstName.orNull, lastName: lastName.orNull, email: email.orNull, phone: phone.orNull, password: password.orNull, acceptsMarketing: acceptsMarketing.orNull)
+			self.init(firstName: firstName.orUndefined, lastName: lastName.orUndefined, email: email.orUndefined, phone: phone.orUndefined, password: password.orUndefined, acceptsMarketing: acceptsMarketing.orUndefined)
 		}
 
 		internal func serialize() -> String {

--- a/Buy/Generated/Storefront/MailingAddressInput.swift
+++ b/Buy/Generated/Storefront/MailingAddressInput.swift
@@ -96,7 +96,7 @@ extension Storefront {
 		///
 		@available(*, deprecated, message: "Use the static create() method instead.")
 		public convenience init(address1: String? = nil, address2: String? = nil, city: String? = nil, company: String? = nil, country: String? = nil, firstName: String? = nil, lastName: String? = nil, phone: String? = nil, province: String? = nil, zip: String? = nil) {
-			self.init(address1: address1.orNull, address2: address2.orNull, city: city.orNull, company: company.orNull, country: country.orNull, firstName: firstName.orNull, lastName: lastName.orNull, phone: phone.orNull, province: province.orNull, zip: zip.orNull)
+			self.init(address1: address1.orUndefined, address2: address2.orUndefined, city: city.orUndefined, company: company.orUndefined, country: country.orUndefined, firstName: firstName.orUndefined, lastName: lastName.orUndefined, phone: phone.orUndefined, province: province.orUndefined, zip: zip.orUndefined)
 		}
 
 		internal func serialize() -> String {

--- a/Buy/Generated/Storefront/TokenizedPaymentInput.swift
+++ b/Buy/Generated/Storefront/TokenizedPaymentInput.swift
@@ -92,7 +92,7 @@ extension Storefront {
 		///
 		@available(*, deprecated, message: "Use the static create() method instead.")
 		public convenience init(amount: Decimal, idempotencyKey: String, billingAddress: MailingAddressInput, type: String, paymentData: String, test: Bool? = nil, identifier: String? = nil) {
-			self.init(amount: amount, idempotencyKey: idempotencyKey, billingAddress: billingAddress, type: type, paymentData: paymentData, test: test.orNull, identifier: identifier.orNull)
+			self.init(amount: amount, idempotencyKey: idempotencyKey, billingAddress: billingAddress, type: type, paymentData: paymentData, test: test.orUndefined, identifier: identifier.orUndefined)
 		}
 
 		internal func serialize() -> String {


### PR DESCRIPTION
### What this does

Fixes an issues where deprecated input object initializers were assigning `.orNull` values instead of `.orUndefined` values.