### PR TITLE
Update readme to catch locale usage

### DIFF
--- a/Buy/Client/Graph.Client.swift
+++ b/Buy/Client/Graph.Client.swift
@@ -79,7 +79,7 @@ extension Graph {
         ///     - shopDomain: The domain of your shop (ex: "shopname.myshopify.com").
         ///     - apiKey:     The API key for you app, obtained from the Shopify admin.
         ///     - session:    A `URLSession` to use for this client. If left blank, a session with a `default` configuration will be created.
-        ///     - locale:   The buyer's current locale. Supported values are limited to locales available to your shop.
+        ///     - locale:     The buyer's current locale. Supported values are limited to locales available to your shop.
         ///
         public init(shopDomain: String, apiKey: String, session: URLSession = URLSession(configuration: URLSessionConfiguration.default), locale: Locale? = nil) {
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ If your store supports multiple languages, Storefront API can return translated 
 let client = Graph.Client(
 	shopDomain: "shoes.myshopify.com",
 	apiKey:     "dGhpcyBpcyBhIHByaXZhdGUgYXBpIGtleQ",
-  locale:     Locale.current
+        locale:     Locale.current
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -287,11 +287,23 @@ The `Graph.Client` is a network layer built on top of `URLSession` that executes
 - Your shop's `.myshopify.com` domain
 - Your API key, which you can find in your shop's admin page
 - A `URLSession` (optional), if you want to customize the configuration used for network requests or share your existing `URLSession` with the `Graph.Client`
+- (optional) The buyer's current locale. Supported values are limited to locales available to your shop.
 
 ```swift
 let client = Graph.Client(
 	shopDomain: "shoes.myshopify.com",
 	apiKey:     "dGhpcyBpcyBhIHByaXZhdGUgYXBpIGtleQ"
+)
+```
+
+If your store supports multiple languages, Storefront API can return translated resource types and fields. Learn more about [translating content](https://help.shopify.com/en/api/guides/multi-language/translating-content-api).
+
+```swift
+// Initializing a client to return translated content
+let client = Graph.Client(
+	shopDomain: "shoes.myshopify.com",
+	apiKey:     "dGhpcyBpcyBhIHByaXZhdGUgYXBpIGtleQ",
+  locale:     Locale.current
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ let client = Graph.Client(
 )
 ```
 
-If your store supports multiple languages, Storefront API can return translated resource types and fields. Learn more about [translating content](https://help.shopify.com/en/api/guides/multi-language/translating-content-api).
+If your store supports multiple languages, then the Storefront API can return translated resource types and fields. Learn more about [translating content](https://shopify.dev/tutorials/manage-app-translations-with-admin-api).
 
 ```swift
 // Initializing a client to return translated content


### PR DESCRIPTION
### Retrieving translated content with mobile buy ios sdk 

Update sdk readme on how to get translated data for their dynamic content. See corresponding [release notes](https://shopify.dev/concepts/about-apis/versioning/release-notes/2020-01) on _Retrieving translated content with storefront API_ 

CC: @Shopify/api-documentation @Shopify/documentation 