### PR TITLE
Update schema.

### DIFF
--- a/Buy.xcodeproj/project.pbxproj
+++ b/Buy.xcodeproj/project.pbxproj
@@ -664,6 +664,9 @@
 		B3B5A030223FF6C3008ECA02 /* SEO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B5A02F223FF6C3008ECA02 /* SEO.swift */; };
 		B3B5A031223FF6C3008ECA02 /* SEO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B5A02F223FF6C3008ECA02 /* SEO.swift */; };
 		B3B5A032223FF6C3008ECA02 /* SEO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B5A02F223FF6C3008ECA02 /* SEO.swift */; };
+		FB7707D822CD488E00ED289E /* ApiVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7707D722CD488E00ED289E /* ApiVersion.swift */; };
+		FB7707D922CD488E00ED289E /* ApiVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7707D722CD488E00ED289E /* ApiVersion.swift */; };
+		FB7707DA22CD488E00ED289E /* ApiVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7707D722CD488E00ED289E /* ApiVersion.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -936,6 +939,7 @@
 		9AFA3B6C1E6D9A5E0056C5AA /* GraphQL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphQL.swift; sourceTree = "<group>"; };
 		9AFEF46D1F72DB64003FA8C5 /* MockPaySession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPaySession.swift; sourceTree = "<group>"; };
 		B3B5A02F223FF6C3008ECA02 /* SEO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SEO.swift; sourceTree = "<group>"; };
+		FB7707D722CD488E00ED289E /* ApiVersion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApiVersion.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -989,6 +993,7 @@
 		9A0C7FF81EAA51C50020F187 /* Storefront */ = {
 			isa = PBXGroup;
 			children = (
+				FB7707D722CD488E00ED289E /* ApiVersion.swift */,
 				9A0C7FF91EAA51C50020F187 /* AppliedGiftCard.swift */,
 				9AA416C21EE095AA0060029B /* Article.swift */,
 				9AA416C31EE095AA0060029B /* ArticleAuthor.swift */,
@@ -1831,6 +1836,7 @@
 				9AC2EF791F6818180037E0D7 /* CustomerAccessTokenRenewPayload.swift in Sources */,
 				9AC2EF7A1F6818180037E0D7 /* CustomerAddressDeletePayload.swift in Sources */,
 				9AC2EF7B1F6818180037E0D7 /* Product.swift in Sources */,
+				FB7707D922CD488E00ED289E /* ApiVersion.swift in Sources */,
 				9AC2EF7C1F6818180037E0D7 /* CustomerAddressUpdatePayload.swift in Sources */,
 				9AC2EF7D1F6818180037E0D7 /* Payment.swift in Sources */,
 				9AC2EF7E1F6818180037E0D7 /* ProductCollectionSortKeys.swift in Sources */,
@@ -2035,6 +2041,7 @@
 				9A0C80801EAA51C50020F187 /* CustomerAccessTokenRenewPayload.swift in Sources */,
 				9A0C80841EAA51C50020F187 /* CustomerAddressDeletePayload.swift in Sources */,
 				9A0C80A31EAA51C50020F187 /* Product.swift in Sources */,
+				FB7707D822CD488E00ED289E /* ApiVersion.swift in Sources */,
 				9A0C80851EAA51C50020F187 /* CustomerAddressUpdatePayload.swift in Sources */,
 				9A0C80A21EAA51C50020F187 /* Payment.swift in Sources */,
 				9AF1C1891F13B45E0064AEA0 /* ProductCollectionSortKeys.swift in Sources */,
@@ -2239,6 +2246,7 @@
 				9AF255F31F6FEE50005BB0C9 /* CustomerAccessTokenRenewPayload.swift in Sources */,
 				9AF255F41F6FEE50005BB0C9 /* CustomerAddressDeletePayload.swift in Sources */,
 				9AF255F51F6FEE50005BB0C9 /* Product.swift in Sources */,
+				FB7707DA22CD488E00ED289E /* ApiVersion.swift in Sources */,
 				9AF255F61F6FEE50005BB0C9 /* CustomerAddressUpdatePayload.swift in Sources */,
 				9AF255F71F6FEE50005BB0C9 /* Payment.swift in Sources */,
 				9AF255F81F6FEE50005BB0C9 /* ProductCollectionSortKeys.swift in Sources */,

--- a/Buy/Client/Graph.Client.swift
+++ b/Buy/Client/Graph.Client.swift
@@ -51,20 +51,20 @@ extension Graph {
     /// `mutation` and `error` are **not** mutually exclusive. In other words, it is valid for a request to return both a non-nil `mutation` and `error`. In this case, the `error` generally represents an issue with only a subset of the query.
     ///
     public typealias MutationCompletion = (_ mutation: Storefront.Mutation?, _ error: QueryError?) -> Void
-    
+
     /// The `Graph.Client` is a network layer designed to abstract the communication with the Shopify GraphQL endpoint
     /// by handling the serialization and deserialization of GraphQL models for `query` and `mutation` requests.
     /// In addition, the `Client` will take care of appending the necessary headers for authorizing the network
     /// requests based on the provided `shopDomain` and `apiKey`.
     ///
     public class Client {
-        
-        /// Cache policy to use for all `query` operations produced by this instance of `Graph.Client` 
+
+        /// Cache policy to use for all `query` operations produced by this instance of `Graph.Client`
         public var cachePolicy: CachePolicy = .networkOnly
-        
+
         /// The `URLSession` backing all `Client` network operations. You can provide your own session when initializing a new `Client`.
         public let session: URLSession
-        
+
         internal let cache: Cache
 
         internal let apiURL:  URL
@@ -83,7 +83,7 @@ extension Graph {
         public init(shopDomain: String, apiKey: String, session: URLSession = URLSession(configuration: URLSessionConfiguration.default)) {
 
             let shopURL  = Client.urlFor(shopDomain)
-            self.apiURL  = Client.urlFor(shopDomain, path: "/api/graphql")
+            self.apiURL  = Client.urlFor(shopDomain, path: "/api/2019-07/graphql")
             self.cache   = Cache(shopName: shopDomain)
             self.session = session
             self.headers = [
@@ -166,7 +166,7 @@ extension Graph {
         //  MARK: - Request Management -
         //
         private func graphRequestTask<Q: GraphQL.AbstractQuery, R: GraphQL.AbstractResponse>(query: Q, cachePolicy: CachePolicy, retryHandler: RetryHandler<R>? = nil, completionHandler: @escaping (R?, QueryError?) -> Void) -> Task {
-            
+
             let request = self.graphRequestFor(query: query)
             return InternalTask<R>(
                 session:      self.session,
@@ -181,11 +181,11 @@ extension Graph {
         func graphRequestFor(query: GraphQL.AbstractQuery) -> URLRequest {
             var request     = URLRequest(url: self.apiURL)
             let requestData = String(describing: query).data(using: .utf8)!
-            
+
             request.httpMethod              = "POST"
             request.httpBody                = requestData
             request.httpShouldHandleCookies = false
-            
+
             request.setValue("application/json",    forHTTPHeaderField: Header.accept)
             request.setValue("application/graphql", forHTTPHeaderField: Header.contentType)
             request.setValue(MD5.hash(requestData), forHTTPHeaderField: Header.queryTag)

--- a/Buy/Generated/Storefront/ApiVersion.swift
+++ b/Buy/Generated/Storefront/ApiVersion.swift
@@ -1,0 +1,119 @@
+//
+//  ApiVersion.swift
+//  Buy
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+extension Storefront {
+	/// A version of the API. 
+	open class ApiVersionQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = ApiVersion
+
+		/// The human-readable name of the version. 
+		@discardableResult
+		open func displayName(alias: String? = nil) -> ApiVersionQuery {
+			addField(field: "displayName", aliasSuffix: alias)
+			return self
+		}
+
+		/// The unique identifier of an ApiVersion. All supported API versions have a 
+		/// date-based (YYYY-MM) or `unstable` handle. 
+		@discardableResult
+		open func handle(alias: String? = nil) -> ApiVersionQuery {
+			addField(field: "handle", aliasSuffix: alias)
+			return self
+		}
+
+		/// Whether the version is supported by Shopify. 
+		@discardableResult
+		open func supported(alias: String? = nil) -> ApiVersionQuery {
+			addField(field: "supported", aliasSuffix: alias)
+			return self
+		}
+	}
+
+	/// A version of the API. 
+	open class ApiVersion: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = ApiVersionQuery
+
+		internal override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
+			let fieldValue = value
+			switch fieldName {
+				case "displayName":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: ApiVersion.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "handle":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: ApiVersion.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "supported":
+				guard let value = value as? Bool else {
+					throw SchemaViolationError(type: ApiVersion.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				default:
+				throw SchemaViolationError(type: ApiVersion.self, field: fieldName, value: fieldValue)
+			}
+		}
+
+		/// The human-readable name of the version. 
+		open var displayName: String {
+			return internalGetDisplayName()
+		}
+
+		func internalGetDisplayName(alias: String? = nil) -> String {
+			return field(field: "displayName", aliasSuffix: alias) as! String
+		}
+
+		/// The unique identifier of an ApiVersion. All supported API versions have a 
+		/// date-based (YYYY-MM) or `unstable` handle. 
+		open var handle: String {
+			return internalGetHandle()
+		}
+
+		func internalGetHandle(alias: String? = nil) -> String {
+			return field(field: "handle", aliasSuffix: alias) as! String
+		}
+
+		/// Whether the version is supported by Shopify. 
+		open var supported: Bool {
+			return internalGetSupported()
+		}
+
+		func internalGetSupported(alias: String? = nil) -> Bool {
+			return field(field: "supported", aliasSuffix: alias) as! Bool
+		}
+
+		internal override func childResponseObjectMap() -> [GraphQL.AbstractResponse]  {
+			return []
+		}
+	}
+}

--- a/Buy/Generated/Storefront/CheckoutErrorCode.swift
+++ b/Buy/Generated/Storefront/CheckoutErrorCode.swift
@@ -32,6 +32,9 @@ extension Storefront {
 		/// Checkout is already completed. 
 		case alreadyCompleted = "ALREADY_COMPLETED"
 
+		/// Input email contains an invalid domain name. 
+		case badDomain = "BAD_DOMAIN"
+
 		/// Input value is blank. 
 		case blank = "BLANK"
 
@@ -65,6 +68,9 @@ extension Storefront {
 		/// Gift card currency does not match checkout currency. 
 		case giftCardCurrencyMismatch = "GIFT_CARD_CURRENCY_MISMATCH"
 
+		/// Gift card has no funds left. 
+		case giftCardDepleted = "GIFT_CARD_DEPLETED"
+
 		/// Gift card is disabled. 
 		case giftCardDisabled = "GIFT_CARD_DISABLED"
 
@@ -82,6 +88,9 @@ extension Storefront {
 
 		/// Input value is invalid. 
 		case invalid = "INVALID"
+
+		/// Input Zip is invalid for country provided. 
+		case invalidForCountry = "INVALID_FOR_COUNTRY"
 
 		/// Input Zip is invalid for country and province provided. 
 		case invalidForCountryAndProvince = "INVALID_FOR_COUNTRY_AND_PROVINCE"
@@ -124,6 +133,9 @@ extension Storefront {
 
 		/// Input value is too long. 
 		case tooLong = "TOO_LONG"
+
+		/// The amount of the payment does not match the value to be paid. 
+		case totalPriceMismatch = "TOTAL_PRICE_MISMATCH"
 
 		case unknownValue = ""
 	}

--- a/Buy/Generated/Storefront/CurrencyCode.swift
+++ b/Buy/Generated/Storefront/CurrencyCode.swift
@@ -99,6 +99,7 @@ extension Storefront {
 		case bwp = "BWP"
 
 		/// Belarusian Ruble (BYR). 
+		@available(*, deprecated, message:"`BYR` is deprecated. Use `BYN` available from version `2019-10` onwards instead.")
 		case byr = "BYR"
 
 		/// Belize Dollar (BZD). 

--- a/Buy/Generated/Storefront/Product.swift
+++ b/Buy/Generated/Storefront/Product.swift
@@ -35,7 +35,7 @@ extension Storefront {
 	open class ProductQuery: GraphQL.AbstractQuery, GraphQLQuery {
 		public typealias Response = Product
 
-		/// Indicates if at least one product variant is available for sale. 
+		/// Whether the product is available on the Online Store channel and in stock. 
 		@discardableResult
 		open func availableForSale(alias: String? = nil) -> ProductQuery {
 			addField(field: "availableForSale", aliasSuffix: alias)
@@ -624,7 +624,7 @@ extension Storefront {
 			}
 		}
 
-		/// Indicates if at least one product variant is available for sale. 
+		/// Whether the product is available on the Online Store channel and in stock. 
 		open var availableForSale: Bool {
 			return internalGetAvailableForSale()
 		}

--- a/Buy/Generated/Storefront/ProductVariant.swift
+++ b/Buy/Generated/Storefront/ProductVariant.swift
@@ -258,6 +258,14 @@ extension Storefront {
 			return self
 		}
 
+		/// Whether a customer needs to provide a shipping address when placing an 
+		/// order for the product variant. 
+		@discardableResult
+		open func requiresShipping(alias: String? = nil) -> ProductVariantQuery {
+			addField(field: "requiresShipping", aliasSuffix: alias)
+			return self
+		}
+
 		/// List of product options applied to the variant. 
 		@discardableResult
 		open func selectedOptions(alias: String? = nil, _ subfields: (SelectedOptionQuery) -> Void) -> ProductVariantQuery {
@@ -382,6 +390,12 @@ extension Storefront {
 					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
 				}
 				return try Product(fields: value)
+
+				case "requiresShipping":
+				guard let value = value as? Bool else {
+					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
+				}
+				return value
 
 				case "selectedOptions":
 				guard let value = value as? [[String: Any]] else {
@@ -549,6 +563,16 @@ extension Storefront {
 
 		func internalGetProduct(alias: String? = nil) -> Storefront.Product {
 			return field(field: "product", aliasSuffix: alias) as! Storefront.Product
+		}
+
+		/// Whether a customer needs to provide a shipping address when placing an 
+		/// order for the product variant. 
+		open var requiresShipping: Bool {
+			return internalGetRequiresShipping()
+		}
+
+		func internalGetRequiresShipping(alias: String? = nil) -> Bool {
+			return field(field: "requiresShipping", aliasSuffix: alias) as! Bool
 		}
 
 		/// List of product options applied to the variant. 

--- a/Scripts/update_schema
+++ b/Scripts/update_schema
@@ -8,7 +8,8 @@ require 'graphql_schema'
 require 'graphql_swift_gen'
 
 shared_storefront_api_key = "4a6c829ec3cb12ef9004bf8ed27adf12"
-endpoint                  = URI("https://app.shopify.com/services/graphql/introspection/storefront?api_client_api_key=#{shared_storefront_api_key}")
+storefront_api_version    = "2019-07"
+endpoint                  = URI("https://app.shopify.com/services/graphql/introspection/storefront?api_client_api_key=#{shared_storefront_api_key}&api_version=#{storefront_api_version}")
 body                      = Net::HTTP.get(endpoint)
 schema                    = GraphQLSchema.new(JSON.parse(body))
 
@@ -46,9 +47,9 @@ customScalars = [
 ]
 
 content = GraphQLSwiftGen.new(
-	schema, 
-	nest_under: 'Storefront', 
-	import_graphql_support: false, 
+	schema,
+	nest_under: 'Storefront',
+	import_graphql_support: false,
 	custom_scalars: customScalars
 )
 content.save("../Buy/Generated/")


### PR DESCRIPTION
### What this does

- Lock schema end-point to `2019-07`
- Add support for querying GraphQL schema version
- Add `requiresShipping` field on `ProductVariant`
- Add `BAD_DOMAIN`, `GIFT_CARD_DEPLETED`, `INVALID_FOR_COUNTRY` and `TOTAL_PRICE_MISMATCH` checkout error codes.
- Deprecate `CurrencyCode.byr`