### PR TITLE
Require shopName for PaySession

### DIFF
--- a/Pay/PayCheckout.swift
+++ b/Pay/PayCheckout.swift
@@ -71,7 +71,7 @@ public struct PayCheckout {
 //
 internal extension PayCheckout {
 
-    var summaryItems: [PKPaymentSummaryItem] {
+    func summaryItems(for shop: String) -> [PKPaymentSummaryItem] {
         var summaryItems: [PKPaymentSummaryItem] = []
 
         if self.hasLineItems || self.discount != nil {
@@ -103,7 +103,7 @@ internal extension PayCheckout {
         //            }
         //        }
 
-        summaryItems.append(self.paymentDue.summaryItemNamed("TOTAL"))
+        summaryItems.append(self.paymentDue.summaryItemNamed(shop))
 
         return summaryItems
     }

--- a/PayTests/Models/Models.swift
+++ b/PayTests/Models/Models.swift
@@ -67,7 +67,7 @@ struct Models {
     //  MARK: - Pay Models -
     //
     static func createSession(checkout: PayCheckout, currency: PayCurrency) -> MockPaySession {
-        return MockPaySession(checkout: checkout, currency: currency, merchantID: "com.merchant.identifier", controllerType: MockAuthorizationController.self)
+        return MockPaySession(shopName: "Jaded Labs", checkout: checkout, currency: currency, merchantID: "com.merchant.identifier", controllerType: MockAuthorizationController.self)
     }
     
     static func createDiscount() -> PayDiscount {

--- a/PayTests/PayCheckoutTests.swift
+++ b/PayTests/PayCheckoutTests.swift
@@ -30,6 +30,8 @@ import XCTest
 @available(iOS 11.0, *)
 class PayCheckoutTests: XCTestCase {
 
+    private let shopName = "SHOPIFY"
+    
     // ----------------------------------
     //  MARK: - Init -
     //
@@ -68,54 +70,54 @@ class PayCheckoutTests: XCTestCase {
     //
     func testSummaryItemsWithTaxes() {
         let checkout     = Models.createCheckout(requiresShipping: false)
-        let summaryItems = checkout.summaryItems
+        let summaryItems = checkout.summaryItems(for: self.shopName)
         
         XCTAssertEqual(summaryItems.count, 4)
         XCTAssertEqual(summaryItems[0].label, "CART TOTAL")
         XCTAssertEqual(summaryItems[1].label, "SUBTOTAL")
         XCTAssertEqual(summaryItems[2].label, "TAXES")
-        XCTAssertEqual(summaryItems[3].label, "TOTAL")
+        XCTAssertEqual(summaryItems[3].label, "SHOPIFY")
     }
     
     func testSummaryItemsWithShipping() {
         let address      = Models.createAddress()
         let rate         = Models.createShippingRate()
         let checkout     = Models.createCheckout(requiresShipping: true, shippingAddress: address, shippingRate: rate)
-        let summaryItems = checkout.summaryItems
+        let summaryItems = checkout.summaryItems(for: self.shopName)
         
         XCTAssertEqual(summaryItems.count, 5)
         XCTAssertEqual(summaryItems[0].label, "CART TOTAL")
         XCTAssertEqual(summaryItems[1].label, "SUBTOTAL")
         XCTAssertEqual(summaryItems[2].label, "SHIPPING")
         XCTAssertEqual(summaryItems[3].label, "TAXES")
-        XCTAssertEqual(summaryItems[4].label, "TOTAL")
+        XCTAssertEqual(summaryItems[4].label, "SHOPIFY")
     }
     
     func testSummaryItemsWithoutTax() {
         let checkout     = Models.createCheckout(requiresShipping: false, hasTax: false)
-        let summaryItems = checkout.summaryItems
+        let summaryItems = checkout.summaryItems(for: self.shopName)
         
         XCTAssertEqual(summaryItems.count, 3)
         XCTAssertEqual(summaryItems[0].label, "CART TOTAL")
         XCTAssertEqual(summaryItems[1].label, "SUBTOTAL")
-        XCTAssertEqual(summaryItems[2].label, "TOTAL")
+        XCTAssertEqual(summaryItems[2].label, "SHOPIFY")
     }
     
     func testSummaryItemsWithDiscount() {
         let discount     = Models.createDiscount()
         let checkout     = Models.createCheckout(requiresShipping: false, discount: discount, empty: true, hasTax: false)
-        var summaryItems = checkout.summaryItems
+        var summaryItems = checkout.summaryItems(for: self.shopName)
         
         XCTAssertEqual(summaryItems.count, 4)
         XCTAssertEqual(summaryItems[0].label, "CART TOTAL")
         XCTAssertEqual(summaryItems[1].label, "DISCOUNT (WIN20)")
         XCTAssertEqual(summaryItems[2].label, "SUBTOTAL")
-        XCTAssertEqual(summaryItems[3].label, "TOTAL")
+        XCTAssertEqual(summaryItems[3].label, "SHOPIFY")
         
         let anonymousDiscount = Models.createAnonymousDiscount()
         let checkout2         = Models.createCheckout(requiresShipping: false, discount: anonymousDiscount, empty: true, hasTax: false)
         
-        summaryItems = checkout2.summaryItems
+        summaryItems = checkout2.summaryItems(for: self.shopName)
         
         XCTAssertEqual(summaryItems[1].label, "DISCOUNT")
     }

--- a/Sample Apps/Storefront/Storefront/Client.swift
+++ b/Sample Apps/Storefront/Storefront/Client.swift
@@ -46,6 +46,28 @@ final class Client {
     }
     
     // ----------------------------------
+    //  MARK: - Shop -
+    //
+    @discardableResult
+    func fetchShopName(completion: @escaping (String?) -> Void) -> Task {
+        
+        let query = ClientQuery.queryForShopName()
+        let task  = self.client.queryGraphWith(query) { (query, error) in
+            error.debugPrint()
+            
+            if let query = query {
+                completion(query.shop.name)
+            } else {
+                print("Failed to fetch shop name: \(String(describing: error))")
+                completion(nil)
+            }
+        }
+        
+        task.resume()
+        return task
+    }
+    
+    // ----------------------------------
     //  MARK: - Collections -
     //
     @discardableResult

--- a/Sample Apps/Storefront/Storefront/ClientQuery.swift
+++ b/Sample Apps/Storefront/Storefront/ClientQuery.swift
@@ -31,6 +31,17 @@ import Pay
 final class ClientQuery {
 
     // ----------------------------------
+    //  MARK: - Shop -
+    //
+    static func queryForShopName() -> Storefront.QueryRootQuery {
+        return Storefront.buildQuery { $0
+            .shop { $0
+                .name()
+            }
+        }
+    }
+    
+    // ----------------------------------
     //  MARK: - Storefront -
     //
     static func queryForCollections(limit: Int, after cursor: String? = nil, productLimit: Int = 25, productCursor: String? = nil) -> Storefront.QueryRootQuery {


### PR DESCRIPTION
### What this does

Updates `PaySession` to require a `shopName` for creating Apple Pay payment sessions. A shop name is required to accurately reflect the entity to which the payment is being made by the customer.

Updates tests and sample app.

Fixes #781 
