### PR TITLE
Increases zip code padding check to 4 characters for UK addresses

### DIFF
--- a/Pay/PayAddress.swift
+++ b/Pay/PayAddress.swift
@@ -80,7 +80,7 @@ public struct PayPostalAddress {
         if let zip = zip {
             
             let trimmedZip = zip.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmedZip.count < 4 {
+            if trimmedZip.count < 5 {
                 let (zip, isPadded) = PayPostalAddress.paddedPostalCode(trimmedZip, for: countryCode)
                 self.zip      = zip
                 self.isPadded = isPadded


### PR DESCRIPTION
### What this does

Apple Pay anonymizes postal codes for British and Canadian addresses until the user has accepted payment. [(source)](https://developer.apple.com/forums/thread/124800)

The mobile-buy-sdk accounts for this by adding padding to British and Canadian postal codes when Apple Pay only shows 3 characters.  Some British postal codes have 4 characters, though, causing no padding to be added which causes errors in Apple Pay when attempting to get shipping costs.

An example postal code that causes this is `WC2H 9BH` in London.  Apple pay will shorten this to `WC2H `.

This change increases the number of characters by 1 to allow these British postal codes to still apply padding.