### PR TITLE
Update test_pod_version with more stable diff

### DIFF
--- a/.github/workflows/test_pod_version.yml
+++ b/.github/workflows/test_pod_version.yml
@@ -13,7 +13,7 @@ jobs:
 
     - name: Ensure Mobile-Buy-SDK.podspec version is changed
       run: |
-        LINES=$(git log -- Mobile-Buy-SDK.podspec master..HEAD | xargs -n 4 | grep s.version | wc -l)
+        LINES=$(git diff master..HEAD -- Mobile-Buy-SDK.podspec | xargs -n 4 | grep s.version | wc -l)
         if [ "$LINES" -eq "2" ]; then
           echo "Podfile version was updated";
           exit 0;

--- a/.github/workflows/test_pod_version.yml
+++ b/.github/workflows/test_pod_version.yml
@@ -13,7 +13,7 @@ jobs:
 
     - name: Ensure Mobile-Buy-SDK.podspec version is changed
       run: |
-        LINES=$(git diff master..HEAD -- Mobile-Buy-SDK.podspec | xargs -n 4 | grep s.version | wc -l)
+        LINES=$(git diff master..HEAD -- Mobile-Buy-SDK.podspec | grep s.version | wc -l)
         if [ "$LINES" -eq "2" ]; then
           echo "Podfile version was updated";
           exit 0;


### PR DESCRIPTION
The current git command only works sometimes, as evidenced by it's last run. Using git diff is more stable for what we want here. 