### PR TITLE
Use short bundle version, it’s more reliable.

### DIFF
--- a/Buy/Utilities/Global.swift
+++ b/Buy/Utilities/Global.swift
@@ -39,7 +39,7 @@ class Global {
     //  MARK: - Versions -
     //
     static var frameworkVersion: String {
-        return self.frameworkBundle.object(forInfoDictionaryKey: kCFBundleVersionKey as String) as! String
+        return self.frameworkBundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
     }
     
     static var applicationIdentifier: String {


### PR DESCRIPTION
### What this does

Updates to how we determine and send the SDK version in request headers. This a more reliable alternative to `CFBundleVersionKey`. CocoaPods doesn't respect that value and uses `1` instead. Migrating to "short version" string instead fixies the problem.
