### PR TITLE
SDK 3.7.0

### DIFF
--- a/Buy.xcodeproj/project.pbxproj
+++ b/Buy.xcodeproj/project.pbxproj
@@ -36,6 +36,36 @@
 		8128551E23C4AC7E00ADA66E /* MediaConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550F23C4AC7E00ADA66E /* MediaConnection.swift */; };
 		8128551F23C4AC7E00ADA66E /* MediaImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128551023C4AC7E00ADA66E /* MediaImage.swift */; };
 		8128552023C4AC7E00ADA66E /* UnitPriceMeasurementMeasuredType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128551123C4AC7E00ADA66E /* UnitPriceMeasurementMeasuredType.swift */; };
+		815FAB3A23C4B81500F98749 /* ExternalVideo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550D23C4AC7E00ADA66E /* ExternalVideo.swift */; };
+		815FAB3B23C4B81500F98749 /* Media.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550923C4AC7E00ADA66E /* Media.swift */; };
+		815FAB3C23C4B81500F98749 /* MediaConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550F23C4AC7E00ADA66E /* MediaConnection.swift */; };
+		815FAB3D23C4B81500F98749 /* MediaContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550C23C4AC7E00ADA66E /* MediaContentType.swift */; };
+		815FAB3E23C4B81500F98749 /* MediaEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550A23C4AC7E00ADA66E /* MediaEdge.swift */; };
+		815FAB3F23C4B81500F98749 /* MediaImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128551023C4AC7E00ADA66E /* MediaImage.swift */; };
+		815FAB4023C4B81500F98749 /* Model3d.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550423C4AC7D00ADA66E /* Model3d.swift */; };
+		815FAB4123C4B81500F98749 /* Model3dSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550323C4AC7D00ADA66E /* Model3dSource.swift */; };
+		815FAB4223C4B81500F98749 /* MoneyV2Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550B23C4AC7E00ADA66E /* MoneyV2Connection.swift */; };
+		815FAB4323C4B81500F98749 /* MoneyV2Edge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550E23C4AC7E00ADA66E /* MoneyV2Edge.swift */; };
+		815FAB4423C4B81500F98749 /* UnitPriceMeasurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550523C4AC7E00ADA66E /* UnitPriceMeasurement.swift */; };
+		815FAB4523C4B81500F98749 /* UnitPriceMeasurementMeasuredType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128551123C4AC7E00ADA66E /* UnitPriceMeasurementMeasuredType.swift */; };
+		815FAB4623C4B81500F98749 /* UnitPriceMeasurementMeasuredUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550823C4AC7E00ADA66E /* UnitPriceMeasurementMeasuredUnit.swift */; };
+		815FAB4723C4B81500F98749 /* Video.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550723C4AC7E00ADA66E /* Video.swift */; };
+		815FAB4823C4B81500F98749 /* VideoSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550623C4AC7E00ADA66E /* VideoSource.swift */; };
+		815FAB4923C4B82C00F98749 /* ExternalVideo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550D23C4AC7E00ADA66E /* ExternalVideo.swift */; };
+		815FAB4A23C4B82C00F98749 /* Media.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550923C4AC7E00ADA66E /* Media.swift */; };
+		815FAB4B23C4B82C00F98749 /* MediaConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550F23C4AC7E00ADA66E /* MediaConnection.swift */; };
+		815FAB4C23C4B82C00F98749 /* MediaContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550C23C4AC7E00ADA66E /* MediaContentType.swift */; };
+		815FAB4D23C4B82C00F98749 /* MediaEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550A23C4AC7E00ADA66E /* MediaEdge.swift */; };
+		815FAB4E23C4B82C00F98749 /* MediaImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128551023C4AC7E00ADA66E /* MediaImage.swift */; };
+		815FAB4F23C4B82C00F98749 /* Model3d.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550423C4AC7D00ADA66E /* Model3d.swift */; };
+		815FAB5023C4B82C00F98749 /* Model3dSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550323C4AC7D00ADA66E /* Model3dSource.swift */; };
+		815FAB5123C4B82C00F98749 /* MoneyV2Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550B23C4AC7E00ADA66E /* MoneyV2Connection.swift */; };
+		815FAB5223C4B82D00F98749 /* MoneyV2Edge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550E23C4AC7E00ADA66E /* MoneyV2Edge.swift */; };
+		815FAB5323C4B82D00F98749 /* UnitPriceMeasurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550523C4AC7E00ADA66E /* UnitPriceMeasurement.swift */; };
+		815FAB5423C4B82D00F98749 /* UnitPriceMeasurementMeasuredType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128551123C4AC7E00ADA66E /* UnitPriceMeasurementMeasuredType.swift */; };
+		815FAB5523C4B82D00F98749 /* UnitPriceMeasurementMeasuredUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550823C4AC7E00ADA66E /* UnitPriceMeasurementMeasuredUnit.swift */; };
+		815FAB5623C4B82D00F98749 /* Video.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550723C4AC7E00ADA66E /* Video.swift */; };
+		815FAB5723C4B82D00F98749 /* VideoSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550623C4AC7E00ADA66E /* VideoSource.swift */; };
 		9A035E102177B764008596C9 /* TokenizedPaymentInputV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A035E0F2177B763008596C9 /* TokenizedPaymentInputV2.swift */; };
 		9A035E112177B764008596C9 /* TokenizedPaymentInputV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A035E0F2177B763008596C9 /* TokenizedPaymentInputV2.swift */; };
 		9A035E122177B764008596C9 /* TokenizedPaymentInputV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A035E0F2177B763008596C9 /* TokenizedPaymentInputV2.swift */; };
@@ -1784,6 +1814,21 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				815FAB4923C4B82C00F98749 /* ExternalVideo.swift in Sources */,
+				815FAB4A23C4B82C00F98749 /* Media.swift in Sources */,
+				815FAB4B23C4B82C00F98749 /* MediaConnection.swift in Sources */,
+				815FAB4C23C4B82C00F98749 /* MediaContentType.swift in Sources */,
+				815FAB4D23C4B82C00F98749 /* MediaEdge.swift in Sources */,
+				815FAB4E23C4B82C00F98749 /* MediaImage.swift in Sources */,
+				815FAB4F23C4B82C00F98749 /* Model3d.swift in Sources */,
+				815FAB5023C4B82C00F98749 /* Model3dSource.swift in Sources */,
+				815FAB5123C4B82C00F98749 /* MoneyV2Connection.swift in Sources */,
+				815FAB5223C4B82D00F98749 /* MoneyV2Edge.swift in Sources */,
+				815FAB5323C4B82D00F98749 /* UnitPriceMeasurement.swift in Sources */,
+				815FAB5423C4B82D00F98749 /* UnitPriceMeasurementMeasuredType.swift in Sources */,
+				815FAB5523C4B82D00F98749 /* UnitPriceMeasurementMeasuredUnit.swift in Sources */,
+				815FAB5623C4B82D00F98749 /* Video.swift in Sources */,
+				815FAB5723C4B82D00F98749 /* VideoSource.swift in Sources */,
 				9AC2EF391F6818180037E0D7 /* Attribute.swift in Sources */,
 				9AC2EF3A1F6818180037E0D7 /* OrderLineItem.swift in Sources */,
 				9AC2EF3B1F6818180037E0D7 /* Log.swift in Sources */,
@@ -2209,6 +2254,21 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				815FAB3A23C4B81500F98749 /* ExternalVideo.swift in Sources */,
+				815FAB3B23C4B81500F98749 /* Media.swift in Sources */,
+				815FAB3C23C4B81500F98749 /* MediaConnection.swift in Sources */,
+				815FAB3D23C4B81500F98749 /* MediaContentType.swift in Sources */,
+				815FAB3E23C4B81500F98749 /* MediaEdge.swift in Sources */,
+				815FAB3F23C4B81500F98749 /* MediaImage.swift in Sources */,
+				815FAB4023C4B81500F98749 /* Model3d.swift in Sources */,
+				815FAB4123C4B81500F98749 /* Model3dSource.swift in Sources */,
+				815FAB4223C4B81500F98749 /* MoneyV2Connection.swift in Sources */,
+				815FAB4323C4B81500F98749 /* MoneyV2Edge.swift in Sources */,
+				815FAB4423C4B81500F98749 /* UnitPriceMeasurement.swift in Sources */,
+				815FAB4523C4B81500F98749 /* UnitPriceMeasurementMeasuredType.swift in Sources */,
+				815FAB4623C4B81500F98749 /* UnitPriceMeasurementMeasuredUnit.swift in Sources */,
+				815FAB4723C4B81500F98749 /* Video.swift in Sources */,
+				815FAB4823C4B81500F98749 /* VideoSource.swift in Sources */,
 				9AF255B31F6FEE50005BB0C9 /* Attribute.swift in Sources */,
 				9AF255B41F6FEE50005BB0C9 /* OrderLineItem.swift in Sources */,
 				9AF255B51F6FEE50005BB0C9 /* Log.swift in Sources */,
@@ -2468,11 +2528,11 @@
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 3.6.1;
+				CURRENT_PROJECT_VERSION = 3.7.0;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 3.6.1;
+				DYLIB_CURRENT_VERSION = 3.7.0;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Pay/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -2493,11 +2553,11 @@
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 3.6.1;
+				CURRENT_PROJECT_VERSION = 3.7.0;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 3.6.1;
+				DYLIB_CURRENT_VERSION = 3.7.0;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Pay/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -2546,11 +2606,11 @@
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3.6.1;
+				CURRENT_PROJECT_VERSION = 3.7.0;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 3.6.1;
+				DYLIB_CURRENT_VERSION = 3.7.0;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Buy/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -2574,11 +2634,11 @@
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3.6.1;
+				CURRENT_PROJECT_VERSION = 3.7.0;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 3.6.1;
+				DYLIB_CURRENT_VERSION = 3.7.0;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Buy/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -2716,11 +2776,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 3.6.1;
+				CURRENT_PROJECT_VERSION = 3.7.0;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 3.6.1;
+				DYLIB_CURRENT_VERSION = 3.7.0;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Buy/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -2738,11 +2798,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 3.6.1;
+				CURRENT_PROJECT_VERSION = 3.7.0;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 3.6.1;
+				DYLIB_CURRENT_VERSION = 3.7.0;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Buy/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -2761,11 +2821,11 @@
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3.6.1;
+				CURRENT_PROJECT_VERSION = 3.7.0;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 3.6.1;
+				DYLIB_CURRENT_VERSION = 3.7.0;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Buy/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -2790,11 +2850,11 @@
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3.6.1;
+				CURRENT_PROJECT_VERSION = 3.7.0;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 3.6.1;
+				DYLIB_CURRENT_VERSION = 3.7.0;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Buy/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/Buy.xcodeproj/project.pbxproj
+++ b/Buy.xcodeproj/project.pbxproj
@@ -21,6 +21,21 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		8128551223C4AC7E00ADA66E /* Model3dSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550323C4AC7D00ADA66E /* Model3dSource.swift */; };
+		8128551323C4AC7E00ADA66E /* Model3d.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550423C4AC7D00ADA66E /* Model3d.swift */; };
+		8128551423C4AC7E00ADA66E /* UnitPriceMeasurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550523C4AC7E00ADA66E /* UnitPriceMeasurement.swift */; };
+		8128551523C4AC7E00ADA66E /* VideoSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550623C4AC7E00ADA66E /* VideoSource.swift */; };
+		8128551623C4AC7E00ADA66E /* Video.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550723C4AC7E00ADA66E /* Video.swift */; };
+		8128551723C4AC7E00ADA66E /* UnitPriceMeasurementMeasuredUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550823C4AC7E00ADA66E /* UnitPriceMeasurementMeasuredUnit.swift */; };
+		8128551823C4AC7E00ADA66E /* Media.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550923C4AC7E00ADA66E /* Media.swift */; };
+		8128551923C4AC7E00ADA66E /* MediaEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550A23C4AC7E00ADA66E /* MediaEdge.swift */; };
+		8128551A23C4AC7E00ADA66E /* MoneyV2Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550B23C4AC7E00ADA66E /* MoneyV2Connection.swift */; };
+		8128551B23C4AC7E00ADA66E /* MediaContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550C23C4AC7E00ADA66E /* MediaContentType.swift */; };
+		8128551C23C4AC7E00ADA66E /* ExternalVideo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550D23C4AC7E00ADA66E /* ExternalVideo.swift */; };
+		8128551D23C4AC7E00ADA66E /* MoneyV2Edge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550E23C4AC7E00ADA66E /* MoneyV2Edge.swift */; };
+		8128551E23C4AC7E00ADA66E /* MediaConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128550F23C4AC7E00ADA66E /* MediaConnection.swift */; };
+		8128551F23C4AC7E00ADA66E /* MediaImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128551023C4AC7E00ADA66E /* MediaImage.swift */; };
+		8128552023C4AC7E00ADA66E /* UnitPriceMeasurementMeasuredType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128551123C4AC7E00ADA66E /* UnitPriceMeasurementMeasuredType.swift */; };
 		9A035E102177B764008596C9 /* TokenizedPaymentInputV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A035E0F2177B763008596C9 /* TokenizedPaymentInputV2.swift */; };
 		9A035E112177B764008596C9 /* TokenizedPaymentInputV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A035E0F2177B763008596C9 /* TokenizedPaymentInputV2.swift */; };
 		9A035E122177B764008596C9 /* TokenizedPaymentInputV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A035E0F2177B763008596C9 /* TokenizedPaymentInputV2.swift */; };
@@ -687,6 +702,21 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		8128550323C4AC7D00ADA66E /* Model3dSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Model3dSource.swift; sourceTree = "<group>"; };
+		8128550423C4AC7D00ADA66E /* Model3d.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Model3d.swift; sourceTree = "<group>"; };
+		8128550523C4AC7E00ADA66E /* UnitPriceMeasurement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitPriceMeasurement.swift; sourceTree = "<group>"; };
+		8128550623C4AC7E00ADA66E /* VideoSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoSource.swift; sourceTree = "<group>"; };
+		8128550723C4AC7E00ADA66E /* Video.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Video.swift; sourceTree = "<group>"; };
+		8128550823C4AC7E00ADA66E /* UnitPriceMeasurementMeasuredUnit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitPriceMeasurementMeasuredUnit.swift; sourceTree = "<group>"; };
+		8128550923C4AC7E00ADA66E /* Media.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Media.swift; sourceTree = "<group>"; };
+		8128550A23C4AC7E00ADA66E /* MediaEdge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaEdge.swift; sourceTree = "<group>"; };
+		8128550B23C4AC7E00ADA66E /* MoneyV2Connection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MoneyV2Connection.swift; sourceTree = "<group>"; };
+		8128550C23C4AC7E00ADA66E /* MediaContentType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaContentType.swift; sourceTree = "<group>"; };
+		8128550D23C4AC7E00ADA66E /* ExternalVideo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExternalVideo.swift; sourceTree = "<group>"; };
+		8128550E23C4AC7E00ADA66E /* MoneyV2Edge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MoneyV2Edge.swift; sourceTree = "<group>"; };
+		8128550F23C4AC7E00ADA66E /* MediaConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaConnection.swift; sourceTree = "<group>"; };
+		8128551023C4AC7E00ADA66E /* MediaImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaImage.swift; sourceTree = "<group>"; };
+		8128551123C4AC7E00ADA66E /* UnitPriceMeasurementMeasuredType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitPriceMeasurementMeasuredType.swift; sourceTree = "<group>"; };
 		9A035E0F2177B763008596C9 /* TokenizedPaymentInputV2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenizedPaymentInputV2.swift; sourceTree = "<group>"; };
 		9A0C7FCC1EA6631B0020F187 /* Models.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		9A0C7FD01EA669C80020F187 /* PayDiscount.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayDiscount.swift; sourceTree = "<group>"; };
@@ -993,6 +1023,21 @@
 		9A0C7FF81EAA51C50020F187 /* Storefront */ = {
 			isa = PBXGroup;
 			children = (
+				8128550D23C4AC7E00ADA66E /* ExternalVideo.swift */,
+				8128550923C4AC7E00ADA66E /* Media.swift */,
+				8128550F23C4AC7E00ADA66E /* MediaConnection.swift */,
+				8128550C23C4AC7E00ADA66E /* MediaContentType.swift */,
+				8128550A23C4AC7E00ADA66E /* MediaEdge.swift */,
+				8128551023C4AC7E00ADA66E /* MediaImage.swift */,
+				8128550423C4AC7D00ADA66E /* Model3d.swift */,
+				8128550323C4AC7D00ADA66E /* Model3dSource.swift */,
+				8128550B23C4AC7E00ADA66E /* MoneyV2Connection.swift */,
+				8128550E23C4AC7E00ADA66E /* MoneyV2Edge.swift */,
+				8128550523C4AC7E00ADA66E /* UnitPriceMeasurement.swift */,
+				8128551123C4AC7E00ADA66E /* UnitPriceMeasurementMeasuredType.swift */,
+				8128550823C4AC7E00ADA66E /* UnitPriceMeasurementMeasuredUnit.swift */,
+				8128550723C4AC7E00ADA66E /* Video.swift */,
+				8128550623C4AC7E00ADA66E /* VideoSource.swift */,
 				FB7707D722CD488E00ED289E /* ApiVersion.swift */,
 				9A0C7FF91EAA51C50020F187 /* AppliedGiftCard.swift */,
 				9AA416C21EE095AA0060029B /* Article.swift */,
@@ -1953,6 +1998,7 @@
 				9A2ACDDB21CABB7100C09FF7 /* CheckoutLineItemsReplacePayload.swift in Sources */,
 				9A67116421666AB200A57A3F /* ManualDiscountApplication.swift in Sources */,
 				9A0C80AB1EAA51C50020F187 /* QueryRoot.swift in Sources */,
+				8128551A23C4AC7E00ADA66E /* MoneyV2Connection.swift in Sources */,
 				9A0C80AD1EAA51C50020F187 /* ShippingRate.swift in Sources */,
 				9A0C80641EAA51C50020F187 /* CheckoutCustomerAssociatePayload.swift in Sources */,
 				9AA416D01EE095B20060029B /* Blog.swift in Sources */,
@@ -1963,6 +2009,7 @@
 				9A0C80671EAA51C50020F187 /* CheckoutGiftCardApplyPayload.swift in Sources */,
 				9A0C809B1EAA51C50020F187 /* OrderDisplayFulfillmentStatus.swift in Sources */,
 				9A0C80A51EAA51C50020F187 /* ProductEdge.swift in Sources */,
+				8128551823C4AC7E00ADA66E /* Media.swift in Sources */,
 				9A0C805E1EAA51C50020F187 /* CheckoutAttributesUpdatePayload.swift in Sources */,
 				9A0C80B51EAA51C50020F187 /* WeightUnit.swift in Sources */,
 				9A2ACE2D21CD3C8700C09FF7 /* AutomaticDiscountApplication.swift in Sources */,
@@ -1992,16 +2039,19 @@
 				9ABEB3C12122FFE900A373F2 /* CheckoutGiftCardsAppendPayload.swift in Sources */,
 				9A0C80881EAA51C50020F187 /* CustomerRecoverPayload.swift in Sources */,
 				9A67114221666A6700A57A3F /* CheckoutErrorCode.swift in Sources */,
+				8128551323C4AC7E00ADA66E /* Model3d.swift in Sources */,
 				9AF1C1881F13B45C0064AEA0 /* PaymentSettings.swift in Sources */,
 				9A0C808D1EAA51C50020F187 /* Domain.swift in Sources */,
 				9A0C80F21EB773520020F187 /* Card.CreditCard.swift in Sources */,
 				9A67117321666AB200A57A3F /* DiscountAllocation.swift in Sources */,
 				9A0C80B11EAA51C50020F187 /* Transaction.swift in Sources */,
+				8128551623C4AC7E00ADA66E /* Video.swift in Sources */,
 				9A0C80631EAA51C50020F187 /* CheckoutCreatePayload.swift in Sources */,
 				9A0C81051EBA66440020F187 /* Graph.Cache.swift in Sources */,
 				9A0C80961EAA51C50020F187 /* Node.swift in Sources */,
 				9A0C80711EAA51C50020F187 /* CheckoutShippingAddressUpdatePayload.swift in Sources */,
 				9A0C809F1EAA51C50020F187 /* OrderLineItemEdge.swift in Sources */,
+				8128551923C4AC7E00ADA66E /* MediaEdge.swift in Sources */,
 				9A47C04C218087880043525D /* CheckoutGiftCardRemoveV2Payload.swift in Sources */,
 				9A0C80F01EB773310020F187 /* Card.swift in Sources */,
 				9A0C80701EAA51C50020F187 /* CheckoutLineItemUpdateInput.swift in Sources */,
@@ -2057,6 +2107,8 @@
 				9A0C80871EAA51C50020F187 /* CustomerCreatePayload.swift in Sources */,
 				9AA416C71EE095AA0060029B /* Article.swift in Sources */,
 				9A0C80911EAA51C50020F187 /* MailingAddress.swift in Sources */,
+				8128551523C4AC7E00ADA66E /* VideoSource.swift in Sources */,
+				8128551723C4AC7E00ADA66E /* UnitPriceMeasurementMeasuredUnit.swift in Sources */,
 				9A2ACDCE21CABAC200C09FF7 /* ProductVariantPricePairConnection.swift in Sources */,
 				9AA416C91EE095AA0060029B /* ArticleConnection.swift in Sources */,
 				9A0C80791EAA51C50020F187 /* CropRegion.swift in Sources */,
@@ -2071,16 +2123,20 @@
 				9A0C805C1EAA51C50020F187 /* Checkout.swift in Sources */,
 				9A0C806A1EAA51C50020F187 /* CheckoutLineItemConnection.swift in Sources */,
 				9AC2EFD71F686DB90037E0D7 /* Optional+Input.swift in Sources */,
+				8128551423C4AC7E00ADA66E /* UnitPriceMeasurement.swift in Sources */,
 				9A0C80931EAA51C50020F187 /* MailingAddressEdge.swift in Sources */,
 				9AA416DA1EE095BB0060029B /* CommentConnection.swift in Sources */,
 				9A67115E21666AB200A57A3F /* DiscountCodeApplication.swift in Sources */,
 				9A0C80B21EAA51C50020F187 /* TransactionKind.swift in Sources */,
 				9A0C80861EAA51C50020F187 /* CustomerCreateInput.swift in Sources */,
+				8128551C23C4AC7E00ADA66E /* ExternalVideo.swift in Sources */,
 				9AA416CA1EE095AA0060029B /* ArticleEdge.swift in Sources */,
 				9AA9A3F62279E79B0002DFDA /* Metafield.swift in Sources */,
+				8128551B23C4AC7E00ADA66E /* MediaContentType.swift in Sources */,
 				9A0C80B41EAA51C50020F187 /* UserError.swift in Sources */,
 				9A0C80811EAA51C50020F187 /* CustomerActivateInput.swift in Sources */,
 				9A2ACDCB21CABAC200C09FF7 /* ProductVariantPricePairEdge.swift in Sources */,
+				8128551D23C4AC7E00ADA66E /* MoneyV2Edge.swift in Sources */,
 				9A47C049218087880043525D /* CheckoutCustomerAssociateV2Payload.swift in Sources */,
 				9A0C80821EAA51C50020F187 /* CustomerActivatePayload.swift in Sources */,
 				9A0C805A1EAA51C50020F187 /* AttributeInput.swift in Sources */,
@@ -2091,9 +2147,11 @@
 				9A67113B2166678500A57A3F /* MoneyInput.swift in Sources */,
 				9AA416C81EE095AA0060029B /* ArticleAuthor.swift in Sources */,
 				9ABEB3BD2122FF8000A373F2 /* CustomerErrorCode.swift in Sources */,
+				8128551F23C4AC7E00ADA66E /* MediaImage.swift in Sources */,
 				9A0C80AC1EAA51C50020F187 /* SelectedOption.swift in Sources */,
 				9A0C809E1EAA51C50020F187 /* OrderLineItemConnection.swift in Sources */,
 				9A0C805D1EAA51C50020F187 /* CheckoutAttributesUpdateInput.swift in Sources */,
+				8128551E23C4AC7E00ADA66E /* MediaConnection.swift in Sources */,
 				9A0C806D1EAA51C50020F187 /* CheckoutLineItemsAddPayload.swift in Sources */,
 				9A0C80781EAA51C50020F187 /* CreditCardPaymentInput.swift in Sources */,
 				9A125D001F16A0E0008DCF38 /* StringEdge.swift in Sources */,
@@ -2114,6 +2172,7 @@
 				9AA416CB1EE095AA0060029B /* ArticleSortKeys.swift in Sources */,
 				9AD577652153E315006BD1C5 /* CheckoutAttributesUpdateV2Payload.swift in Sources */,
 				9A9EA43C20AF0EBB002CB926 /* DisplayableError.swift in Sources */,
+				8128552023C4AC7E00ADA66E /* UnitPriceMeasurementMeasuredType.swift in Sources */,
 				9A52D3A31F3CA58E00C093C8 /* CardBrand.swift in Sources */,
 				9A656CC62183B04700D3A41C /* CheckoutDiscountCodeApplyV2Payload.swift in Sources */,
 				9A67115521666AB200A57A3F /* ScriptDiscountApplication.swift in Sources */,
@@ -2126,6 +2185,7 @@
 				9AA9A4032279E7AF0002DFDA /* HasMetafields.swift in Sources */,
 				9A0C80A01EAA51C50020F187 /* OrderSortKeys.swift in Sources */,
 				9A6711382166678500A57A3F /* CreditCardPaymentInputV2.swift in Sources */,
+				8128551223C4AC7E00ADA66E /* Model3dSource.swift in Sources */,
 				9A0C80601EAA51C50020F187 /* CheckoutCompleteWithCreditCardPayload.swift in Sources */,
 				9A0C806B1EAA51C50020F187 /* CheckoutLineItemEdge.swift in Sources */,
 				9A0C80A41EAA51C50020F187 /* ProductConnection.swift in Sources */,

--- a/Buy/Generated/Storefront/CheckoutErrorCode.swift
+++ b/Buy/Generated/Storefront/CheckoutErrorCode.swift
@@ -137,6 +137,9 @@ extension Storefront {
 		/// The amount of the payment does not match the value to be paid. 
 		case totalPriceMismatch = "TOTAL_PRICE_MISMATCH"
 
+		/// Unable to apply discount. 
+		case unableToApply = "UNABLE_TO_APPLY"
+
 		case unknownValue = ""
 	}
 }

--- a/Buy/Generated/Storefront/CountryCode.swift
+++ b/Buy/Generated/Storefront/CountryCode.swift
@@ -113,7 +113,7 @@ extension Storefront {
 		/// Bolivia. 
 		case bo = "BO"
 
-		/// Bonaire, Sint Eustatius and Saba. 
+		/// Caribbean Netherlands. 
 		case bq = "BQ"
 
 		/// Brazil. 

--- a/Buy/Generated/Storefront/CurrencyCode.swift
+++ b/Buy/Generated/Storefront/CurrencyCode.swift
@@ -27,7 +27,7 @@
 import Foundation
 
 extension Storefront {
-	/// Currency codes 
+	/// Currency codes. 
 	public enum CurrencyCode: String {
 		/// United Arab Emirates Dirham (AED). 
 		case aed = "AED"
@@ -156,6 +156,9 @@ extension Storefront {
 		/// Fijian Dollars (FJD). 
 		case fjd = "FJD"
 
+		/// Falkland Islands Pounds (FKP). 
+		case fkp = "FKP"
+
 		/// United Kingdom Pounds (GBP). 
 		case gbp = "GBP"
 
@@ -164,6 +167,9 @@ extension Storefront {
 
 		/// Ghanaian Cedi (GHS). 
 		case ghs = "GHS"
+
+		/// Gibraltar Pounds (GIP). 
+		case gip = "GIP"
 
 		/// Gambian Dalasi (GMD). 
 		case gmd = "GMD"
@@ -383,6 +389,9 @@ extension Storefront {
 
 		/// Singapore Dollars (SGD). 
 		case sgd = "SGD"
+
+		/// Saint Helena Pounds (SHP). 
+		case shp = "SHP"
 
 		/// Sierra Leonean Leone (SLL). 
 		case sll = "SLL"

--- a/Buy/Generated/Storefront/CustomerCreateInput.swift
+++ b/Buy/Generated/Storefront/CustomerCreateInput.swift
@@ -38,7 +38,8 @@ extension Storefront {
 		/// The customer’s email. 
 		open var email: String
 
-		/// The customer’s phone number. 
+		/// A unique phone number for the customer. Formatted using E.164 standard. For 
+		/// example, _+16135551111_. 
 		open var phone: Input<String>
 
 		/// The login password used by the customer. 
@@ -54,7 +55,7 @@ extension Storefront {
 		///     - firstName: The customer’s first name.
 		///     - lastName: The customer’s last name.
 		///     - email: The customer’s email.
-		///     - phone: The customer’s phone number.
+		///     - phone: A unique phone number for the customer.  Formatted using E.164 standard. For example, _+16135551111_. 
 		///     - password: The login password used by the customer.
 		///     - acceptsMarketing: Indicates whether the customer has consented to be sent marketing material via email.
 		///
@@ -77,7 +78,7 @@ extension Storefront {
 		///     - firstName: The customer’s first name.
 		///     - lastName: The customer’s last name.
 		///     - email: The customer’s email.
-		///     - phone: The customer’s phone number.
+		///     - phone: A unique phone number for the customer.  Formatted using E.164 standard. For example, _+16135551111_. 
 		///     - password: The login password used by the customer.
 		///     - acceptsMarketing: Indicates whether the customer has consented to be sent marketing material via email.
 		///

--- a/Buy/Generated/Storefront/CustomerUpdateInput.swift
+++ b/Buy/Generated/Storefront/CustomerUpdateInput.swift
@@ -38,7 +38,8 @@ extension Storefront {
 		/// The customer’s email. 
 		open var email: Input<String>
 
-		/// The customer’s phone number. 
+		/// A unique phone number for the customer. Formatted using E.164 standard. For 
+		/// example, _+16135551111_. 
 		open var phone: Input<String>
 
 		/// The login password used by the customer. 
@@ -54,7 +55,7 @@ extension Storefront {
 		///     - firstName: The customer’s first name.
 		///     - lastName: The customer’s last name.
 		///     - email: The customer’s email.
-		///     - phone: The customer’s phone number.
+		///     - phone: A unique phone number for the customer.  Formatted using E.164 standard. For example, _+16135551111_. 
 		///     - password: The login password used by the customer.
 		///     - acceptsMarketing: Indicates whether the customer has consented to be sent marketing material via email.
 		///
@@ -77,7 +78,7 @@ extension Storefront {
 		///     - firstName: The customer’s first name.
 		///     - lastName: The customer’s last name.
 		///     - email: The customer’s email.
-		///     - phone: The customer’s phone number.
+		///     - phone: A unique phone number for the customer.  Formatted using E.164 standard. For example, _+16135551111_. 
 		///     - password: The login password used by the customer.
 		///     - acceptsMarketing: Indicates whether the customer has consented to be sent marketing material via email.
 		///

--- a/Buy/Generated/Storefront/ExternalVideo.swift
+++ b/Buy/Generated/Storefront/ExternalVideo.swift
@@ -1,0 +1,179 @@
+//
+//  ExternalVideo.swift
+//  Buy
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+extension Storefront {
+	/// Represents a video hosted outside of Shopify. 
+	open class ExternalVideoQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = ExternalVideo
+
+		/// A word or phrase to share the nature or contents of a media. 
+		@discardableResult
+		open func alt(alias: String? = nil) -> ExternalVideoQuery {
+			addField(field: "alt", aliasSuffix: alias)
+			return self
+		}
+
+		/// The URL. 
+		@discardableResult
+		open func embeddedUrl(alias: String? = nil) -> ExternalVideoQuery {
+			addField(field: "embeddedUrl", aliasSuffix: alias)
+			return self
+		}
+
+		/// Globally unique identifier. 
+		@discardableResult
+		open func id(alias: String? = nil) -> ExternalVideoQuery {
+			addField(field: "id", aliasSuffix: alias)
+			return self
+		}
+
+		/// The media content type. 
+		@discardableResult
+		open func mediaContentType(alias: String? = nil) -> ExternalVideoQuery {
+			addField(field: "mediaContentType", aliasSuffix: alias)
+			return self
+		}
+
+		/// The preview image for the media. 
+		@discardableResult
+		open func previewImage(alias: String? = nil, _ subfields: (ImageQuery) -> Void) -> ExternalVideoQuery {
+			let subquery = ImageQuery()
+			subfields(subquery)
+
+			addField(field: "previewImage", aliasSuffix: alias, subfields: subquery)
+			return self
+		}
+	}
+
+	/// Represents a video hosted outside of Shopify. 
+	open class ExternalVideo: GraphQL.AbstractResponse, GraphQLObject, Media, Node {
+		public typealias Query = ExternalVideoQuery
+
+		internal override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
+			let fieldValue = value
+			switch fieldName {
+				case "alt":
+				if value is NSNull { return nil }
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: ExternalVideo.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "embeddedUrl":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: ExternalVideo.self, field: fieldName, value: fieldValue)
+				}
+				return URL(string: value)!
+
+				case "id":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: ExternalVideo.self, field: fieldName, value: fieldValue)
+				}
+				return GraphQL.ID(rawValue: value)
+
+				case "mediaContentType":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: ExternalVideo.self, field: fieldName, value: fieldValue)
+				}
+				return MediaContentType(rawValue: value) ?? .unknownValue
+
+				case "previewImage":
+				if value is NSNull { return nil }
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: ExternalVideo.self, field: fieldName, value: fieldValue)
+				}
+				return try Image(fields: value)
+
+				default:
+				throw SchemaViolationError(type: ExternalVideo.self, field: fieldName, value: fieldValue)
+			}
+		}
+
+		/// A word or phrase to share the nature or contents of a media. 
+		open var alt: String? {
+			return internalGetAlt()
+		}
+
+		func internalGetAlt(alias: String? = nil) -> String? {
+			return field(field: "alt", aliasSuffix: alias) as! String?
+		}
+
+		/// The URL. 
+		open var embeddedUrl: URL {
+			return internalGetEmbeddedUrl()
+		}
+
+		func internalGetEmbeddedUrl(alias: String? = nil) -> URL {
+			return field(field: "embeddedUrl", aliasSuffix: alias) as! URL
+		}
+
+		/// Globally unique identifier. 
+		open var id: GraphQL.ID {
+			return internalGetId()
+		}
+
+		func internalGetId(alias: String? = nil) -> GraphQL.ID {
+			return field(field: "id", aliasSuffix: alias) as! GraphQL.ID
+		}
+
+		/// The media content type. 
+		open var mediaContentType: Storefront.MediaContentType {
+			return internalGetMediaContentType()
+		}
+
+		func internalGetMediaContentType(alias: String? = nil) -> Storefront.MediaContentType {
+			return field(field: "mediaContentType", aliasSuffix: alias) as! Storefront.MediaContentType
+		}
+
+		/// The preview image for the media. 
+		open var previewImage: Storefront.Image? {
+			return internalGetPreviewImage()
+		}
+
+		func internalGetPreviewImage(alias: String? = nil) -> Storefront.Image? {
+			return field(field: "previewImage", aliasSuffix: alias) as! Storefront.Image?
+		}
+
+		internal override func childResponseObjectMap() -> [GraphQL.AbstractResponse]  {
+			var response: [GraphQL.AbstractResponse] = []
+			objectMap.keys.forEach {
+				switch($0) {
+					case "previewImage":
+					if let value = internalGetPreviewImage() {
+						response.append(value)
+						response.append(contentsOf: value.childResponseObjectMap())
+					}
+
+					default:
+					break
+				}
+			}
+			return response
+		}
+	}
+}

--- a/Buy/Generated/Storefront/MailingAddressInput.swift
+++ b/Buy/Generated/Storefront/MailingAddressInput.swift
@@ -29,39 +29,52 @@ import Foundation
 extension Storefront {
 	/// Specifies the fields accepted to create or update a mailing address. 
 	open class MailingAddressInput {
+		/// The first line of the address. Typically the street address or PO Box 
+		/// number. 
 		open var address1: Input<String>
 
+		/// The second line of the address. Typically the number of the apartment, 
+		/// suite, or unit. 
 		open var address2: Input<String>
 
+		/// The name of the city, district, village, or town. 
 		open var city: Input<String>
 
+		/// The name of the customer's company or organization. 
 		open var company: Input<String>
 
+		/// The name of the country. 
 		open var country: Input<String>
 
+		/// The first name of the customer. 
 		open var firstName: Input<String>
 
+		/// The last name of the customer. 
 		open var lastName: Input<String>
 
+		/// A unique phone number for the customer. Formatted using E.164 standard. For 
+		/// example, _+16135551111_. 
 		open var phone: Input<String>
 
+		/// The region of the address, such as the province, state, or district. 
 		open var province: Input<String>
 
+		/// The zip or postal code of the address. 
 		open var zip: Input<String>
 
 		/// Creates the input object.
 		///
 		/// - parameters:
-		///     - address1: No description
-		///     - address2: No description
-		///     - city: No description
-		///     - company: No description
-		///     - country: No description
-		///     - firstName: No description
-		///     - lastName: No description
-		///     - phone: No description
-		///     - province: No description
-		///     - zip: No description
+		///     - address1: The first line of the address. Typically the street address or PO Box number. 
+		///     - address2: The second line of the address. Typically the number of the apartment, suite, or unit. 
+		///     - city: The name of the city, district, village, or town. 
+		///     - company: The name of the customer's company or organization. 
+		///     - country: The name of the country.
+		///     - firstName: The first name of the customer.
+		///     - lastName: The last name of the customer.
+		///     - phone: A unique phone number for the customer.  Formatted using E.164 standard. For example, _+16135551111_. 
+		///     - province: The region of the address, such as the province, state, or district.
+		///     - zip: The zip or postal code of the address.
 		///
 		public static func create(address1: Input<String> = .undefined, address2: Input<String> = .undefined, city: Input<String> = .undefined, company: Input<String> = .undefined, country: Input<String> = .undefined, firstName: Input<String> = .undefined, lastName: Input<String> = .undefined, phone: Input<String> = .undefined, province: Input<String> = .undefined, zip: Input<String> = .undefined) -> MailingAddressInput {
 			return MailingAddressInput(address1: address1, address2: address2, city: city, company: company, country: country, firstName: firstName, lastName: lastName, phone: phone, province: province, zip: zip)
@@ -83,16 +96,16 @@ extension Storefront {
 		/// Creates the input object.
 		///
 		/// - parameters:
-		///     - address1: No description
-		///     - address2: No description
-		///     - city: No description
-		///     - company: No description
-		///     - country: No description
-		///     - firstName: No description
-		///     - lastName: No description
-		///     - phone: No description
-		///     - province: No description
-		///     - zip: No description
+		///     - address1: The first line of the address. Typically the street address or PO Box number. 
+		///     - address2: The second line of the address. Typically the number of the apartment, suite, or unit. 
+		///     - city: The name of the city, district, village, or town. 
+		///     - company: The name of the customer's company or organization. 
+		///     - country: The name of the country.
+		///     - firstName: The first name of the customer.
+		///     - lastName: The last name of the customer.
+		///     - phone: A unique phone number for the customer.  Formatted using E.164 standard. For example, _+16135551111_. 
+		///     - province: The region of the address, such as the province, state, or district.
+		///     - zip: The zip or postal code of the address.
 		///
 		@available(*, deprecated, message: "Use the static create() method instead.")
 		public convenience init(address1: String? = nil, address2: String? = nil, city: String? = nil, company: String? = nil, country: String? = nil, firstName: String? = nil, lastName: String? = nil, phone: String? = nil, province: String? = nil, zip: String? = nil) {

--- a/Buy/Generated/Storefront/Media.swift
+++ b/Buy/Generated/Storefront/Media.swift
@@ -1,0 +1,203 @@
+//
+//  Media.swift
+//  Buy
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+/// Represents a media interface. 
+public protocol Media {
+	var alt: String? { get }
+
+	var mediaContentType: Storefront.MediaContentType { get }
+
+	var previewImage: Storefront.Image? { get }
+}
+
+extension Storefront {
+	/// Represents a media interface. 
+	open class MediaQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = Media
+
+		/// A word or phrase to share the nature or contents of a media. 
+		@discardableResult
+		open func alt(alias: String? = nil) -> MediaQuery {
+			addField(field: "alt", aliasSuffix: alias)
+			return self
+		}
+
+		/// The media content type. 
+		@discardableResult
+		open func mediaContentType(alias: String? = nil) -> MediaQuery {
+			addField(field: "mediaContentType", aliasSuffix: alias)
+			return self
+		}
+
+		/// The preview image for the media. 
+		@discardableResult
+		open func previewImage(alias: String? = nil, _ subfields: (ImageQuery) -> Void) -> MediaQuery {
+			let subquery = ImageQuery()
+			subfields(subquery)
+
+			addField(field: "previewImage", aliasSuffix: alias, subfields: subquery)
+			return self
+		}
+
+		override init() {
+			super.init()
+			addField(field: "__typename")
+		}
+
+		/// Represents a media interface. 
+		@discardableResult
+		open func onExternalVideo(subfields: (ExternalVideoQuery) -> Void) -> MediaQuery {
+			let subquery = ExternalVideoQuery()
+			subfields(subquery)
+			addInlineFragment(on: "ExternalVideo", subfields: subquery)
+			return self
+		}
+
+		/// Represents a media interface. 
+		@discardableResult
+		open func onMediaImage(subfields: (MediaImageQuery) -> Void) -> MediaQuery {
+			let subquery = MediaImageQuery()
+			subfields(subquery)
+			addInlineFragment(on: "MediaImage", subfields: subquery)
+			return self
+		}
+
+		/// Represents a media interface. 
+		@discardableResult
+		open func onModel3d(subfields: (Model3dQuery) -> Void) -> MediaQuery {
+			let subquery = Model3dQuery()
+			subfields(subquery)
+			addInlineFragment(on: "Model3d", subfields: subquery)
+			return self
+		}
+
+		/// Represents a media interface. 
+		@discardableResult
+		open func onVideo(subfields: (VideoQuery) -> Void) -> MediaQuery {
+			let subquery = VideoQuery()
+			subfields(subquery)
+			addInlineFragment(on: "Video", subfields: subquery)
+			return self
+		}
+	}
+
+	/// Represents a media interface. 
+	open class UnknownMedia: GraphQL.AbstractResponse, GraphQLObject, Media {
+		public typealias Query = MediaQuery
+
+		internal override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
+			let fieldValue = value
+			switch fieldName {
+				case "alt":
+				if value is NSNull { return nil }
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: UnknownMedia.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "mediaContentType":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: UnknownMedia.self, field: fieldName, value: fieldValue)
+				}
+				return MediaContentType(rawValue: value) ?? .unknownValue
+
+				case "previewImage":
+				if value is NSNull { return nil }
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: UnknownMedia.self, field: fieldName, value: fieldValue)
+				}
+				return try Image(fields: value)
+
+				default:
+				throw SchemaViolationError(type: UnknownMedia.self, field: fieldName, value: fieldValue)
+			}
+		}
+
+		internal static func create(fields: [String: Any]) throws -> Media {
+			guard let typeName = fields["__typename"] as? String else {
+				throw SchemaViolationError(type: UnknownMedia.self, field: "__typename", value: fields["__typename"] ?? NSNull())
+			}
+			switch typeName {
+				case "ExternalVideo": return try ExternalVideo.init(fields: fields)
+
+				case "MediaImage": return try MediaImage.init(fields: fields)
+
+				case "Model3d": return try Model3d.init(fields: fields)
+
+				case "Video": return try Video.init(fields: fields)
+
+				default:
+				return try UnknownMedia.init(fields: fields)
+			}
+		}
+
+		/// A word or phrase to share the nature or contents of a media. 
+		open var alt: String? {
+			return internalGetAlt()
+		}
+
+		func internalGetAlt(alias: String? = nil) -> String? {
+			return field(field: "alt", aliasSuffix: alias) as! String?
+		}
+
+		/// The media content type. 
+		open var mediaContentType: Storefront.MediaContentType {
+			return internalGetMediaContentType()
+		}
+
+		func internalGetMediaContentType(alias: String? = nil) -> Storefront.MediaContentType {
+			return field(field: "mediaContentType", aliasSuffix: alias) as! Storefront.MediaContentType
+		}
+
+		/// The preview image for the media. 
+		open var previewImage: Storefront.Image? {
+			return internalGetPreviewImage()
+		}
+
+		func internalGetPreviewImage(alias: String? = nil) -> Storefront.Image? {
+			return field(field: "previewImage", aliasSuffix: alias) as! Storefront.Image?
+		}
+
+		internal override func childResponseObjectMap() -> [GraphQL.AbstractResponse]  {
+			var response: [GraphQL.AbstractResponse] = []
+			objectMap.keys.forEach {
+				switch($0) {
+					case "previewImage":
+					if let value = internalGetPreviewImage() {
+						response.append(value)
+						response.append(contentsOf: value.childResponseObjectMap())
+					}
+
+					default:
+					break
+				}
+			}
+			return response
+		}
+	}
+}

--- a/Buy/Generated/Storefront/MediaConnection.swift
+++ b/Buy/Generated/Storefront/MediaConnection.swift
@@ -1,0 +1,116 @@
+//
+//  MediaConnection.swift
+//  Buy
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+extension Storefront {
+	open class MediaConnectionQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = MediaConnection
+
+		/// A list of edges. 
+		@discardableResult
+		open func edges(alias: String? = nil, _ subfields: (MediaEdgeQuery) -> Void) -> MediaConnectionQuery {
+			let subquery = MediaEdgeQuery()
+			subfields(subquery)
+
+			addField(field: "edges", aliasSuffix: alias, subfields: subquery)
+			return self
+		}
+
+		/// Information to aid in pagination. 
+		@discardableResult
+		open func pageInfo(alias: String? = nil, _ subfields: (PageInfoQuery) -> Void) -> MediaConnectionQuery {
+			let subquery = PageInfoQuery()
+			subfields(subquery)
+
+			addField(field: "pageInfo", aliasSuffix: alias, subfields: subquery)
+			return self
+		}
+	}
+
+	open class MediaConnection: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = MediaConnectionQuery
+
+		internal override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
+			let fieldValue = value
+			switch fieldName {
+				case "edges":
+				guard let value = value as? [[String: Any]] else {
+					throw SchemaViolationError(type: MediaConnection.self, field: fieldName, value: fieldValue)
+				}
+				return try value.map { return try MediaEdge(fields: $0) }
+
+				case "pageInfo":
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: MediaConnection.self, field: fieldName, value: fieldValue)
+				}
+				return try PageInfo(fields: value)
+
+				default:
+				throw SchemaViolationError(type: MediaConnection.self, field: fieldName, value: fieldValue)
+			}
+		}
+
+		/// A list of edges. 
+		open var edges: [Storefront.MediaEdge] {
+			return internalGetEdges()
+		}
+
+		func internalGetEdges(alias: String? = nil) -> [Storefront.MediaEdge] {
+			return field(field: "edges", aliasSuffix: alias) as! [Storefront.MediaEdge]
+		}
+
+		/// Information to aid in pagination. 
+		open var pageInfo: Storefront.PageInfo {
+			return internalGetPageInfo()
+		}
+
+		func internalGetPageInfo(alias: String? = nil) -> Storefront.PageInfo {
+			return field(field: "pageInfo", aliasSuffix: alias) as! Storefront.PageInfo
+		}
+
+		internal override func childResponseObjectMap() -> [GraphQL.AbstractResponse]  {
+			var response: [GraphQL.AbstractResponse] = []
+			objectMap.keys.forEach {
+				switch($0) {
+					case "edges":
+					internalGetEdges().forEach {
+						response.append($0)
+						response.append(contentsOf: $0.childResponseObjectMap())
+					}
+
+					case "pageInfo":
+					response.append(internalGetPageInfo())
+					response.append(contentsOf: internalGetPageInfo().childResponseObjectMap())
+
+					default:
+					break
+				}
+			}
+			return response
+		}
+	}
+}

--- a/Buy/Generated/Storefront/MediaContentType.swift
+++ b/Buy/Generated/Storefront/MediaContentType.swift
@@ -1,0 +1,46 @@
+//
+//  MediaContentType.swift
+//  Buy
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+extension Storefront {
+	/// The possible content types for a media object. 
+	public enum MediaContentType: String {
+		/// An externally hosted video. 
+		case externalVideo = "EXTERNAL_VIDEO"
+
+		/// A Shopify hosted image. 
+		case image = "IMAGE"
+
+		/// A 3d model. 
+		case model3d = "MODEL_3D"
+
+		/// A Shopify hosted video. 
+		case video = "VIDEO"
+
+		case unknownValue = ""
+	}
+}

--- a/Buy/Generated/Storefront/MediaEdge.swift
+++ b/Buy/Generated/Storefront/MediaEdge.swift
@@ -1,0 +1,107 @@
+//
+//  MediaEdge.swift
+//  Buy
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+extension Storefront {
+	open class MediaEdgeQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = MediaEdge
+
+		/// A cursor for use in pagination. 
+		@discardableResult
+		open func cursor(alias: String? = nil) -> MediaEdgeQuery {
+			addField(field: "cursor", aliasSuffix: alias)
+			return self
+		}
+
+		/// The item at the end of MediaEdge. 
+		@discardableResult
+		open func node(alias: String? = nil, _ subfields: (MediaQuery) -> Void) -> MediaEdgeQuery {
+			let subquery = MediaQuery()
+			subfields(subquery)
+
+			addField(field: "node", aliasSuffix: alias, subfields: subquery)
+			return self
+		}
+	}
+
+	open class MediaEdge: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = MediaEdgeQuery
+
+		internal override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
+			let fieldValue = value
+			switch fieldName {
+				case "cursor":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: MediaEdge.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "node":
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: MediaEdge.self, field: fieldName, value: fieldValue)
+				}
+				return try UnknownMedia.create(fields: value)
+
+				default:
+				throw SchemaViolationError(type: MediaEdge.self, field: fieldName, value: fieldValue)
+			}
+		}
+
+		/// A cursor for use in pagination. 
+		open var cursor: String {
+			return internalGetCursor()
+		}
+
+		func internalGetCursor(alias: String? = nil) -> String {
+			return field(field: "cursor", aliasSuffix: alias) as! String
+		}
+
+		/// The item at the end of MediaEdge. 
+		open var node: Media {
+			return internalGetNode()
+		}
+
+		func internalGetNode(alias: String? = nil) -> Media {
+			return field(field: "node", aliasSuffix: alias) as! Media
+		}
+
+		internal override func childResponseObjectMap() -> [GraphQL.AbstractResponse]  {
+			var response: [GraphQL.AbstractResponse] = []
+			objectMap.keys.forEach {
+				switch($0) {
+					case "node":
+					response.append((internalGetNode() as! GraphQL.AbstractResponse))
+					response.append(contentsOf: (internalGetNode() as! GraphQL.AbstractResponse).childResponseObjectMap())
+
+					default:
+					break
+				}
+			}
+			return response
+		}
+	}
+}

--- a/Buy/Generated/Storefront/MediaImage.swift
+++ b/Buy/Generated/Storefront/MediaImage.swift
@@ -1,0 +1,189 @@
+//
+//  MediaImage.swift
+//  Buy
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+extension Storefront {
+	/// Represents a Shopify hosted image. 
+	open class MediaImageQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = MediaImage
+
+		/// A word or phrase to share the nature or contents of a media. 
+		@discardableResult
+		open func alt(alias: String? = nil) -> MediaImageQuery {
+			addField(field: "alt", aliasSuffix: alias)
+			return self
+		}
+
+		/// Globally unique identifier. 
+		@discardableResult
+		open func id(alias: String? = nil) -> MediaImageQuery {
+			addField(field: "id", aliasSuffix: alias)
+			return self
+		}
+
+		/// The image for the media. 
+		@discardableResult
+		open func image(alias: String? = nil, _ subfields: (ImageQuery) -> Void) -> MediaImageQuery {
+			let subquery = ImageQuery()
+			subfields(subquery)
+
+			addField(field: "image", aliasSuffix: alias, subfields: subquery)
+			return self
+		}
+
+		/// The media content type. 
+		@discardableResult
+		open func mediaContentType(alias: String? = nil) -> MediaImageQuery {
+			addField(field: "mediaContentType", aliasSuffix: alias)
+			return self
+		}
+
+		/// The preview image for the media. 
+		@discardableResult
+		open func previewImage(alias: String? = nil, _ subfields: (ImageQuery) -> Void) -> MediaImageQuery {
+			let subquery = ImageQuery()
+			subfields(subquery)
+
+			addField(field: "previewImage", aliasSuffix: alias, subfields: subquery)
+			return self
+		}
+	}
+
+	/// Represents a Shopify hosted image. 
+	open class MediaImage: GraphQL.AbstractResponse, GraphQLObject, Media, Node {
+		public typealias Query = MediaImageQuery
+
+		internal override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
+			let fieldValue = value
+			switch fieldName {
+				case "alt":
+				if value is NSNull { return nil }
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: MediaImage.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "id":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: MediaImage.self, field: fieldName, value: fieldValue)
+				}
+				return GraphQL.ID(rawValue: value)
+
+				case "image":
+				if value is NSNull { return nil }
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: MediaImage.self, field: fieldName, value: fieldValue)
+				}
+				return try Image(fields: value)
+
+				case "mediaContentType":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: MediaImage.self, field: fieldName, value: fieldValue)
+				}
+				return MediaContentType(rawValue: value) ?? .unknownValue
+
+				case "previewImage":
+				if value is NSNull { return nil }
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: MediaImage.self, field: fieldName, value: fieldValue)
+				}
+				return try Image(fields: value)
+
+				default:
+				throw SchemaViolationError(type: MediaImage.self, field: fieldName, value: fieldValue)
+			}
+		}
+
+		/// A word or phrase to share the nature or contents of a media. 
+		open var alt: String? {
+			return internalGetAlt()
+		}
+
+		func internalGetAlt(alias: String? = nil) -> String? {
+			return field(field: "alt", aliasSuffix: alias) as! String?
+		}
+
+		/// Globally unique identifier. 
+		open var id: GraphQL.ID {
+			return internalGetId()
+		}
+
+		func internalGetId(alias: String? = nil) -> GraphQL.ID {
+			return field(field: "id", aliasSuffix: alias) as! GraphQL.ID
+		}
+
+		/// The image for the media. 
+		open var image: Storefront.Image? {
+			return internalGetImage()
+		}
+
+		func internalGetImage(alias: String? = nil) -> Storefront.Image? {
+			return field(field: "image", aliasSuffix: alias) as! Storefront.Image?
+		}
+
+		/// The media content type. 
+		open var mediaContentType: Storefront.MediaContentType {
+			return internalGetMediaContentType()
+		}
+
+		func internalGetMediaContentType(alias: String? = nil) -> Storefront.MediaContentType {
+			return field(field: "mediaContentType", aliasSuffix: alias) as! Storefront.MediaContentType
+		}
+
+		/// The preview image for the media. 
+		open var previewImage: Storefront.Image? {
+			return internalGetPreviewImage()
+		}
+
+		func internalGetPreviewImage(alias: String? = nil) -> Storefront.Image? {
+			return field(field: "previewImage", aliasSuffix: alias) as! Storefront.Image?
+		}
+
+		internal override func childResponseObjectMap() -> [GraphQL.AbstractResponse]  {
+			var response: [GraphQL.AbstractResponse] = []
+			objectMap.keys.forEach {
+				switch($0) {
+					case "image":
+					if let value = internalGetImage() {
+						response.append(value)
+						response.append(contentsOf: value.childResponseObjectMap())
+					}
+
+					case "previewImage":
+					if let value = internalGetPreviewImage() {
+						response.append(value)
+						response.append(contentsOf: value.childResponseObjectMap())
+					}
+
+					default:
+					break
+				}
+			}
+			return response
+		}
+	}
+}

--- a/Buy/Generated/Storefront/Model3d.swift
+++ b/Buy/Generated/Storefront/Model3d.swift
@@ -1,0 +1,188 @@
+//
+//  Model3d.swift
+//  Buy
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+extension Storefront {
+	/// Represents a Shopify hosted 3D model. 
+	open class Model3dQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = Model3d
+
+		/// A word or phrase to share the nature or contents of a media. 
+		@discardableResult
+		open func alt(alias: String? = nil) -> Model3dQuery {
+			addField(field: "alt", aliasSuffix: alias)
+			return self
+		}
+
+		/// Globally unique identifier. 
+		@discardableResult
+		open func id(alias: String? = nil) -> Model3dQuery {
+			addField(field: "id", aliasSuffix: alias)
+			return self
+		}
+
+		/// The media content type. 
+		@discardableResult
+		open func mediaContentType(alias: String? = nil) -> Model3dQuery {
+			addField(field: "mediaContentType", aliasSuffix: alias)
+			return self
+		}
+
+		/// The preview image for the media. 
+		@discardableResult
+		open func previewImage(alias: String? = nil, _ subfields: (ImageQuery) -> Void) -> Model3dQuery {
+			let subquery = ImageQuery()
+			subfields(subquery)
+
+			addField(field: "previewImage", aliasSuffix: alias, subfields: subquery)
+			return self
+		}
+
+		/// The sources for a 3d model. 
+		@discardableResult
+		open func sources(alias: String? = nil, _ subfields: (Model3dSourceQuery) -> Void) -> Model3dQuery {
+			let subquery = Model3dSourceQuery()
+			subfields(subquery)
+
+			addField(field: "sources", aliasSuffix: alias, subfields: subquery)
+			return self
+		}
+	}
+
+	/// Represents a Shopify hosted 3D model. 
+	open class Model3d: GraphQL.AbstractResponse, GraphQLObject, Media, Node {
+		public typealias Query = Model3dQuery
+
+		internal override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
+			let fieldValue = value
+			switch fieldName {
+				case "alt":
+				if value is NSNull { return nil }
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: Model3d.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "id":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: Model3d.self, field: fieldName, value: fieldValue)
+				}
+				return GraphQL.ID(rawValue: value)
+
+				case "mediaContentType":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: Model3d.self, field: fieldName, value: fieldValue)
+				}
+				return MediaContentType(rawValue: value) ?? .unknownValue
+
+				case "previewImage":
+				if value is NSNull { return nil }
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: Model3d.self, field: fieldName, value: fieldValue)
+				}
+				return try Image(fields: value)
+
+				case "sources":
+				guard let value = value as? [[String: Any]] else {
+					throw SchemaViolationError(type: Model3d.self, field: fieldName, value: fieldValue)
+				}
+				return try value.map { return try Model3dSource(fields: $0) }
+
+				default:
+				throw SchemaViolationError(type: Model3d.self, field: fieldName, value: fieldValue)
+			}
+		}
+
+		/// A word or phrase to share the nature or contents of a media. 
+		open var alt: String? {
+			return internalGetAlt()
+		}
+
+		func internalGetAlt(alias: String? = nil) -> String? {
+			return field(field: "alt", aliasSuffix: alias) as! String?
+		}
+
+		/// Globally unique identifier. 
+		open var id: GraphQL.ID {
+			return internalGetId()
+		}
+
+		func internalGetId(alias: String? = nil) -> GraphQL.ID {
+			return field(field: "id", aliasSuffix: alias) as! GraphQL.ID
+		}
+
+		/// The media content type. 
+		open var mediaContentType: Storefront.MediaContentType {
+			return internalGetMediaContentType()
+		}
+
+		func internalGetMediaContentType(alias: String? = nil) -> Storefront.MediaContentType {
+			return field(field: "mediaContentType", aliasSuffix: alias) as! Storefront.MediaContentType
+		}
+
+		/// The preview image for the media. 
+		open var previewImage: Storefront.Image? {
+			return internalGetPreviewImage()
+		}
+
+		func internalGetPreviewImage(alias: String? = nil) -> Storefront.Image? {
+			return field(field: "previewImage", aliasSuffix: alias) as! Storefront.Image?
+		}
+
+		/// The sources for a 3d model. 
+		open var sources: [Storefront.Model3dSource] {
+			return internalGetSources()
+		}
+
+		func internalGetSources(alias: String? = nil) -> [Storefront.Model3dSource] {
+			return field(field: "sources", aliasSuffix: alias) as! [Storefront.Model3dSource]
+		}
+
+		internal override func childResponseObjectMap() -> [GraphQL.AbstractResponse]  {
+			var response: [GraphQL.AbstractResponse] = []
+			objectMap.keys.forEach {
+				switch($0) {
+					case "previewImage":
+					if let value = internalGetPreviewImage() {
+						response.append(value)
+						response.append(contentsOf: value.childResponseObjectMap())
+					}
+
+					case "sources":
+					internalGetSources().forEach {
+						response.append($0)
+						response.append(contentsOf: $0.childResponseObjectMap())
+					}
+
+					default:
+					break
+				}
+			}
+			return response
+		}
+	}
+}

--- a/Buy/Generated/Storefront/Model3dSource.swift
+++ b/Buy/Generated/Storefront/Model3dSource.swift
@@ -1,0 +1,139 @@
+//
+//  Model3dSource.swift
+//  Buy
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+extension Storefront {
+	/// Represents a source for a Shopify hosted 3d model. 
+	open class Model3dSourceQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = Model3dSource
+
+		/// The filesize of the 3d model. 
+		@discardableResult
+		open func filesize(alias: String? = nil) -> Model3dSourceQuery {
+			addField(field: "filesize", aliasSuffix: alias)
+			return self
+		}
+
+		/// The format of the 3d model. 
+		@discardableResult
+		open func format(alias: String? = nil) -> Model3dSourceQuery {
+			addField(field: "format", aliasSuffix: alias)
+			return self
+		}
+
+		/// The MIME type of the 3d model. 
+		@discardableResult
+		open func mimeType(alias: String? = nil) -> Model3dSourceQuery {
+			addField(field: "mimeType", aliasSuffix: alias)
+			return self
+		}
+
+		/// The URL of the 3d model. 
+		@discardableResult
+		open func url(alias: String? = nil) -> Model3dSourceQuery {
+			addField(field: "url", aliasSuffix: alias)
+			return self
+		}
+	}
+
+	/// Represents a source for a Shopify hosted 3d model. 
+	open class Model3dSource: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = Model3dSourceQuery
+
+		internal override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
+			let fieldValue = value
+			switch fieldName {
+				case "filesize":
+				guard let value = value as? Int else {
+					throw SchemaViolationError(type: Model3dSource.self, field: fieldName, value: fieldValue)
+				}
+				return Int32(value)
+
+				case "format":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: Model3dSource.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "mimeType":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: Model3dSource.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "url":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: Model3dSource.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				default:
+				throw SchemaViolationError(type: Model3dSource.self, field: fieldName, value: fieldValue)
+			}
+		}
+
+		/// The filesize of the 3d model. 
+		open var filesize: Int32 {
+			return internalGetFilesize()
+		}
+
+		func internalGetFilesize(alias: String? = nil) -> Int32 {
+			return field(field: "filesize", aliasSuffix: alias) as! Int32
+		}
+
+		/// The format of the 3d model. 
+		open var format: String {
+			return internalGetFormat()
+		}
+
+		func internalGetFormat(alias: String? = nil) -> String {
+			return field(field: "format", aliasSuffix: alias) as! String
+		}
+
+		/// The MIME type of the 3d model. 
+		open var mimeType: String {
+			return internalGetMimeType()
+		}
+
+		func internalGetMimeType(alias: String? = nil) -> String {
+			return field(field: "mimeType", aliasSuffix: alias) as! String
+		}
+
+		/// The URL of the 3d model. 
+		open var url: String {
+			return internalGetUrl()
+		}
+
+		func internalGetUrl(alias: String? = nil) -> String {
+			return field(field: "url", aliasSuffix: alias) as! String
+		}
+
+		internal override func childResponseObjectMap() -> [GraphQL.AbstractResponse]  {
+			return []
+		}
+	}
+}

--- a/Buy/Generated/Storefront/MoneyV2Connection.swift
+++ b/Buy/Generated/Storefront/MoneyV2Connection.swift
@@ -1,0 +1,116 @@
+//
+//  MoneyV2Connection.swift
+//  Buy
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+extension Storefront {
+	open class MoneyV2ConnectionQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = MoneyV2Connection
+
+		/// A list of edges. 
+		@discardableResult
+		open func edges(alias: String? = nil, _ subfields: (MoneyV2EdgeQuery) -> Void) -> MoneyV2ConnectionQuery {
+			let subquery = MoneyV2EdgeQuery()
+			subfields(subquery)
+
+			addField(field: "edges", aliasSuffix: alias, subfields: subquery)
+			return self
+		}
+
+		/// Information to aid in pagination. 
+		@discardableResult
+		open func pageInfo(alias: String? = nil, _ subfields: (PageInfoQuery) -> Void) -> MoneyV2ConnectionQuery {
+			let subquery = PageInfoQuery()
+			subfields(subquery)
+
+			addField(field: "pageInfo", aliasSuffix: alias, subfields: subquery)
+			return self
+		}
+	}
+
+	open class MoneyV2Connection: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = MoneyV2ConnectionQuery
+
+		internal override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
+			let fieldValue = value
+			switch fieldName {
+				case "edges":
+				guard let value = value as? [[String: Any]] else {
+					throw SchemaViolationError(type: MoneyV2Connection.self, field: fieldName, value: fieldValue)
+				}
+				return try value.map { return try MoneyV2Edge(fields: $0) }
+
+				case "pageInfo":
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: MoneyV2Connection.self, field: fieldName, value: fieldValue)
+				}
+				return try PageInfo(fields: value)
+
+				default:
+				throw SchemaViolationError(type: MoneyV2Connection.self, field: fieldName, value: fieldValue)
+			}
+		}
+
+		/// A list of edges. 
+		open var edges: [Storefront.MoneyV2Edge] {
+			return internalGetEdges()
+		}
+
+		func internalGetEdges(alias: String? = nil) -> [Storefront.MoneyV2Edge] {
+			return field(field: "edges", aliasSuffix: alias) as! [Storefront.MoneyV2Edge]
+		}
+
+		/// Information to aid in pagination. 
+		open var pageInfo: Storefront.PageInfo {
+			return internalGetPageInfo()
+		}
+
+		func internalGetPageInfo(alias: String? = nil) -> Storefront.PageInfo {
+			return field(field: "pageInfo", aliasSuffix: alias) as! Storefront.PageInfo
+		}
+
+		internal override func childResponseObjectMap() -> [GraphQL.AbstractResponse]  {
+			var response: [GraphQL.AbstractResponse] = []
+			objectMap.keys.forEach {
+				switch($0) {
+					case "edges":
+					internalGetEdges().forEach {
+						response.append($0)
+						response.append(contentsOf: $0.childResponseObjectMap())
+					}
+
+					case "pageInfo":
+					response.append(internalGetPageInfo())
+					response.append(contentsOf: internalGetPageInfo().childResponseObjectMap())
+
+					default:
+					break
+				}
+			}
+			return response
+		}
+	}
+}

--- a/Buy/Generated/Storefront/MoneyV2Edge.swift
+++ b/Buy/Generated/Storefront/MoneyV2Edge.swift
@@ -1,0 +1,107 @@
+//
+//  MoneyV2Edge.swift
+//  Buy
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+extension Storefront {
+	open class MoneyV2EdgeQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = MoneyV2Edge
+
+		/// A cursor for use in pagination. 
+		@discardableResult
+		open func cursor(alias: String? = nil) -> MoneyV2EdgeQuery {
+			addField(field: "cursor", aliasSuffix: alias)
+			return self
+		}
+
+		/// The item at the end of MoneyV2Edge. 
+		@discardableResult
+		open func node(alias: String? = nil, _ subfields: (MoneyV2Query) -> Void) -> MoneyV2EdgeQuery {
+			let subquery = MoneyV2Query()
+			subfields(subquery)
+
+			addField(field: "node", aliasSuffix: alias, subfields: subquery)
+			return self
+		}
+	}
+
+	open class MoneyV2Edge: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = MoneyV2EdgeQuery
+
+		internal override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
+			let fieldValue = value
+			switch fieldName {
+				case "cursor":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: MoneyV2Edge.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "node":
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: MoneyV2Edge.self, field: fieldName, value: fieldValue)
+				}
+				return try MoneyV2(fields: value)
+
+				default:
+				throw SchemaViolationError(type: MoneyV2Edge.self, field: fieldName, value: fieldValue)
+			}
+		}
+
+		/// A cursor for use in pagination. 
+		open var cursor: String {
+			return internalGetCursor()
+		}
+
+		func internalGetCursor(alias: String? = nil) -> String {
+			return field(field: "cursor", aliasSuffix: alias) as! String
+		}
+
+		/// The item at the end of MoneyV2Edge. 
+		open var node: Storefront.MoneyV2 {
+			return internalGetNode()
+		}
+
+		func internalGetNode(alias: String? = nil) -> Storefront.MoneyV2 {
+			return field(field: "node", aliasSuffix: alias) as! Storefront.MoneyV2
+		}
+
+		internal override func childResponseObjectMap() -> [GraphQL.AbstractResponse]  {
+			var response: [GraphQL.AbstractResponse] = []
+			objectMap.keys.forEach {
+				switch($0) {
+					case "node":
+					response.append(internalGetNode())
+					response.append(contentsOf: internalGetNode().childResponseObjectMap())
+
+					default:
+					break
+				}
+			}
+			return response
+		}
+	}
+}

--- a/Buy/Generated/Storefront/Node.swift
+++ b/Buy/Generated/Storefront/Node.swift
@@ -113,6 +113,15 @@ extension Storefront {
 
 		/// An object with an ID to support global identification. 
 		@discardableResult
+		open func onExternalVideo(subfields: (ExternalVideoQuery) -> Void) -> NodeQuery {
+			let subquery = ExternalVideoQuery()
+			subfields(subquery)
+			addInlineFragment(on: "ExternalVideo", subfields: subquery)
+			return self
+		}
+
+		/// An object with an ID to support global identification. 
+		@discardableResult
 		open func onMailingAddress(subfields: (MailingAddressQuery) -> Void) -> NodeQuery {
 			let subquery = MailingAddressQuery()
 			subfields(subquery)
@@ -122,10 +131,28 @@ extension Storefront {
 
 		/// An object with an ID to support global identification. 
 		@discardableResult
+		open func onMediaImage(subfields: (MediaImageQuery) -> Void) -> NodeQuery {
+			let subquery = MediaImageQuery()
+			subfields(subquery)
+			addInlineFragment(on: "MediaImage", subfields: subquery)
+			return self
+		}
+
+		/// An object with an ID to support global identification. 
+		@discardableResult
 		open func onMetafield(subfields: (MetafieldQuery) -> Void) -> NodeQuery {
 			let subquery = MetafieldQuery()
 			subfields(subquery)
 			addInlineFragment(on: "Metafield", subfields: subquery)
+			return self
+		}
+
+		/// An object with an ID to support global identification. 
+		@discardableResult
+		open func onModel3d(subfields: (Model3dQuery) -> Void) -> NodeQuery {
+			let subquery = Model3dQuery()
+			subfields(subquery)
+			addInlineFragment(on: "Model3d", subfields: subquery)
 			return self
 		}
 
@@ -191,6 +218,15 @@ extension Storefront {
 			addInlineFragment(on: "ShopPolicy", subfields: subquery)
 			return self
 		}
+
+		/// An object with an ID to support global identification. 
+		@discardableResult
+		open func onVideo(subfields: (VideoQuery) -> Void) -> NodeQuery {
+			let subquery = VideoQuery()
+			subfields(subquery)
+			addInlineFragment(on: "Video", subfields: subquery)
+			return self
+		}
 	}
 
 	/// An object with an ID to support global identification. 
@@ -230,9 +266,15 @@ extension Storefront {
 
 				case "Comment": return try Comment.init(fields: fields)
 
+				case "ExternalVideo": return try ExternalVideo.init(fields: fields)
+
 				case "MailingAddress": return try MailingAddress.init(fields: fields)
 
+				case "MediaImage": return try MediaImage.init(fields: fields)
+
 				case "Metafield": return try Metafield.init(fields: fields)
+
+				case "Model3d": return try Model3d.init(fields: fields)
 
 				case "Order": return try Order.init(fields: fields)
 
@@ -247,6 +289,8 @@ extension Storefront {
 				case "ProductVariant": return try ProductVariant.init(fields: fields)
 
 				case "ShopPolicy": return try ShopPolicy.init(fields: fields)
+
+				case "Video": return try Video.init(fields: fields)
 
 				default:
 				return try UnknownNode.init(fields: fields)

--- a/Buy/Generated/Storefront/ProductVariant.swift
+++ b/Buy/Generated/Storefront/ProductVariant.swift
@@ -230,6 +230,53 @@ extension Storefront {
 			return self
 		}
 
+		/// List of unit prices in the presentment currencies for this shop. 
+		///
+		/// - parameters:
+		///     - presentmentCurrencies: Specify the currencies in which to return presentment unit prices.
+		///     - first: Returns up to the first `n` elements from the list.
+		///     - after: Returns the elements that come after the specified cursor.
+		///     - last: Returns up to the last `n` elements from the list.
+		///     - before: Returns the elements that come before the specified cursor.
+		///     - reverse: Reverse the order of the underlying list.
+		///
+		@discardableResult
+		open func presentmentUnitPrices(alias: String? = nil, presentmentCurrencies: [CurrencyCode]? = nil, first: Int32? = nil, after: String? = nil, last: Int32? = nil, before: String? = nil, reverse: Bool? = nil, _ subfields: (MoneyV2ConnectionQuery) -> Void) -> ProductVariantQuery {
+			var args: [String] = []
+
+			if let presentmentCurrencies = presentmentCurrencies {
+				args.append("presentmentCurrencies:[\(presentmentCurrencies.map{ "\($0.rawValue)" }.joined(separator: ","))]")
+			}
+
+			if let first = first {
+				args.append("first:\(first)")
+			}
+
+			if let after = after {
+				args.append("after:\(GraphQL.quoteString(input: after))")
+			}
+
+			if let last = last {
+				args.append("last:\(last)")
+			}
+
+			if let before = before {
+				args.append("before:\(GraphQL.quoteString(input: before))")
+			}
+
+			if let reverse = reverse {
+				args.append("reverse:\(reverse)")
+			}
+
+			let argsString: String? = args.isEmpty ? nil : "(\(args.joined(separator: ",")))"
+
+			let subquery = MoneyV2ConnectionQuery()
+			subfields(subquery)
+
+			addField(field: "presentmentUnitPrices", aliasSuffix: alias, args: argsString, subfields: subquery)
+			return self
+		}
+
 		/// The product variant’s price. 
 		@available(*, deprecated, message:"Use `priceV2` instead")
 		@discardableResult
@@ -287,6 +334,26 @@ extension Storefront {
 		@discardableResult
 		open func title(alias: String? = nil) -> ProductVariantQuery {
 			addField(field: "title", aliasSuffix: alias)
+			return self
+		}
+
+		/// The unit price value for the variant based on the variant's measurement. 
+		@discardableResult
+		open func unitPrice(alias: String? = nil, _ subfields: (MoneyV2Query) -> Void) -> ProductVariantQuery {
+			let subquery = MoneyV2Query()
+			subfields(subquery)
+
+			addField(field: "unitPrice", aliasSuffix: alias, subfields: subquery)
+			return self
+		}
+
+		/// The unit price measurement for the variant. 
+		@discardableResult
+		open func unitPriceMeasurement(alias: String? = nil, _ subfields: (UnitPriceMeasurementQuery) -> Void) -> ProductVariantQuery {
+			let subquery = UnitPriceMeasurementQuery()
+			subfields(subquery)
+
+			addField(field: "unitPriceMeasurement", aliasSuffix: alias, subfields: subquery)
 			return self
 		}
 
@@ -373,6 +440,12 @@ extension Storefront {
 				}
 				return try ProductVariantPricePairConnection(fields: value)
 
+				case "presentmentUnitPrices":
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
+				}
+				return try MoneyV2Connection(fields: value)
+
 				case "price":
 				guard let value = value as? String else {
 					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
@@ -415,6 +488,20 @@ extension Storefront {
 					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
 				}
 				return value
+
+				case "unitPrice":
+				if value is NSNull { return nil }
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
+				}
+				return try MoneyV2(fields: value)
+
+				case "unitPriceMeasurement":
+				if value is NSNull { return nil }
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: ProductVariant.self, field: fieldName, value: fieldValue)
+				}
+				return try UnitPriceMeasurement(fields: value)
 
 				case "weight":
 				if value is NSNull { return nil }
@@ -537,6 +624,19 @@ extension Storefront {
 			return field(field: "presentmentPrices", aliasSuffix: alias) as! Storefront.ProductVariantPricePairConnection
 		}
 
+		/// List of unit prices in the presentment currencies for this shop. 
+		open var presentmentUnitPrices: Storefront.MoneyV2Connection {
+			return internalGetPresentmentUnitPrices()
+		}
+
+		open func aliasedPresentmentUnitPrices(alias: String) -> Storefront.MoneyV2Connection {
+			return internalGetPresentmentUnitPrices(alias: alias)
+		}
+
+		func internalGetPresentmentUnitPrices(alias: String? = nil) -> Storefront.MoneyV2Connection {
+			return field(field: "presentmentUnitPrices", aliasSuffix: alias) as! Storefront.MoneyV2Connection
+		}
+
 		/// The product variant’s price. 
 		@available(*, deprecated, message:"Use `priceV2` instead")
 		open var price: Decimal {
@@ -602,6 +702,24 @@ extension Storefront {
 			return field(field: "title", aliasSuffix: alias) as! String
 		}
 
+		/// The unit price value for the variant based on the variant's measurement. 
+		open var unitPrice: Storefront.MoneyV2? {
+			return internalGetUnitPrice()
+		}
+
+		func internalGetUnitPrice(alias: String? = nil) -> Storefront.MoneyV2? {
+			return field(field: "unitPrice", aliasSuffix: alias) as! Storefront.MoneyV2?
+		}
+
+		/// The unit price measurement for the variant. 
+		open var unitPriceMeasurement: Storefront.UnitPriceMeasurement? {
+			return internalGetUnitPriceMeasurement()
+		}
+
+		func internalGetUnitPriceMeasurement(alias: String? = nil) -> Storefront.UnitPriceMeasurement? {
+			return field(field: "unitPriceMeasurement", aliasSuffix: alias) as! Storefront.UnitPriceMeasurement?
+		}
+
 		/// The weight of the product variant in the unit system specified with 
 		/// `weight_unit`. 
 		open var weight: Double? {
@@ -651,6 +769,10 @@ extension Storefront {
 					response.append(internalGetPresentmentPrices())
 					response.append(contentsOf: internalGetPresentmentPrices().childResponseObjectMap())
 
+					case "presentmentUnitPrices":
+					response.append(internalGetPresentmentUnitPrices())
+					response.append(contentsOf: internalGetPresentmentUnitPrices().childResponseObjectMap())
+
 					case "priceV2":
 					response.append(internalGetPriceV2())
 					response.append(contentsOf: internalGetPriceV2().childResponseObjectMap())
@@ -663,6 +785,18 @@ extension Storefront {
 					internalGetSelectedOptions().forEach {
 						response.append($0)
 						response.append(contentsOf: $0.childResponseObjectMap())
+					}
+
+					case "unitPrice":
+					if let value = internalGetUnitPrice() {
+						response.append(value)
+						response.append(contentsOf: value.childResponseObjectMap())
+					}
+
+					case "unitPriceMeasurement":
+					if let value = internalGetUnitPriceMeasurement() {
+						response.append(value)
+						response.append(contentsOf: value.childResponseObjectMap())
 					}
 
 					default:

--- a/Buy/Generated/Storefront/TokenizedPaymentInputV2.swift
+++ b/Buy/Generated/Storefront/TokenizedPaymentInputV2.swift
@@ -41,6 +41,9 @@ extension Storefront {
 		/// The billing address for the payment. 
 		open var billingAddress: MailingAddressInput
 
+		/// The type of payment token. 
+		open var type: String
+
 		/// A simple string or JSON containing the required payment data for the 
 		/// tokenized payment. 
 		open var paymentData: String
@@ -51,32 +54,29 @@ extension Storefront {
 		/// Public Hash Key used for AndroidPay payments only. 
 		open var identifier: Input<String>
 
-		/// The type of payment token. 
-		open var type: String
-
 		/// Creates the input object.
 		///
 		/// - parameters:
 		///     - paymentAmount: The amount and currency of the payment.
 		///     - idempotencyKey: A unique client generated key used to avoid duplicate charges. When a duplicate payment is found, the original is returned instead of creating a new one.
 		///     - billingAddress: The billing address for the payment.
+		///     - type: The type of payment token.
 		///     - paymentData: A simple string or JSON containing the required payment data for the tokenized payment.
 		///     - test: Executes the payment in test mode if possible. Defaults to `false`.
 		///     - identifier: Public Hash Key used for AndroidPay payments only.
-		///     - type: The type of payment token.
 		///
-		public static func create(paymentAmount: MoneyInput, idempotencyKey: String, billingAddress: MailingAddressInput, paymentData: String, type: String, test: Input<Bool> = .undefined, identifier: Input<String> = .undefined) -> TokenizedPaymentInputV2 {
-			return TokenizedPaymentInputV2(paymentAmount: paymentAmount, idempotencyKey: idempotencyKey, billingAddress: billingAddress, paymentData: paymentData, type: type, test: test, identifier: identifier)
+		public static func create(paymentAmount: MoneyInput, idempotencyKey: String, billingAddress: MailingAddressInput, type: String, paymentData: String, test: Input<Bool> = .undefined, identifier: Input<String> = .undefined) -> TokenizedPaymentInputV2 {
+			return TokenizedPaymentInputV2(paymentAmount: paymentAmount, idempotencyKey: idempotencyKey, billingAddress: billingAddress, type: type, paymentData: paymentData, test: test, identifier: identifier)
 		}
 
-		private init(paymentAmount: MoneyInput, idempotencyKey: String, billingAddress: MailingAddressInput, paymentData: String, type: String, test: Input<Bool> = .undefined, identifier: Input<String> = .undefined) {
+		private init(paymentAmount: MoneyInput, idempotencyKey: String, billingAddress: MailingAddressInput, type: String, paymentData: String, test: Input<Bool> = .undefined, identifier: Input<String> = .undefined) {
 			self.paymentAmount = paymentAmount
 			self.idempotencyKey = idempotencyKey
 			self.billingAddress = billingAddress
+			self.type = type
 			self.paymentData = paymentData
 			self.test = test
 			self.identifier = identifier
-			self.type = type
 		}
 
 		/// Creates the input object.
@@ -85,14 +85,14 @@ extension Storefront {
 		///     - paymentAmount: The amount and currency of the payment.
 		///     - idempotencyKey: A unique client generated key used to avoid duplicate charges. When a duplicate payment is found, the original is returned instead of creating a new one.
 		///     - billingAddress: The billing address for the payment.
+		///     - type: The type of payment token.
 		///     - paymentData: A simple string or JSON containing the required payment data for the tokenized payment.
 		///     - test: Executes the payment in test mode if possible. Defaults to `false`.
 		///     - identifier: Public Hash Key used for AndroidPay payments only.
-		///     - type: The type of payment token.
 		///
 		@available(*, deprecated, message: "Use the static create() method instead.")
-		public convenience init(paymentAmount: MoneyInput, idempotencyKey: String, billingAddress: MailingAddressInput, paymentData: String, type: String, test: Bool? = nil, identifier: String? = nil) {
-			self.init(paymentAmount: paymentAmount, idempotencyKey: idempotencyKey, billingAddress: billingAddress, paymentData: paymentData, type: type, test: test.orUndefined, identifier: identifier.orUndefined)
+		public convenience init(paymentAmount: MoneyInput, idempotencyKey: String, billingAddress: MailingAddressInput, type: String, paymentData: String, test: Bool? = nil, identifier: String? = nil) {
+			self.init(paymentAmount: paymentAmount, idempotencyKey: idempotencyKey, billingAddress: billingAddress, type: type, paymentData: paymentData, test: test.orUndefined, identifier: identifier.orUndefined)
 		}
 
 		internal func serialize() -> String {
@@ -103,6 +103,8 @@ extension Storefront {
 			fields.append("idempotencyKey:\(GraphQL.quoteString(input: idempotencyKey))")
 
 			fields.append("billingAddress:\(billingAddress.serialize())")
+
+			fields.append("type:\(GraphQL.quoteString(input: type))")
 
 			fields.append("paymentData:\(GraphQL.quoteString(input: paymentData))")
 
@@ -125,8 +127,6 @@ extension Storefront {
 				fields.append("identifier:\(GraphQL.quoteString(input: identifier))")
 				case .undefined: break
 			}
-
-			fields.append("type:\(GraphQL.quoteString(input: type))")
 
 			return "{\(fields.joined(separator: ","))}"
 		}

--- a/Buy/Generated/Storefront/TokenizedPaymentInputV2.swift
+++ b/Buy/Generated/Storefront/TokenizedPaymentInputV2.swift
@@ -41,9 +41,6 @@ extension Storefront {
 		/// The billing address for the payment. 
 		open var billingAddress: MailingAddressInput
 
-		/// The type of payment token. 
-		open var type: String
-
 		/// A simple string or JSON containing the required payment data for the 
 		/// tokenized payment. 
 		open var paymentData: String
@@ -54,29 +51,32 @@ extension Storefront {
 		/// Public Hash Key used for AndroidPay payments only. 
 		open var identifier: Input<String>
 
+		/// The type of payment token. 
+		open var type: String
+
 		/// Creates the input object.
 		///
 		/// - parameters:
 		///     - paymentAmount: The amount and currency of the payment.
 		///     - idempotencyKey: A unique client generated key used to avoid duplicate charges. When a duplicate payment is found, the original is returned instead of creating a new one.
 		///     - billingAddress: The billing address for the payment.
-		///     - type: The type of payment token.
 		///     - paymentData: A simple string or JSON containing the required payment data for the tokenized payment.
 		///     - test: Executes the payment in test mode if possible. Defaults to `false`.
 		///     - identifier: Public Hash Key used for AndroidPay payments only.
+		///     - type: The type of payment token.
 		///
-		public static func create(paymentAmount: MoneyInput, idempotencyKey: String, billingAddress: MailingAddressInput, type: String, paymentData: String, test: Input<Bool> = .undefined, identifier: Input<String> = .undefined) -> TokenizedPaymentInputV2 {
-			return TokenizedPaymentInputV2(paymentAmount: paymentAmount, idempotencyKey: idempotencyKey, billingAddress: billingAddress, type: type, paymentData: paymentData, test: test, identifier: identifier)
+		public static func create(paymentAmount: MoneyInput, idempotencyKey: String, billingAddress: MailingAddressInput, paymentData: String, type: String, test: Input<Bool> = .undefined, identifier: Input<String> = .undefined) -> TokenizedPaymentInputV2 {
+			return TokenizedPaymentInputV2(paymentAmount: paymentAmount, idempotencyKey: idempotencyKey, billingAddress: billingAddress, paymentData: paymentData, type: type, test: test, identifier: identifier)
 		}
 
-		private init(paymentAmount: MoneyInput, idempotencyKey: String, billingAddress: MailingAddressInput, type: String, paymentData: String, test: Input<Bool> = .undefined, identifier: Input<String> = .undefined) {
+		private init(paymentAmount: MoneyInput, idempotencyKey: String, billingAddress: MailingAddressInput, paymentData: String, type: String, test: Input<Bool> = .undefined, identifier: Input<String> = .undefined) {
 			self.paymentAmount = paymentAmount
 			self.idempotencyKey = idempotencyKey
 			self.billingAddress = billingAddress
-			self.type = type
 			self.paymentData = paymentData
 			self.test = test
 			self.identifier = identifier
+			self.type = type
 		}
 
 		/// Creates the input object.
@@ -85,14 +85,14 @@ extension Storefront {
 		///     - paymentAmount: The amount and currency of the payment.
 		///     - idempotencyKey: A unique client generated key used to avoid duplicate charges. When a duplicate payment is found, the original is returned instead of creating a new one.
 		///     - billingAddress: The billing address for the payment.
-		///     - type: The type of payment token.
 		///     - paymentData: A simple string or JSON containing the required payment data for the tokenized payment.
 		///     - test: Executes the payment in test mode if possible. Defaults to `false`.
 		///     - identifier: Public Hash Key used for AndroidPay payments only.
+		///     - type: The type of payment token.
 		///
 		@available(*, deprecated, message: "Use the static create() method instead.")
-		public convenience init(paymentAmount: MoneyInput, idempotencyKey: String, billingAddress: MailingAddressInput, type: String, paymentData: String, test: Bool? = nil, identifier: String? = nil) {
-			self.init(paymentAmount: paymentAmount, idempotencyKey: idempotencyKey, billingAddress: billingAddress, type: type, paymentData: paymentData, test: test.orUndefined, identifier: identifier.orUndefined)
+		public convenience init(paymentAmount: MoneyInput, idempotencyKey: String, billingAddress: MailingAddressInput, paymentData: String, type: String, test: Bool? = nil, identifier: String? = nil) {
+			self.init(paymentAmount: paymentAmount, idempotencyKey: idempotencyKey, billingAddress: billingAddress, paymentData: paymentData, type: type, test: test.orUndefined, identifier: identifier.orUndefined)
 		}
 
 		internal func serialize() -> String {
@@ -103,8 +103,6 @@ extension Storefront {
 			fields.append("idempotencyKey:\(GraphQL.quoteString(input: idempotencyKey))")
 
 			fields.append("billingAddress:\(billingAddress.serialize())")
-
-			fields.append("type:\(GraphQL.quoteString(input: type))")
 
 			fields.append("paymentData:\(GraphQL.quoteString(input: paymentData))")
 
@@ -127,6 +125,8 @@ extension Storefront {
 				fields.append("identifier:\(GraphQL.quoteString(input: identifier))")
 				case .undefined: break
 			}
+
+			fields.append("type:\(GraphQL.quoteString(input: type))")
 
 			return "{\(fields.joined(separator: ","))}"
 		}

--- a/Buy/Generated/Storefront/UnitPriceMeasurement.swift
+++ b/Buy/Generated/Storefront/UnitPriceMeasurement.swift
@@ -1,0 +1,166 @@
+//
+//  UnitPriceMeasurement.swift
+//  Buy
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+extension Storefront {
+	/// The measurement used to calculate a unit price for a product variant (e.g. 
+	/// $9.99 / 100ml). 
+	open class UnitPriceMeasurementQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = UnitPriceMeasurement
+
+		/// The type of unit of measurement for the unit price measurement. 
+		@discardableResult
+		open func measuredType(alias: String? = nil) -> UnitPriceMeasurementQuery {
+			addField(field: "measuredType", aliasSuffix: alias)
+			return self
+		}
+
+		/// The quantity unit for the unit price measurement. 
+		@discardableResult
+		open func quantityUnit(alias: String? = nil) -> UnitPriceMeasurementQuery {
+			addField(field: "quantityUnit", aliasSuffix: alias)
+			return self
+		}
+
+		/// The quantity value for the unit price measurement. 
+		@discardableResult
+		open func quantityValue(alias: String? = nil) -> UnitPriceMeasurementQuery {
+			addField(field: "quantityValue", aliasSuffix: alias)
+			return self
+		}
+
+		/// The reference unit for the unit price measurement. 
+		@discardableResult
+		open func referenceUnit(alias: String? = nil) -> UnitPriceMeasurementQuery {
+			addField(field: "referenceUnit", aliasSuffix: alias)
+			return self
+		}
+
+		/// The reference value for the unit price measurement. 
+		@discardableResult
+		open func referenceValue(alias: String? = nil) -> UnitPriceMeasurementQuery {
+			addField(field: "referenceValue", aliasSuffix: alias)
+			return self
+		}
+	}
+
+	/// The measurement used to calculate a unit price for a product variant (e.g. 
+	/// $9.99 / 100ml). 
+	open class UnitPriceMeasurement: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = UnitPriceMeasurementQuery
+
+		internal override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
+			let fieldValue = value
+			switch fieldName {
+				case "measuredType":
+				if value is NSNull { return nil }
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: UnitPriceMeasurement.self, field: fieldName, value: fieldValue)
+				}
+				return UnitPriceMeasurementMeasuredType(rawValue: value) ?? .unknownValue
+
+				case "quantityUnit":
+				if value is NSNull { return nil }
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: UnitPriceMeasurement.self, field: fieldName, value: fieldValue)
+				}
+				return UnitPriceMeasurementMeasuredUnit(rawValue: value) ?? .unknownValue
+
+				case "quantityValue":
+				guard let value = value as? Double else {
+					throw SchemaViolationError(type: UnitPriceMeasurement.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "referenceUnit":
+				if value is NSNull { return nil }
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: UnitPriceMeasurement.self, field: fieldName, value: fieldValue)
+				}
+				return UnitPriceMeasurementMeasuredUnit(rawValue: value) ?? .unknownValue
+
+				case "referenceValue":
+				guard let value = value as? Int else {
+					throw SchemaViolationError(type: UnitPriceMeasurement.self, field: fieldName, value: fieldValue)
+				}
+				return Int32(value)
+
+				default:
+				throw SchemaViolationError(type: UnitPriceMeasurement.self, field: fieldName, value: fieldValue)
+			}
+		}
+
+		/// The type of unit of measurement for the unit price measurement. 
+		open var measuredType: Storefront.UnitPriceMeasurementMeasuredType? {
+			return internalGetMeasuredType()
+		}
+
+		func internalGetMeasuredType(alias: String? = nil) -> Storefront.UnitPriceMeasurementMeasuredType? {
+			return field(field: "measuredType", aliasSuffix: alias) as! Storefront.UnitPriceMeasurementMeasuredType?
+		}
+
+		/// The quantity unit for the unit price measurement. 
+		open var quantityUnit: Storefront.UnitPriceMeasurementMeasuredUnit? {
+			return internalGetQuantityUnit()
+		}
+
+		func internalGetQuantityUnit(alias: String? = nil) -> Storefront.UnitPriceMeasurementMeasuredUnit? {
+			return field(field: "quantityUnit", aliasSuffix: alias) as! Storefront.UnitPriceMeasurementMeasuredUnit?
+		}
+
+		/// The quantity value for the unit price measurement. 
+		open var quantityValue: Double {
+			return internalGetQuantityValue()
+		}
+
+		func internalGetQuantityValue(alias: String? = nil) -> Double {
+			return field(field: "quantityValue", aliasSuffix: alias) as! Double
+		}
+
+		/// The reference unit for the unit price measurement. 
+		open var referenceUnit: Storefront.UnitPriceMeasurementMeasuredUnit? {
+			return internalGetReferenceUnit()
+		}
+
+		func internalGetReferenceUnit(alias: String? = nil) -> Storefront.UnitPriceMeasurementMeasuredUnit? {
+			return field(field: "referenceUnit", aliasSuffix: alias) as! Storefront.UnitPriceMeasurementMeasuredUnit?
+		}
+
+		/// The reference value for the unit price measurement. 
+		open var referenceValue: Int32 {
+			return internalGetReferenceValue()
+		}
+
+		func internalGetReferenceValue(alias: String? = nil) -> Int32 {
+			return field(field: "referenceValue", aliasSuffix: alias) as! Int32
+		}
+
+		internal override func childResponseObjectMap() -> [GraphQL.AbstractResponse]  {
+			return []
+		}
+	}
+}

--- a/Buy/Generated/Storefront/UnitPriceMeasurementMeasuredType.swift
+++ b/Buy/Generated/Storefront/UnitPriceMeasurementMeasuredType.swift
@@ -1,0 +1,46 @@
+//
+//  UnitPriceMeasurementMeasuredType.swift
+//  Buy
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+extension Storefront {
+	/// The accepted types of unit of measurement. 
+	public enum UnitPriceMeasurementMeasuredType: String {
+		/// Unit of measurements representing areas. 
+		case area = "AREA"
+
+		/// Unit of measurements representing lengths. 
+		case length = "LENGTH"
+
+		/// Unit of measurements representing volumes. 
+		case volume = "VOLUME"
+
+		/// Unit of measurements representing weights. 
+		case weight = "WEIGHT"
+
+		case unknownValue = ""
+	}
+}

--- a/Buy/Generated/Storefront/UnitPriceMeasurementMeasuredUnit.swift
+++ b/Buy/Generated/Storefront/UnitPriceMeasurementMeasuredUnit.swift
@@ -1,0 +1,67 @@
+//
+//  UnitPriceMeasurementMeasuredUnit.swift
+//  Buy
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+extension Storefront {
+	/// The valid units of measurement for a unit price measurement. 
+	public enum UnitPriceMeasurementMeasuredUnit: String {
+		/// 100 centiliters equals 1 liter. 
+		case cl = "CL"
+
+		/// 100 centimeters equals 1 meter. 
+		case cm = "CM"
+
+		/// Metric system unit of weight. 
+		case g = "G"
+
+		/// 1 kilogram equals 1000 grams. 
+		case kg = "KG"
+
+		/// Metric system unit of volume. 
+		case l = "L"
+
+		/// Metric system unit of length. 
+		case m = "M"
+
+		/// Metric system unit of area. 
+		case m2 = "M2"
+
+		/// 1 cubic meter equals 1000 liters. 
+		case m3 = "M3"
+
+		/// 1000 milligrams equals 1 gram. 
+		case mg = "MG"
+
+		/// 1000 milliliters equals 1 liter. 
+		case ml = "ML"
+
+		/// 1000 millimeters equals 1 meter. 
+		case mm = "MM"
+
+		case unknownValue = ""
+	}
+}

--- a/Buy/Generated/Storefront/Video.swift
+++ b/Buy/Generated/Storefront/Video.swift
@@ -1,0 +1,188 @@
+//
+//  Video.swift
+//  Buy
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+extension Storefront {
+	/// Represents a Shopify hosted video. 
+	open class VideoQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = Video
+
+		/// A word or phrase to share the nature or contents of a media. 
+		@discardableResult
+		open func alt(alias: String? = nil) -> VideoQuery {
+			addField(field: "alt", aliasSuffix: alias)
+			return self
+		}
+
+		/// Globally unique identifier. 
+		@discardableResult
+		open func id(alias: String? = nil) -> VideoQuery {
+			addField(field: "id", aliasSuffix: alias)
+			return self
+		}
+
+		/// The media content type. 
+		@discardableResult
+		open func mediaContentType(alias: String? = nil) -> VideoQuery {
+			addField(field: "mediaContentType", aliasSuffix: alias)
+			return self
+		}
+
+		/// The preview image for the media. 
+		@discardableResult
+		open func previewImage(alias: String? = nil, _ subfields: (ImageQuery) -> Void) -> VideoQuery {
+			let subquery = ImageQuery()
+			subfields(subquery)
+
+			addField(field: "previewImage", aliasSuffix: alias, subfields: subquery)
+			return self
+		}
+
+		/// The sources for a video. 
+		@discardableResult
+		open func sources(alias: String? = nil, _ subfields: (VideoSourceQuery) -> Void) -> VideoQuery {
+			let subquery = VideoSourceQuery()
+			subfields(subquery)
+
+			addField(field: "sources", aliasSuffix: alias, subfields: subquery)
+			return self
+		}
+	}
+
+	/// Represents a Shopify hosted video. 
+	open class Video: GraphQL.AbstractResponse, GraphQLObject, Media, Node {
+		public typealias Query = VideoQuery
+
+		internal override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
+			let fieldValue = value
+			switch fieldName {
+				case "alt":
+				if value is NSNull { return nil }
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: Video.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "id":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: Video.self, field: fieldName, value: fieldValue)
+				}
+				return GraphQL.ID(rawValue: value)
+
+				case "mediaContentType":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: Video.self, field: fieldName, value: fieldValue)
+				}
+				return MediaContentType(rawValue: value) ?? .unknownValue
+
+				case "previewImage":
+				if value is NSNull { return nil }
+				guard let value = value as? [String: Any] else {
+					throw SchemaViolationError(type: Video.self, field: fieldName, value: fieldValue)
+				}
+				return try Image(fields: value)
+
+				case "sources":
+				guard let value = value as? [[String: Any]] else {
+					throw SchemaViolationError(type: Video.self, field: fieldName, value: fieldValue)
+				}
+				return try value.map { return try VideoSource(fields: $0) }
+
+				default:
+				throw SchemaViolationError(type: Video.self, field: fieldName, value: fieldValue)
+			}
+		}
+
+		/// A word or phrase to share the nature or contents of a media. 
+		open var alt: String? {
+			return internalGetAlt()
+		}
+
+		func internalGetAlt(alias: String? = nil) -> String? {
+			return field(field: "alt", aliasSuffix: alias) as! String?
+		}
+
+		/// Globally unique identifier. 
+		open var id: GraphQL.ID {
+			return internalGetId()
+		}
+
+		func internalGetId(alias: String? = nil) -> GraphQL.ID {
+			return field(field: "id", aliasSuffix: alias) as! GraphQL.ID
+		}
+
+		/// The media content type. 
+		open var mediaContentType: Storefront.MediaContentType {
+			return internalGetMediaContentType()
+		}
+
+		func internalGetMediaContentType(alias: String? = nil) -> Storefront.MediaContentType {
+			return field(field: "mediaContentType", aliasSuffix: alias) as! Storefront.MediaContentType
+		}
+
+		/// The preview image for the media. 
+		open var previewImage: Storefront.Image? {
+			return internalGetPreviewImage()
+		}
+
+		func internalGetPreviewImage(alias: String? = nil) -> Storefront.Image? {
+			return field(field: "previewImage", aliasSuffix: alias) as! Storefront.Image?
+		}
+
+		/// The sources for a video. 
+		open var sources: [Storefront.VideoSource] {
+			return internalGetSources()
+		}
+
+		func internalGetSources(alias: String? = nil) -> [Storefront.VideoSource] {
+			return field(field: "sources", aliasSuffix: alias) as! [Storefront.VideoSource]
+		}
+
+		internal override func childResponseObjectMap() -> [GraphQL.AbstractResponse]  {
+			var response: [GraphQL.AbstractResponse] = []
+			objectMap.keys.forEach {
+				switch($0) {
+					case "previewImage":
+					if let value = internalGetPreviewImage() {
+						response.append(value)
+						response.append(contentsOf: value.childResponseObjectMap())
+					}
+
+					case "sources":
+					internalGetSources().forEach {
+						response.append($0)
+						response.append(contentsOf: $0.childResponseObjectMap())
+					}
+
+					default:
+					break
+				}
+			}
+			return response
+		}
+	}
+}

--- a/Buy/Generated/Storefront/VideoSource.swift
+++ b/Buy/Generated/Storefront/VideoSource.swift
@@ -1,0 +1,161 @@
+//
+//  VideoSource.swift
+//  Buy
+//
+//  Created by Shopify.
+//  Copyright (c) 2017 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+extension Storefront {
+	/// Represents a source for a Shopify hosted video. 
+	open class VideoSourceQuery: GraphQL.AbstractQuery, GraphQLQuery {
+		public typealias Response = VideoSource
+
+		/// The format of the video source. 
+		@discardableResult
+		open func format(alias: String? = nil) -> VideoSourceQuery {
+			addField(field: "format", aliasSuffix: alias)
+			return self
+		}
+
+		/// The height of the video. 
+		@discardableResult
+		open func height(alias: String? = nil) -> VideoSourceQuery {
+			addField(field: "height", aliasSuffix: alias)
+			return self
+		}
+
+		/// The video MIME type. 
+		@discardableResult
+		open func mimeType(alias: String? = nil) -> VideoSourceQuery {
+			addField(field: "mimeType", aliasSuffix: alias)
+			return self
+		}
+
+		/// The URL of the video. 
+		@discardableResult
+		open func url(alias: String? = nil) -> VideoSourceQuery {
+			addField(field: "url", aliasSuffix: alias)
+			return self
+		}
+
+		/// The width of the video. 
+		@discardableResult
+		open func width(alias: String? = nil) -> VideoSourceQuery {
+			addField(field: "width", aliasSuffix: alias)
+			return self
+		}
+	}
+
+	/// Represents a source for a Shopify hosted video. 
+	open class VideoSource: GraphQL.AbstractResponse, GraphQLObject {
+		public typealias Query = VideoSourceQuery
+
+		internal override func deserializeValue(fieldName: String, value: Any) throws -> Any? {
+			let fieldValue = value
+			switch fieldName {
+				case "format":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: VideoSource.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "height":
+				guard let value = value as? Int else {
+					throw SchemaViolationError(type: VideoSource.self, field: fieldName, value: fieldValue)
+				}
+				return Int32(value)
+
+				case "mimeType":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: VideoSource.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "url":
+				guard let value = value as? String else {
+					throw SchemaViolationError(type: VideoSource.self, field: fieldName, value: fieldValue)
+				}
+				return value
+
+				case "width":
+				guard let value = value as? Int else {
+					throw SchemaViolationError(type: VideoSource.self, field: fieldName, value: fieldValue)
+				}
+				return Int32(value)
+
+				default:
+				throw SchemaViolationError(type: VideoSource.self, field: fieldName, value: fieldValue)
+			}
+		}
+
+		/// The format of the video source. 
+		open var format: String {
+			return internalGetFormat()
+		}
+
+		func internalGetFormat(alias: String? = nil) -> String {
+			return field(field: "format", aliasSuffix: alias) as! String
+		}
+
+		/// The height of the video. 
+		open var height: Int32 {
+			return internalGetHeight()
+		}
+
+		func internalGetHeight(alias: String? = nil) -> Int32 {
+			return field(field: "height", aliasSuffix: alias) as! Int32
+		}
+
+		/// The video MIME type. 
+		open var mimeType: String {
+			return internalGetMimeType()
+		}
+
+		func internalGetMimeType(alias: String? = nil) -> String {
+			return field(field: "mimeType", aliasSuffix: alias) as! String
+		}
+
+		/// The URL of the video. 
+		open var url: String {
+			return internalGetUrl()
+		}
+
+		func internalGetUrl(alias: String? = nil) -> String {
+			return field(field: "url", aliasSuffix: alias) as! String
+		}
+
+		/// The width of the video. 
+		open var width: Int32 {
+			return internalGetWidth()
+		}
+
+		func internalGetWidth(alias: String? = nil) -> Int32 {
+			return field(field: "width", aliasSuffix: alias) as! Int32
+		}
+
+		internal override func childResponseObjectMap() -> [GraphQL.AbstractResponse]  {
+			return []
+		}
+	}
+}

--- a/Mobile-Buy-SDK.podspec
+++ b/Mobile-Buy-SDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                = 'Mobile-Buy-SDK'
-  s.version             = '3.6.1'
+  s.version             = '3.6.2'
   s.summary             = 'Create custom Shopify storefront on iOS.'
   s.description         = 'Shopify’s Mobile Buy SDK makes it simple to create custom storefronts in your mobile app. Utitlizing the power and flexibility of GraphQL you can build native storefront experiences using the Shopify platform.'
   s.homepage            = 'https://github.com/Shopify/mobile-buy-sdk-ios'

--- a/Mobile-Buy-SDK.podspec
+++ b/Mobile-Buy-SDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                = 'Mobile-Buy-SDK'
-  s.version             = '3.6.2'
+  s.version             = '3.7.0'
   s.summary             = 'Create custom Shopify storefront on iOS.'
   s.description         = 'Shopify’s Mobile Buy SDK makes it simple to create custom storefronts in your mobile app. Utitlizing the power and flexibility of GraphQL you can build native storefront experiences using the Shopify platform.'
   s.homepage            = 'https://github.com/Shopify/mobile-buy-sdk-ios'

--- a/Sample Apps/Storefront/Storefront/ClientQuery.swift
+++ b/Sample Apps/Storefront/Storefront/ClientQuery.swift
@@ -306,8 +306,8 @@ final class ClientQuery {
             paymentAmount:  paymentAmount,
             idempotencyKey: idempotencyToken,
             billingAddress: mailingAddress,
-            paymentData:    token,
-            type:           CheckoutViewModel.PaymentType.applePay.rawValue
+            type:           CheckoutViewModel.PaymentType.applePay.rawValue,
+            paymentData:    token
         )
         
         return Storefront.buildMutation { $0

--- a/Sample Apps/Storefront/Storefront/ClientQuery.swift
+++ b/Sample Apps/Storefront/Storefront/ClientQuery.swift
@@ -306,8 +306,8 @@ final class ClientQuery {
             paymentAmount:  paymentAmount,
             idempotencyKey: idempotencyToken,
             billingAddress: mailingAddress,
-            type:           CheckoutViewModel.PaymentType.applePay.rawValue,
-            paymentData:    token
+            paymentData:    token,
+            type:           CheckoutViewModel.PaymentType.applePay.rawValue
         )
         
         return Storefront.buildMutation { $0

--- a/Scripts/update_schema
+++ b/Scripts/update_schema
@@ -8,7 +8,7 @@ require 'graphql_schema'
 require 'graphql_swift_gen'
 
 shared_storefront_api_key = "4a6c829ec3cb12ef9004bf8ed27adf12"
-storefront_api_version    = "2019-10"
+storefront_api_version    = "2020-01"
 endpoint                  = URI("https://app.shopify.com/services/graphql/introspection/storefront?api_client_api_key=#{shared_storefront_api_key}&api_version=#{storefront_api_version}")
 body                      = Net::HTTP.get(endpoint)
 schema                    = GraphQLSchema.new(JSON.parse(body))


### PR DESCRIPTION
### Summary of changes
- Update to 2020-01 storefront API schema 
- Bump sdk version

#### Release notes (https://help.shopify.com/en/api/versioning/release-notes/2020-01#storefront-api-changes)
- Retrieve a product’s media. Media supported: images, 3D models, and videos.
- New supported currencies - SHP, GIP, and FKP
- Get unit measurement and price data for product variants to display per-unit prices

This PR resolves https://github.com/Shopify/mobile-buy-sdk-ios/issues/1044