### PR TITLE
Update deprecated PaySession initializer in tests.

### DIFF
--- a/PayTests/PaySessionTests.swift
+++ b/PayTests/PaySessionTests.swift
@@ -50,7 +50,7 @@ class PaySessionTests: XCTestCase {
     func testDeprecatedInit() {
         let checkout = Models.createCheckout()
         let currency = Models.createCurrency()
-        let session  = PaySession(checkout: checkout, currency: currency, merchantID: "some-id")
+        let session  = PaySession(shopName: "test", checkout: checkout, currency: currency, merchantID: "some-id")
         
         XCTAssertEqual(session.shopName, "TOTAL")
     }


### PR DESCRIPTION
### What this does

Update deprecated initializer in `PaySession` tests.
