### PR TITLE
Get git submodule before deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,9 @@ jobs:
         ruby-version: '2.6' 
         
     - name: Install dependencies
-      run: gem install cocoapods
+      run: |
+        gem install cocoapods
+        git submodule sync --recursive && git submodule update --recursive --init
     
     - name: Push to cocoapods
       run: |


### PR DESCRIPTION
Deploy failed with `error: use of undeclared type 'GraphQL'` which I'm guessing is because it didn't grab the sub-modules on checkout.

See failed run here: https://github.com/Shopify/mobile-buy-sdk-ios/runs/574263599
