### PR TITLE
Fix incorrect subtotal in Apple Pay dialog.

### DIFF
--- a/Sample Apps/Storefront/Storefront/CartViewController.swift
+++ b/Sample Apps/Storefront/Storefront/CartViewController.swift
@@ -120,7 +120,7 @@ class CartViewController: ParallaxViewController {
     func authorizePaymentFor(_ shopName: String, in checkout: CheckoutViewModel) {
         let payCurrency = PayCurrency(currencyCode: "CAD", countryCode: "CA")
         let payItems    = checkout.lineItems.map { item in
-            PayLineItem(price: item.totalPrice, quantity: item.quantity)
+            PayLineItem(price: item.individualPrice, quantity: item.quantity)
         }
         
         let payCheckout = PayCheckout(

--- a/Sample Apps/Storefront/Storefront/CheckoutViewModel+PayCheckout.swift
+++ b/Sample Apps/Storefront/Storefront/CheckoutViewModel+PayCheckout.swift
@@ -31,7 +31,7 @@ extension CheckoutViewModel {
     var payCheckout: PayCheckout {
         
         let payItems = self.lineItems.map { item in
-            PayLineItem(price: item.totalPrice, quantity: item.quantity)
+            PayLineItem(price: item.individualPrice, quantity: item.quantity)
         }
         
         return PayCheckout(


### PR DESCRIPTION
### What this does

Fixes an issue in the sample that cause the Apple Pay dialog to accumulate incorrect values during checkout.

Fixes #861 
