### PR TITLE
Associate logged-in use with web checkout.

### DIFF
--- a/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
+++ b/Sample Apps/Storefront/Storefront.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		9A4EDDE721270F620071BA56 /* OrderCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A4EDDE521270F620071BA56 /* OrderCell.xib */; };
 		9A4EDDE9212ADDF10071BA56 /* CustomerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4EDDE8212ADDF10071BA56 /* CustomerViewModel.swift */; };
 		9A4EDDEB212AE8C80071BA56 /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4EDDEA212AE8C80071BA56 /* ProfileViewController.swift */; };
+		9A4EDDF4212B30510071BA56 /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4EDDF3212B30510071BA56 /* WebViewController.swift */; };
 		9A7E3F6F1E89615E00713740 /* UICollectionView+Touch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7E3F6E1E89615E00713740 /* UICollectionView+Touch.swift */; };
 		9A8E88511E719A6E0042879D /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8E88501E719A6E0042879D /* Client.swift */; };
 		9A8E885A1E719EB20042879D /* ClientQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8E88591E719EB20042879D /* ClientQuery.swift */; };
@@ -192,6 +193,7 @@
 		9A4EDDE521270F620071BA56 /* OrderCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderCell.xib; sourceTree = "<group>"; };
 		9A4EDDE8212ADDF10071BA56 /* CustomerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerViewModel.swift; sourceTree = "<group>"; };
 		9A4EDDEA212AE8C80071BA56 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
+		9A4EDDF3212B30510071BA56 /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
 		9A52D3BB1F3F25C300C093C8 /* Storefront.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Storefront.entitlements; sourceTree = "<group>"; };
 		9A7E3F6E1E89615E00713740 /* UICollectionView+Touch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UICollectionView+Touch.swift"; sourceTree = "<group>"; };
 		9A8E88501E719A6E0042879D /* Client.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
@@ -489,6 +491,7 @@
 				9AC583C81E81BEF8005DB319 /* CartViewController.swift */,
 				9AC583D11E81C165005DB319 /* CartNavigationController.swift */,
 				9ADCC88A1E82FE2900F5B6DD /* TotalsViewController.swift */,
+				9A4EDDF3212B30510071BA56 /* WebViewController.swift */,
 			);
 			name = Cart;
 			sourceTree = "<group>";
@@ -786,6 +789,7 @@
 				9A27C3201E8FD99200218EE8 /* CheckoutViewModel.swift in Sources */,
 				9AAFAB801E60BE9800864A17 /* ViewModelConfigurable.swift in Sources */,
 				9A9FFF2C1E8144F300F6DFF7 /* RoundedButton.swift in Sources */,
+				9A4EDDF4212B30510071BA56 /* WebViewController.swift in Sources */,
 				9AEF61CE1E606F100067FA90 /* Fragment+ImageConnectionQuery.swift in Sources */,
 				9ADAD46B1E563091008AC561 /* AppDelegate.swift in Sources */,
 				9AC583D41E829597005DB319 /* CartItemViewModel.swift in Sources */,

--- a/Sample Apps/Storefront/Storefront/Base.lproj/Main.storyboard
+++ b/Sample Apps/Storefront/Storefront/Base.lproj/Main.storyboard
@@ -587,13 +587,13 @@
                                             <rect key="frame" x="110" y="57" width="155.5" height="66.5"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="John Smith" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gBF-YP-vjT">
-                                                    <rect key="frame" x="24" y="0.0" width="108" height="26"/>
+                                                    <rect key="frame" x="24" y="0.0" width="108" height="26.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="22"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="john.smith@gmail.com" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mu9-61-Z0H">
-                                                    <rect key="frame" x="0.0" y="28" width="156" height="18"/>
+                                                    <rect key="frame" x="0.0" y="28.5" width="155.5" height="18"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>

--- a/Sample Apps/Storefront/Storefront/CartViewController.swift
+++ b/Sample Apps/Storefront/Storefront/CartViewController.swift
@@ -112,9 +112,9 @@ class CartViewController: ParallaxViewController {
     //  MARK: - Actions -
     //
     func openSafariFor(_ checkout: CheckoutViewModel) {
-        let safari                  = SFSafariViewController(url: checkout.webURL)
-        safari.navigationItem.title = "Checkout"
-        self.navigationController?.present(safari, animated: true, completion: nil)
+        let webController = WebViewController(url: checkout.webURL, accessToken: AccountController.shared.accessToken)
+        webController.navigationItem.title = "Checkout"
+        self.navigationController?.pushViewController(webController, animated: true)
     }
     
     func authorizePaymentFor(_ shopName: String, in checkout: CheckoutViewModel) {
@@ -265,7 +265,21 @@ extension CartViewController: TotalsControllerDelegate {
                 }
                 
                 group.notify(queue: .main) {
-                    completeCreateCheckout(updatedCheckout)
+                    if let accessToken = AccountController.shared.accessToken {
+                        
+                        print("Associating checkout with customer: \(accessToken)")
+                        Client.shared.updateCheckout(updatedCheckout.id, associatingCustomer: accessToken) { associatedCheckout in
+                            if let associatedCheckout = associatedCheckout {
+                                completeCreateCheckout(associatedCheckout)
+                            } else {
+                                print("Failed to associate checkout with customer.")
+                                completeCreateCheckout(updatedCheckout)
+                            }
+                        }
+                        
+                    } else {
+                        completeCreateCheckout(updatedCheckout)
+                    }
                 }
             }
         }

--- a/Sample Apps/Storefront/Storefront/Client.swift
+++ b/Sample Apps/Storefront/Storefront/Client.swift
@@ -310,6 +310,24 @@ final class Client {
     }
     
     @discardableResult
+    func updateCheckout(_ id: String, associatingCustomer accessToken: String, completion: @escaping (CheckoutViewModel?) -> Void) -> Task {
+        
+        let mutation = ClientQuery.mutationForUpdateCheckout(id, associatingCustomer: accessToken)
+        let task     = self.client.mutateGraphWith(mutation) { (mutation, error) in
+            error.debugPrint()
+            
+            if let checkout = mutation?.checkoutCustomerAssociate?.checkout {
+                completion(checkout.viewModel)
+            } else {
+                completion(nil)
+            }
+        }
+        
+        task.resume()
+        return task
+    }
+    
+    @discardableResult
     func fetchShippingRatesForCheckout(_ id: String, completion: @escaping ((checkout: CheckoutViewModel, rates: [ShippingRateViewModel])?) -> Void) -> Task {
         
         let retry = Graph.RetryHandler<Storefront.QueryRoot>(endurance: .finite(30)) { response, error -> Bool in

--- a/Sample Apps/Storefront/Storefront/ClientQuery.swift
+++ b/Sample Apps/Storefront/Storefront/ClientQuery.swift
@@ -274,6 +274,21 @@ final class ClientQuery {
         }
     }
     
+    static func mutationForUpdateCheckout(_ checkoutID: String, associatingCustomer accessToken: String) -> Storefront.MutationQuery {
+        let id = GraphQL.ID(rawValue: checkoutID)
+        return Storefront.buildMutation { $0
+            .checkoutCustomerAssociate(checkoutId: id, customerAccessToken: accessToken) { $0
+                .userErrors { $0
+                    .field()
+                    .message()
+                }
+                .checkout { $0
+                    .fragmentForCheckout()
+                }
+            }
+        }
+    }
+    
     static func mutationForCompleteCheckoutUsingApplePay(_ checkout: PayCheckout, billingAddress: PayAddress, token: String, idempotencyToken: String) -> Storefront.MutationQuery {
         
         let mailingAddress = Storefront.MailingAddressInput.create(

--- a/Sample Apps/Storefront/Storefront/WebViewController.swift
+++ b/Sample Apps/Storefront/Storefront/WebViewController.swift
@@ -1,0 +1,79 @@
+//
+//  WebViewController.swift
+//  Storefront
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import UIKit
+import WebKit
+
+class WebViewController: UIViewController {
+    
+    let url: URL
+    let accessToken: String?
+    
+    private let webView = WKWebView(frame: .zero)
+    
+    // ----------------------------------
+    //  MARK: - Init -
+    //
+    init(url: URL, accessToken: String?) {
+        self.url         = url
+        self.accessToken = accessToken
+        
+        super.init(nibName: nil, bundle: nil)
+        
+        self.initialize()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError()
+    }
+    
+    private func initialize() {
+        self.webView.translatesAutoresizingMaskIntoConstraints = false
+        self.view.addSubview(self.webView)
+        
+        NSLayoutConstraint.activate([
+            self.webView.leftAnchor.constraint(equalTo: self.view.leftAnchor),
+            self.webView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+            self.webView.rightAnchor.constraint(equalTo: self.view.rightAnchor),
+            self.webView.topAnchor.constraint(equalTo: self.view.topAnchor),
+        ])
+        
+        self.load(url: self.url)
+    }
+    
+    // ----------------------------------
+    //  MARK: - Request -
+    //
+    private func load(url: URL) {
+        var request = URLRequest(url: self.url)
+        
+        if let accessToken = self.accessToken {
+            request.setValue(accessToken, forHTTPHeaderField: "X-Shopify-Customer-Access-Token")
+        }
+        
+        self.webView.load(request)
+    }
+}


### PR DESCRIPTION
### What this does

Adds support for associating a currently logged-in user with a checkout. Using a `WKWebView` is necessary since a custom header is required to transfer authentication state to web checkout.
