### PR TITLE
Ignore retries for cancelled tasks, no completion.

### DIFF
--- a/Buy/Client/Graph.Task.swift
+++ b/Buy/Client/Graph.Task.swift
@@ -212,7 +212,11 @@ internal extension Graph {
                 let (model, error) = self.processResponse(data, response, error)
                 
                 DispatchQueue.main.async {
-                    if var retryHandler = retryHandler, !self.isCancelled, retryHandler.canRetry, retryHandler.condition(model, error) == true {
+                    guard self.isCancelled == false else {
+                        return
+                    }
+                    
+                    if var retryHandler = retryHandler, retryHandler.canRetry, retryHandler.condition(model, error) == true {
                         
                         /* ---------------------------------
                          ** A retry handler was provided and


### PR DESCRIPTION
### What this does

Remove the overhead of creating a task in the `isCancelled == true` state. Previously, we would create a task and only check if it's `.suspended` to determine whether to `resume()` it or not. Now, we check the cancelled flag before doing any of the above.

Adds test to verify behaviour.