### PR TITLE
Bump schema.

### DIFF
--- a/Buy/Generated/Storefront/AppliedGiftCard.swift
+++ b/Buy/Generated/Storefront/AppliedGiftCard.swift
@@ -32,16 +32,38 @@ extension Storefront {
 		public typealias Response = AppliedGiftCard
 
 		/// The amount that was used taken from the Gift Card by applying it. 
+		@available(*, deprecated, message:"Use `amountUsedV2` instead")
 		@discardableResult
 		open func amountUsed(alias: String? = nil) -> AppliedGiftCardQuery {
 			addField(field: "amountUsed", aliasSuffix: alias)
 			return self
 		}
 
+		/// The amount that was used taken from the Gift Card by applying it. 
+		@discardableResult
+		open func amountUsedV2(alias: String? = nil, _ subfields: (MoneyV2Query) -> Void) -> AppliedGiftCardQuery {
+			let subquery = MoneyV2Query()
+			subfields(subquery)
+
+			addField(field: "amountUsedV2", aliasSuffix: alias, subfields: subquery)
+			return self
+		}
+
 		/// The amount left on the Gift Card. 
+		@available(*, deprecated, message:"Use `balanceV2` instead")
 		@discardableResult
 		open func balance(alias: String? = nil) -> AppliedGiftCardQuery {
 			addField(field: "balance", aliasSuffix: alias)
+			return self
+		}
+
+		/// The amount left on the Gift Card. 
+		@discardableResult
+		open func balanceV2(alias: String? = nil, _ subfields: (MoneyV2Query) -> Void) -> AppliedGiftCardQuery {
+			let subquery = MoneyV2Query()
+			subfields(subquery)
+
+			addField(field: "balanceV2", aliasSuffix: alias, subfields: subquery)
 			return self
 		}
 
@@ -73,11 +95,23 @@ extension Storefront {
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
 
+				case "amountUsedV2":
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: AppliedGiftCard.self, field: fieldName, value: fieldValue)
+				}
+				return try MoneyV2(fields: value)
+
 				case "balance":
 				guard let value = value as? String else {
 					throw SchemaViolationError(type: AppliedGiftCard.self, field: fieldName, value: fieldValue)
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
+
+				case "balanceV2":
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: AppliedGiftCard.self, field: fieldName, value: fieldValue)
+				}
+				return try MoneyV2(fields: value)
 
 				case "id":
 				guard let value = value as? String else {
@@ -97,6 +131,7 @@ extension Storefront {
 		}
 
 		/// The amount that was used taken from the Gift Card by applying it. 
+		@available(*, deprecated, message:"Use `amountUsedV2` instead")
 		open var amountUsed: Decimal {
 			return internalGetAmountUsed()
 		}
@@ -105,13 +140,32 @@ extension Storefront {
 			return field(field: "amountUsed", aliasSuffix: alias) as! Decimal
 		}
 
+		/// The amount that was used taken from the Gift Card by applying it. 
+		open var amountUsedV2: Storefront.MoneyV2 {
+			return internalGetAmountUsedV2()
+		}
+
+		func internalGetAmountUsedV2(alias: String? = nil) -> Storefront.MoneyV2 {
+			return field(field: "amountUsedV2", aliasSuffix: alias) as! Storefront.MoneyV2
+		}
+
 		/// The amount left on the Gift Card. 
+		@available(*, deprecated, message:"Use `balanceV2` instead")
 		open var balance: Decimal {
 			return internalGetBalance()
 		}
 
 		func internalGetBalance(alias: String? = nil) -> Decimal {
 			return field(field: "balance", aliasSuffix: alias) as! Decimal
+		}
+
+		/// The amount left on the Gift Card. 
+		open var balanceV2: Storefront.MoneyV2 {
+			return internalGetBalanceV2()
+		}
+
+		func internalGetBalanceV2(alias: String? = nil) -> Storefront.MoneyV2 {
+			return field(field: "balanceV2", aliasSuffix: alias) as! Storefront.MoneyV2
 		}
 
 		/// Globally unique identifier. 
@@ -133,7 +187,22 @@ extension Storefront {
 		}
 
 		internal override func childResponseObjectMap() -> [GraphQL.AbstractResponse]  {
-			return []
+			var response: [GraphQL.AbstractResponse] = []
+			objectMap.keys.forEach {
+				switch($0) {
+					case "amountUsedV2":
+					response.append(internalGetAmountUsedV2())
+					response.append(contentsOf: internalGetAmountUsedV2().childResponseObjectMap())
+
+					case "balanceV2":
+					response.append(internalGetBalanceV2())
+					response.append(contentsOf: internalGetBalanceV2().childResponseObjectMap())
+
+					default:
+					break
+				}
+			}
+			return response
 		}
 	}
 }

--- a/Buy/Generated/Storefront/Checkout.swift
+++ b/Buy/Generated/Storefront/Checkout.swift
@@ -192,6 +192,17 @@ extension Storefront {
 			return self
 		}
 
+		/// The sum of all the prices of all the items in the checkout. Taxes, shipping 
+		/// and discounts excluded. 
+		@discardableResult
+		open func lineItemsSubtotalPrice(alias: String? = nil, _ subfields: (MoneyV2Query) -> Void) -> CheckoutQuery {
+			let subquery = MoneyV2Query()
+			subfields(subquery)
+
+			addField(field: "lineItemsSubtotalPrice", aliasSuffix: alias, subfields: subquery)
+			return self
+		}
+
 		@discardableResult
 		open func note(alias: String? = nil) -> CheckoutQuery {
 			addField(field: "note", aliasSuffix: alias)
@@ -218,9 +229,21 @@ extension Storefront {
 
 		/// The amount left to be paid. This is equal to the cost of the line items, 
 		/// taxes and shipping minus discounts and gift cards. 
+		@available(*, deprecated, message:"Use `paymentDueV2` instead")
 		@discardableResult
 		open func paymentDue(alias: String? = nil) -> CheckoutQuery {
 			addField(field: "paymentDue", aliasSuffix: alias)
+			return self
+		}
+
+		/// The amount left to be paid. This is equal to the cost of the line items, 
+		/// taxes and shipping minus discounts and gift cards. 
+		@discardableResult
+		open func paymentDueV2(alias: String? = nil, _ subfields: (MoneyV2Query) -> Void) -> CheckoutQuery {
+			let subquery = MoneyV2Query()
+			subfields(subquery)
+
+			addField(field: "paymentDueV2", aliasSuffix: alias, subfields: subquery)
 			return self
 		}
 
@@ -274,9 +297,20 @@ extension Storefront {
 		}
 
 		/// Price of the checkout before shipping and taxes. 
+		@available(*, deprecated, message:"Use `subtotalPriceV2` instead")
 		@discardableResult
 		open func subtotalPrice(alias: String? = nil) -> CheckoutQuery {
 			addField(field: "subtotalPrice", aliasSuffix: alias)
+			return self
+		}
+
+		/// Price of the checkout before shipping and taxes. 
+		@discardableResult
+		open func subtotalPriceV2(alias: String? = nil, _ subfields: (MoneyV2Query) -> Void) -> CheckoutQuery {
+			let subquery = MoneyV2Query()
+			subfields(subquery)
+
+			addField(field: "subtotalPriceV2", aliasSuffix: alias, subfields: subquery)
 			return self
 		}
 
@@ -296,17 +330,41 @@ extension Storefront {
 
 		/// The sum of all the prices of all the items in the checkout, taxes and 
 		/// discounts included. 
+		@available(*, deprecated, message:"Use `totalPriceV2` instead")
 		@discardableResult
 		open func totalPrice(alias: String? = nil) -> CheckoutQuery {
 			addField(field: "totalPrice", aliasSuffix: alias)
 			return self
 		}
 
+		/// The sum of all the prices of all the items in the checkout, taxes and 
+		/// discounts included. 
+		@discardableResult
+		open func totalPriceV2(alias: String? = nil, _ subfields: (MoneyV2Query) -> Void) -> CheckoutQuery {
+			let subquery = MoneyV2Query()
+			subfields(subquery)
+
+			addField(field: "totalPriceV2", aliasSuffix: alias, subfields: subquery)
+			return self
+		}
+
 		/// The sum of all the taxes applied to the line items and shipping lines in 
 		/// the checkout. 
+		@available(*, deprecated, message:"Use `totalTaxV2` instead")
 		@discardableResult
 		open func totalTax(alias: String? = nil) -> CheckoutQuery {
 			addField(field: "totalTax", aliasSuffix: alias)
+			return self
+		}
+
+		/// The sum of all the taxes applied to the line items and shipping lines in 
+		/// the checkout. 
+		@discardableResult
+		open func totalTaxV2(alias: String? = nil, _ subfields: (MoneyV2Query) -> Void) -> CheckoutQuery {
+			let subquery = MoneyV2Query()
+			subfields(subquery)
+
+			addField(field: "totalTaxV2", aliasSuffix: alias, subfields: subquery)
 			return self
 		}
 
@@ -402,6 +460,12 @@ extension Storefront {
 				}
 				return try CheckoutLineItemConnection(fields: value)
 
+				case "lineItemsSubtotalPrice":
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
+				}
+				return try MoneyV2(fields: value)
+
 				case "note":
 				if value is NSNull { return nil }
 				guard let value = value as? String else {
@@ -428,6 +492,12 @@ extension Storefront {
 					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
+
+				case "paymentDueV2":
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
+				}
+				return try MoneyV2(fields: value)
 
 				case "ready":
 				guard let value = value as? Bool else {
@@ -467,6 +537,12 @@ extension Storefront {
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
 
+				case "subtotalPriceV2":
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
+				}
+				return try MoneyV2(fields: value)
+
 				case "taxExempt":
 				guard let value = value as? Bool else {
 					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
@@ -485,11 +561,23 @@ extension Storefront {
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
 
+				case "totalPriceV2":
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
+				}
+				return try MoneyV2(fields: value)
+
 				case "totalTax":
 				guard let value = value as? String else {
 					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
+
+				case "totalTaxV2":
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: Checkout.self, field: fieldName, value: fieldValue)
+				}
+				return try MoneyV2(fields: value)
 
 				case "updatedAt":
 				guard let value = value as? String else {
@@ -617,6 +705,16 @@ extension Storefront {
 			return field(field: "lineItems", aliasSuffix: alias) as! Storefront.CheckoutLineItemConnection
 		}
 
+		/// The sum of all the prices of all the items in the checkout. Taxes, shipping 
+		/// and discounts excluded. 
+		open var lineItemsSubtotalPrice: Storefront.MoneyV2 {
+			return internalGetLineItemsSubtotalPrice()
+		}
+
+		func internalGetLineItemsSubtotalPrice(alias: String? = nil) -> Storefront.MoneyV2 {
+			return field(field: "lineItemsSubtotalPrice", aliasSuffix: alias) as! Storefront.MoneyV2
+		}
+
 		open var note: String? {
 			return internalGetNote()
 		}
@@ -646,12 +744,23 @@ extension Storefront {
 
 		/// The amount left to be paid. This is equal to the cost of the line items, 
 		/// taxes and shipping minus discounts and gift cards. 
+		@available(*, deprecated, message:"Use `paymentDueV2` instead")
 		open var paymentDue: Decimal {
 			return internalGetPaymentDue()
 		}
 
 		func internalGetPaymentDue(alias: String? = nil) -> Decimal {
 			return field(field: "paymentDue", aliasSuffix: alias) as! Decimal
+		}
+
+		/// The amount left to be paid. This is equal to the cost of the line items, 
+		/// taxes and shipping minus discounts and gift cards. 
+		open var paymentDueV2: Storefront.MoneyV2 {
+			return internalGetPaymentDueV2()
+		}
+
+		func internalGetPaymentDueV2(alias: String? = nil) -> Storefront.MoneyV2 {
+			return field(field: "paymentDueV2", aliasSuffix: alias) as! Storefront.MoneyV2
 		}
 
 		/// Whether or not the Checkout is ready and can be completed. Checkouts may 
@@ -705,12 +814,22 @@ extension Storefront {
 		}
 
 		/// Price of the checkout before shipping and taxes. 
+		@available(*, deprecated, message:"Use `subtotalPriceV2` instead")
 		open var subtotalPrice: Decimal {
 			return internalGetSubtotalPrice()
 		}
 
 		func internalGetSubtotalPrice(alias: String? = nil) -> Decimal {
 			return field(field: "subtotalPrice", aliasSuffix: alias) as! Decimal
+		}
+
+		/// Price of the checkout before shipping and taxes. 
+		open var subtotalPriceV2: Storefront.MoneyV2 {
+			return internalGetSubtotalPriceV2()
+		}
+
+		func internalGetSubtotalPriceV2(alias: String? = nil) -> Storefront.MoneyV2 {
+			return field(field: "subtotalPriceV2", aliasSuffix: alias) as! Storefront.MoneyV2
 		}
 
 		/// Specifies if the Checkout is tax exempt. 
@@ -733,6 +852,7 @@ extension Storefront {
 
 		/// The sum of all the prices of all the items in the checkout, taxes and 
 		/// discounts included. 
+		@available(*, deprecated, message:"Use `totalPriceV2` instead")
 		open var totalPrice: Decimal {
 			return internalGetTotalPrice()
 		}
@@ -741,14 +861,35 @@ extension Storefront {
 			return field(field: "totalPrice", aliasSuffix: alias) as! Decimal
 		}
 
+		/// The sum of all the prices of all the items in the checkout, taxes and 
+		/// discounts included. 
+		open var totalPriceV2: Storefront.MoneyV2 {
+			return internalGetTotalPriceV2()
+		}
+
+		func internalGetTotalPriceV2(alias: String? = nil) -> Storefront.MoneyV2 {
+			return field(field: "totalPriceV2", aliasSuffix: alias) as! Storefront.MoneyV2
+		}
+
 		/// The sum of all the taxes applied to the line items and shipping lines in 
 		/// the checkout. 
+		@available(*, deprecated, message:"Use `totalTaxV2` instead")
 		open var totalTax: Decimal {
 			return internalGetTotalTax()
 		}
 
 		func internalGetTotalTax(alias: String? = nil) -> Decimal {
 			return field(field: "totalTax", aliasSuffix: alias) as! Decimal
+		}
+
+		/// The sum of all the taxes applied to the line items and shipping lines in 
+		/// the checkout. 
+		open var totalTaxV2: Storefront.MoneyV2 {
+			return internalGetTotalTaxV2()
+		}
+
+		func internalGetTotalTaxV2(alias: String? = nil) -> Storefront.MoneyV2 {
+			return field(field: "totalTaxV2", aliasSuffix: alias) as! Storefront.MoneyV2
 		}
 
 		/// The date and time when the checkout was last updated. 
@@ -805,11 +946,19 @@ extension Storefront {
 					response.append(internalGetLineItems())
 					response.append(contentsOf: internalGetLineItems().childResponseObjectMap())
 
+					case "lineItemsSubtotalPrice":
+					response.append(internalGetLineItemsSubtotalPrice())
+					response.append(contentsOf: internalGetLineItemsSubtotalPrice().childResponseObjectMap())
+
 					case "order":
 					if let value = internalGetOrder() {
 						response.append(value)
 						response.append(contentsOf: value.childResponseObjectMap())
 					}
+
+					case "paymentDueV2":
+					response.append(internalGetPaymentDueV2())
+					response.append(contentsOf: internalGetPaymentDueV2().childResponseObjectMap())
 
 					case "shippingAddress":
 					if let value = internalGetShippingAddress() {
@@ -828,6 +977,18 @@ extension Storefront {
 						response.append(value)
 						response.append(contentsOf: value.childResponseObjectMap())
 					}
+
+					case "subtotalPriceV2":
+					response.append(internalGetSubtotalPriceV2())
+					response.append(contentsOf: internalGetSubtotalPriceV2().childResponseObjectMap())
+
+					case "totalPriceV2":
+					response.append(internalGetTotalPriceV2())
+					response.append(contentsOf: internalGetTotalPriceV2().childResponseObjectMap())
+
+					case "totalTaxV2":
+					response.append(internalGetTotalTaxV2())
+					response.append(contentsOf: internalGetTotalTaxV2().childResponseObjectMap())
 
 					default:
 					break

--- a/Buy/Generated/Storefront/CheckoutCreateInput.swift
+++ b/Buy/Generated/Storefront/CheckoutCreateInput.swift
@@ -50,6 +50,10 @@ extension Storefront {
 		/// country. Full validation of addresses is still done at complete time. 
 		open var allowPartialAddresses: Input<Bool>
 
+		/// The currency code of one of the shop's enabled presentment currencies. If 
+		/// the shop uses Shopify Payments, then the checkout is set to this currency. 
+		open var presentmentCurrencyCode: Input<CurrencyCode>
+
 		/// Creates the input object.
 		///
 		/// - parameters:
@@ -59,18 +63,20 @@ extension Storefront {
 		///     - note: The text of an optional note that a shop owner can attach to the checkout.
 		///     - customAttributes: A list of extra information that is added to the checkout.
 		///     - allowPartialAddresses: Allows setting partial addresses on a Checkout, skipping the full validation of attributes. The required attributes are city, province, and country. Full validation of addresses is still done at complete time. 
+		///     - presentmentCurrencyCode: The currency code of one of the shop's enabled presentment currencies. If the shop uses Shopify Payments, then the checkout is set to this currency.
 		///
-		public static func create(email: Input<String> = .undefined, lineItems: Input<[CheckoutLineItemInput]> = .undefined, shippingAddress: Input<MailingAddressInput> = .undefined, note: Input<String> = .undefined, customAttributes: Input<[AttributeInput]> = .undefined, allowPartialAddresses: Input<Bool> = .undefined) -> CheckoutCreateInput {
-			return CheckoutCreateInput(email: email, lineItems: lineItems, shippingAddress: shippingAddress, note: note, customAttributes: customAttributes, allowPartialAddresses: allowPartialAddresses)
+		public static func create(email: Input<String> = .undefined, lineItems: Input<[CheckoutLineItemInput]> = .undefined, shippingAddress: Input<MailingAddressInput> = .undefined, note: Input<String> = .undefined, customAttributes: Input<[AttributeInput]> = .undefined, allowPartialAddresses: Input<Bool> = .undefined, presentmentCurrencyCode: Input<CurrencyCode> = .undefined) -> CheckoutCreateInput {
+			return CheckoutCreateInput(email: email, lineItems: lineItems, shippingAddress: shippingAddress, note: note, customAttributes: customAttributes, allowPartialAddresses: allowPartialAddresses, presentmentCurrencyCode: presentmentCurrencyCode)
 		}
 
-		private init(email: Input<String> = .undefined, lineItems: Input<[CheckoutLineItemInput]> = .undefined, shippingAddress: Input<MailingAddressInput> = .undefined, note: Input<String> = .undefined, customAttributes: Input<[AttributeInput]> = .undefined, allowPartialAddresses: Input<Bool> = .undefined) {
+		private init(email: Input<String> = .undefined, lineItems: Input<[CheckoutLineItemInput]> = .undefined, shippingAddress: Input<MailingAddressInput> = .undefined, note: Input<String> = .undefined, customAttributes: Input<[AttributeInput]> = .undefined, allowPartialAddresses: Input<Bool> = .undefined, presentmentCurrencyCode: Input<CurrencyCode> = .undefined) {
 			self.email = email
 			self.lineItems = lineItems
 			self.shippingAddress = shippingAddress
 			self.note = note
 			self.customAttributes = customAttributes
 			self.allowPartialAddresses = allowPartialAddresses
+			self.presentmentCurrencyCode = presentmentCurrencyCode
 		}
 
 		/// Creates the input object.
@@ -82,10 +88,11 @@ extension Storefront {
 		///     - note: The text of an optional note that a shop owner can attach to the checkout.
 		///     - customAttributes: A list of extra information that is added to the checkout.
 		///     - allowPartialAddresses: Allows setting partial addresses on a Checkout, skipping the full validation of attributes. The required attributes are city, province, and country. Full validation of addresses is still done at complete time. 
+		///     - presentmentCurrencyCode: The currency code of one of the shop's enabled presentment currencies. If the shop uses Shopify Payments, then the checkout is set to this currency.
 		///
 		@available(*, deprecated, message: "Use the static create() method instead.")
-		public convenience init(email: String? = nil, lineItems: [CheckoutLineItemInput]? = nil, shippingAddress: MailingAddressInput? = nil, note: String? = nil, customAttributes: [AttributeInput]? = nil, allowPartialAddresses: Bool? = nil) {
-			self.init(email: email.orUndefined, lineItems: lineItems.orUndefined, shippingAddress: shippingAddress.orUndefined, note: note.orUndefined, customAttributes: customAttributes.orUndefined, allowPartialAddresses: allowPartialAddresses.orUndefined)
+		public convenience init(email: String? = nil, lineItems: [CheckoutLineItemInput]? = nil, shippingAddress: MailingAddressInput? = nil, note: String? = nil, customAttributes: [AttributeInput]? = nil, allowPartialAddresses: Bool? = nil, presentmentCurrencyCode: CurrencyCode? = nil) {
+			self.init(email: email.orUndefined, lineItems: lineItems.orUndefined, shippingAddress: shippingAddress.orUndefined, note: note.orUndefined, customAttributes: customAttributes.orUndefined, allowPartialAddresses: allowPartialAddresses.orUndefined, presentmentCurrencyCode: presentmentCurrencyCode.orUndefined)
 		}
 
 		internal func serialize() -> String {
@@ -148,6 +155,16 @@ extension Storefront {
 					break
 				}
 				fields.append("allowPartialAddresses:\(allowPartialAddresses)")
+				case .undefined: break
+			}
+
+			switch presentmentCurrencyCode {
+				case .value(let presentmentCurrencyCode): 
+				guard let presentmentCurrencyCode = presentmentCurrencyCode else {
+					fields.append("presentmentCurrencyCode:null")
+					break
+				}
+				fields.append("presentmentCurrencyCode:\(presentmentCurrencyCode.rawValue)")
 				case .undefined: break
 			}
 

--- a/Buy/Generated/Storefront/CurrencyCode.swift
+++ b/Buy/Generated/Storefront/CurrencyCode.swift
@@ -317,6 +317,9 @@ extension Storefront {
 		/// Omani Rial (OMR). 
 		case omr = "OMR"
 
+		/// Panamian Balboa (PAB). 
+		case pab = "PAB"
+
 		/// Peruvian Nuevo Sol (PEN). 
 		case pen = "PEN"
 

--- a/Buy/Generated/Storefront/PaymentSettings.swift
+++ b/Buy/Generated/Storefront/PaymentSettings.swift
@@ -59,6 +59,15 @@ extension Storefront {
 			return self
 		}
 
+		/// A list of enabled currencies (ISO 4217 format) that the shop accepts. 
+		/// Merchants can enable currencies from their Shopify Payments settings in the 
+		/// Shopify admin. 
+		@discardableResult
+		open func enabledPresentmentCurrencies(alias: String? = nil) -> PaymentSettingsQuery {
+			addField(field: "enabledPresentmentCurrencies", aliasSuffix: alias)
+			return self
+		}
+
 		/// The shop’s Shopify Payments account id. 
 		@discardableResult
 		open func shopifyPaymentsAccountId(alias: String? = nil) -> PaymentSettingsQuery {
@@ -104,6 +113,12 @@ extension Storefront {
 					throw SchemaViolationError(type: PaymentSettings.self, field: fieldName, value: fieldValue)
 				}
 				return CurrencyCode(rawValue: value) ?? .unknownValue
+
+				case "enabledPresentmentCurrencies":
+				guard let value = value as? [String] else {
+					throw SchemaViolationError(type: PaymentSettings.self, field: fieldName, value: fieldValue)
+				}
+				return value.map { return CurrencyCode(rawValue: $0) ?? .unknownValue }
 
 				case "shopifyPaymentsAccountId":
 				if value is NSNull { return nil }
@@ -157,6 +172,17 @@ extension Storefront {
 
 		func internalGetCurrencyCode(alias: String? = nil) -> Storefront.CurrencyCode {
 			return field(field: "currencyCode", aliasSuffix: alias) as! Storefront.CurrencyCode
+		}
+
+		/// A list of enabled currencies (ISO 4217 format) that the shop accepts. 
+		/// Merchants can enable currencies from their Shopify Payments settings in the 
+		/// Shopify admin. 
+		open var enabledPresentmentCurrencies: [Storefront.CurrencyCode] {
+			return internalGetEnabledPresentmentCurrencies()
+		}
+
+		func internalGetEnabledPresentmentCurrencies(alias: String? = nil) -> [Storefront.CurrencyCode] {
+			return field(field: "enabledPresentmentCurrencies", aliasSuffix: alias) as! [Storefront.CurrencyCode]
 		}
 
 		/// The shop’s Shopify Payments account id. 

--- a/Buy/Generated/Storefront/PricingValue.swift
+++ b/Buy/Generated/Storefront/PricingValue.swift
@@ -26,12 +26,12 @@
 
 import Foundation
 
-/// The value of the pricing object. 
+/// The price value (fixed or percentage) for a discount application. 
 public protocol PricingValue {
 }
 
 extension Storefront {
-	/// The value of the pricing object. 
+	/// The price value (fixed or percentage) for a discount application. 
 	open class PricingValueQuery: GraphQL.AbstractQuery, GraphQLQuery {
 		public typealias Response = PricingValue
 
@@ -40,7 +40,7 @@ extension Storefront {
 			addField(field: "__typename")
 		}
 
-		/// The value of the pricing object. 
+		/// The price value (fixed or percentage) for a discount application. 
 		@discardableResult
 		open func onMoneyV2(subfields: (MoneyV2Query) -> Void) -> PricingValueQuery {
 			let subquery = MoneyV2Query()
@@ -49,7 +49,7 @@ extension Storefront {
 			return self
 		}
 
-		/// The value of the pricing object. 
+		/// The price value (fixed or percentage) for a discount application. 
 		@discardableResult
 		open func onPricingPercentageValue(subfields: (PricingPercentageValueQuery) -> Void) -> PricingValueQuery {
 			let subquery = PricingPercentageValueQuery()
@@ -59,7 +59,7 @@ extension Storefront {
 		}
 	}
 
-	/// The value of the pricing object. 
+	/// The price value (fixed or percentage) for a discount application. 
 	open class UnknownPricingValue: GraphQL.AbstractResponse, GraphQLObject, PricingValue {
 		public typealias Query = PricingValueQuery
 

--- a/Buy/Generated/Storefront/ProductVariant.swift
+++ b/Buy/Generated/Storefront/ProductVariant.swift
@@ -49,9 +49,21 @@ extension Storefront {
 
 		/// The compare at price of the variant. This can be used to mark a variant as 
 		/// on sale, when `compareAtPrice` is higher than `price`. 
+		@available(*, deprecated, message:"Use `compareAtPriceV2` instead")
 		@discardableResult
 		open func compareAtPrice(alias: String? = nil) -> ProductVariantQuery {
 			addField(field: "compareAtPrice", aliasSuffix: alias)
+			return self
+		}
+
+		/// The compare at price of the variant. This can be used to mark a variant as 
+		/// on sale, when `compareAtPriceV2` is higher than `priceV2`. 
+		@discardableResult
+		open func compareAtPriceV2(alias: String? = nil, _ subfields: (MoneyV2Query) -> Void) -> ProductVariantQuery {
+			let subquery = MoneyV2Query()
+			subfields(subquery)
+
+			addField(field: "compareAtPriceV2", aliasSuffix: alias, subfields: subquery)
 			return self
 		}
 
@@ -149,9 +161,20 @@ extension Storefront {
 		}
 
 		/// The product variant’s price. 
+		@available(*, deprecated, message:"Use `priceV2` instead")
 		@discardableResult
 		open func price(alias: String? = nil) -> ProductVariantQuery {
 			addField(field: "price", aliasSuffix: alias)
+			return self
+		}
+
+		/// The product variant’s price. 
+		@discardableResult
+		open func priceV2(alias: String? = nil, _ subfields: (MoneyV2Query) -> Void) -> ProductVariantQuery {
+			let subquery = MoneyV2Query()
+			subfields(subquery)
+
+			addField(field: "priceV2", aliasSuffix: alias, subfields: subquery)
 			return self
 		}
 
@@ -233,6 +256,13 @@ extension Storefront {
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
 
+				case "compareAtPriceV2":
+				if value is NSNull { return nil }
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
+				}
+				return try MoneyV2(fields: value)
+
 				case "id":
 				guard let value = value as? String else {
 					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
@@ -257,6 +287,12 @@ extension Storefront {
 					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
 				}
 				return Decimal(string: value, locale: GraphQL.posixLocale)
+
+				case "priceV2":
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
+				}
+				return try MoneyV2(fields: value)
 
 				case "product":
 				guard let value = value as? [String: Any] else {
@@ -322,12 +358,23 @@ extension Storefront {
 
 		/// The compare at price of the variant. This can be used to mark a variant as 
 		/// on sale, when `compareAtPrice` is higher than `price`. 
+		@available(*, deprecated, message:"Use `compareAtPriceV2` instead")
 		open var compareAtPrice: Decimal? {
 			return internalGetCompareAtPrice()
 		}
 
 		func internalGetCompareAtPrice(alias: String? = nil) -> Decimal? {
 			return field(field: "compareAtPrice", aliasSuffix: alias) as! Decimal?
+		}
+
+		/// The compare at price of the variant. This can be used to mark a variant as 
+		/// on sale, when `compareAtPriceV2` is higher than `priceV2`. 
+		open var compareAtPriceV2: Storefront.MoneyV2? {
+			return internalGetCompareAtPriceV2()
+		}
+
+		func internalGetCompareAtPriceV2(alias: String? = nil) -> Storefront.MoneyV2? {
+			return field(field: "compareAtPriceV2", aliasSuffix: alias) as! Storefront.MoneyV2?
 		}
 
 		/// Globally unique identifier. 
@@ -368,12 +415,22 @@ extension Storefront {
 		}
 
 		/// The product variant’s price. 
+		@available(*, deprecated, message:"Use `priceV2` instead")
 		open var price: Decimal {
 			return internalGetPrice()
 		}
 
 		func internalGetPrice(alias: String? = nil) -> Decimal {
 			return field(field: "price", aliasSuffix: alias) as! Decimal
+		}
+
+		/// The product variant’s price. 
+		open var priceV2: Storefront.MoneyV2 {
+			return internalGetPriceV2()
+		}
+
+		func internalGetPriceV2(alias: String? = nil) -> Storefront.MoneyV2 {
+			return field(field: "priceV2", aliasSuffix: alias) as! Storefront.MoneyV2
 		}
 
 		/// The product object that the product variant belongs to. 
@@ -435,6 +492,12 @@ extension Storefront {
 			var response: [GraphQL.AbstractResponse] = []
 			objectMap.keys.forEach {
 				switch($0) {
+					case "compareAtPriceV2":
+					if let value = internalGetCompareAtPriceV2() {
+						response.append(value)
+						response.append(contentsOf: value.childResponseObjectMap())
+					}
+
 					case "image":
 					if let value = internalGetImage() {
 						response.append(value)
@@ -444,6 +507,10 @@ extension Storefront {
 					case "presentmentPrices":
 					response.append(internalGetPresentmentPrices())
 					response.append(contentsOf: internalGetPresentmentPrices().childResponseObjectMap())
+
+					case "priceV2":
+					response.append(internalGetPriceV2())
+					response.append(contentsOf: internalGetPriceV2().childResponseObjectMap())
 
 					case "product":
 					response.append(internalGetProduct())

--- a/Buy/Generated/Storefront/ScriptDiscountApplication.swift
+++ b/Buy/Generated/Storefront/ScriptDiscountApplication.swift
@@ -41,6 +41,7 @@ extension Storefront {
 		}
 
 		/// The description of the application as defined by the Script. 
+		@available(*, deprecated, message:"Use `title` instead")
 		@discardableResult
 		open func description(alias: String? = nil) -> ScriptDiscountApplicationQuery {
 			addField(field: "description", aliasSuffix: alias)
@@ -58,6 +59,13 @@ extension Storefront {
 		@discardableResult
 		open func targetType(alias: String? = nil) -> ScriptDiscountApplicationQuery {
 			addField(field: "targetType", aliasSuffix: alias)
+			return self
+		}
+
+		/// The title of the application as defined by the Script. 
+		@discardableResult
+		open func title(alias: String? = nil) -> ScriptDiscountApplicationQuery {
+			addField(field: "title", aliasSuffix: alias)
 			return self
 		}
 
@@ -104,6 +112,12 @@ extension Storefront {
 				}
 				return DiscountApplicationTargetType(rawValue: value) ?? .unknownValue
 
+				case "title":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: ScriptDiscountApplication.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
 				case "value":
 				guard let value = value as? [String: Any] else {
 					throw SchemaViolationError(type: ScriptDiscountApplication.self, field: fieldName, value: fieldValue)
@@ -126,6 +140,7 @@ extension Storefront {
 		}
 
 		/// The description of the application as defined by the Script. 
+		@available(*, deprecated, message:"Use `title` instead")
 		open var description: String {
 			return internalGetDescription()
 		}
@@ -150,6 +165,15 @@ extension Storefront {
 
 		func internalGetTargetType(alias: String? = nil) -> Storefront.DiscountApplicationTargetType {
 			return field(field: "targetType", aliasSuffix: alias) as! Storefront.DiscountApplicationTargetType
+		}
+
+		/// The title of the application as defined by the Script. 
+		open var title: String {
+			return internalGetTitle()
+		}
+
+		func internalGetTitle(alias: String? = nil) -> String {
+			return field(field: "title", aliasSuffix: alias) as! String
 		}
 
 		/// The value of the discount application. 

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ self.paySession = PaySession(
 	merchantID: "com.merchant.identifier"
 )
 
-self.paySession.delegate = self     
+self.paySession.delegate = self
 self.paySession.authorize()
 ```
 
@@ -748,7 +748,7 @@ Invoked when the customer authorizes the payment. At this point, the `delegate` 
 
 ```swift
 func paySessionDidFinish(_ paySession: PaySession) {
-    // Do something after the  Pay modal is dismissed   
+    // Do something after the  Pay modal is dismissed
 }
 ```
 
@@ -1064,7 +1064,7 @@ Since we'll need to update the checkout with additional information later, all w
 
 A customer's information might not be available when a checkout is created. The Buy SDK provides mutations for updating the specific checkout fields that are required for completion: the `email`, `shippingAddress` and  `shippingLine` fields.
 
-Note that if your checkout contains a line item that requires shipping, you must provide a shipping address and a shipping line as part of your checkout. 
+Note that if your checkout contains a line item that requires shipping, you must provide a shipping address and a shipping line as part of your checkout.
 
 To obtain the handle required for updating a shipping line, you must first poll for shipping rates.
 


### PR DESCRIPTION
### What this does

PR to bump schema. Schema changes include:

**Multi Currency**
- Add `enabledPresentmentCurrencies` to payment settings.
- Add `amountUsedV2`, `balanceV2`, `paymentDueV2`, `subtotalPriceV2`, `totalPriceV2`, `totalTaxV2`.
- Deprecate  `amountUsed`, `balance`, `paymentDue`,  `subtotalPrice`, `totalPrice`, `totalTax`.

**Support**
- Add currency support for Panamian Balboa.
- Add `title` to script discount application query.
- Add `lineItemsSubtotalPrice` as a field returned on checkout.