### PR TITLE
Fix queries sample code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ The following example shows how you can query for a shop's name:
 
 ```swift
 let query = Storefront.buildQuery { $0
-    .shop {
+    .shop { $0
         .name()
     }
 }


### PR DESCRIPTION
### What this does

Fix queries sample code in README that didn't seem to compile in my test app (to learn the Buy SDK), using Xcode 10.2 and Swift 5.0.

Compilation error message I had:
`Contextual type for closure argument list expects 1 argument, which cannot be implicitly ignored`

Added a missing `$0` to a call to `Storefront.buildQuery` in the Queries sections of the README tutorial.