### PR TITLE
Update actions to use GITHUB_ENV file instead of set-env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,6 @@ jobs:
       run: |
         API_VERSION="$(./Scripts/get_api_version)"
         BRANCH_NAME="release/${API_VERSION}-auto-generated"
-        echo "::set-env name=API_VERSION::$API_VERSION"
-        echo "::set-env name=BRANCH_NAME::$BRANCH_NAME"
 
     - name: Create and push the release branch
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,8 @@ jobs:
       run: |
         API_VERSION="$(./Scripts/get_api_version)"
         BRANCH_NAME="release/${API_VERSION}-auto-generated"
+        echo "API_VERSION=$API_VERSION" >> $GITHUB_ENV
+        echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
     - name: Create and push the release branch
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,13 @@ jobs:
       id: sdk-version
       run: |
         SDK_VERSION="$(./Scripts/get_sdk_version)"
-        echo "::set-env name=SDK_VERSION::$SDK_VERSION"
+        echo "SDK_VERSION=$SDK_VERSION" >> $GITHUB_ENV
 
     - name: Get API Version
       id: api-version
       run: |
         API_VERSION="$(./Scripts/get_api_version)"
-        echo "::set-env name=API_VERSION::$API_VERSION"
+        echo "API_VERSION=$API_VERSION" >> $GITHUB_ENV
 
     - name: Create a draft release
       uses: actions/github-script@0.9.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       id: version
       run: |
         CURRENT_SIMULATOR_UUID=$(xcrun simctl create TestDevice com.apple.CoreSimulator.SimDeviceType.iPhone-11 com.apple.CoreSimulator.SimRuntime.iOS-14-0)
-        echo "::set-env name=CURRENT_SIMULATOR_UUID::$CURRENT_SIMULATOR_UUID"
+        echo "CURRENT_SIMULATOR_UUID=$CURRENT_SIMULATOR_UUID" >> $GITHUB_ENV
 
     - name: Test Buy
       run: ./Scripts/test_buy


### PR DESCRIPTION
set-env was deprecated at the end of last year

### What this does

Removes set-env. Looking at the script, I'm not sure this was actually doing anything.
