### PR TITLE
Support Query/Mutation Directives

### DIFF
--- a/Buy/Generated/Storefront/Mutation.swift
+++ b/Buy/Generated/Storefront/Mutation.swift
@@ -33,7 +33,7 @@ extension Storefront {
 		public typealias Response = Mutation
 
 		open override var description: String {
-			return "mutation" + super.description
+			return "mutation " + super.description
 		}
 
 		/// Updates the attributes of a checkout. 

--- a/Buy/Generated/Storefront/QueryRoot.swift
+++ b/Buy/Generated/Storefront/QueryRoot.swift
@@ -32,6 +32,10 @@ extension Storefront {
 	open class QueryRootQuery: GraphQL.AbstractQuery, GraphQLQuery {
 		public typealias Response = QueryRoot
 
+		open override var description: String {
+			return "query " + super.description
+		}
+
 		/// List of the shop's articles. 
 		///
 		/// - parameters:

--- a/Buy/Support/GraphQL.swift
+++ b/Buy/Support/GraphQL.swift
@@ -51,18 +51,45 @@ public class GraphQL {
 			return rawValue
 		}
 	}
+    
+    open class AbstractDirective: CustomStringConvertible {
+        let name: String
+        
+        let args: String?
+        
+        open var description: String {
+            var sig = "@\(name)"
+            if let args = args {
+                sig += args
+            }
+            return sig
+        }
+        
+        init(name: String, args: String? = nil) {
+            self.name = name
+            self.args = args
+        }
+    }
 
 	open class AbstractQuery: CustomStringConvertible {
 		static let aliasSuffixSeparator = "__"
 		var selections: [String: Selection] = [:]
 		var orderedSelections: [Selection] = [] // predictable order for testing
+        
+        var directives = [AbstractDirective]()
 
 		public init () {
 		}
 
 		open var description: String {
 			assert(!selections.isEmpty, "selection set must have at least 1 selection")
-			var query = "{"
+            
+            let directives = directives
+                .map({ String(describing: $0) })
+                .joined(separator: " ")
+            
+            var query = directives.isEmpty ? "{" : "\(directives) {"
+        
 			var first = true
 			for s in orderedSelections {
 				if first {

--- a/BuyTests/Support/GraphQL.AbstractQueryTests.swift
+++ b/BuyTests/Support/GraphQL.AbstractQueryTests.swift
@@ -1,0 +1,74 @@
+//
+//  GraphQL.AbstractQueryTests.swift
+//  BuyTests
+//
+//  Created by Shopify.
+//  Copyright (c) 2021 Shopify Inc. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import XCTest
+@testable import Buy
+
+class GraphQL_AbstractQueryTests: XCTestCase {
+    
+    func testQuery() {
+        XCTAssertEqual(String(describing: RootQuery()), "query {shop{name,name__a:name}}")
+    }
+    
+    func testQueryWithDirectives() {
+        let query = RootQuery()
+        query.directives = []
+        XCTAssertEqual(String(describing: query), "query {shop{name,name__a:name}}")
+        query.directives = [TestDirective(), TestDirectiveWithArgs()]
+        XCTAssertEqual(String(describing: query), "query @test @testArgs(input: \"hello\") {shop{name,name__a:name}}")
+    }
+    
+    private class RootQuery: GraphQL.AbstractQuery {
+        override var description: String {
+            return "query " + super.description
+        }
+        
+        override init() {
+            super.init()
+            addField(field: "shop", subfields: ShopQuery())
+        }
+    }
+
+    private class ShopQuery: GraphQL.AbstractQuery {
+        override init() {
+            super.init()
+            addField(field: "name")
+            addField(field: "name", aliasSuffix: "a")
+        }
+    }
+    
+    private class TestDirective: GraphQL.AbstractDirective {
+        init() {
+            super.init(name: "test")
+        }
+    }
+    
+    private class TestDirectiveWithArgs: GraphQL.AbstractDirective {
+        init() {
+            super.init(name: "testArgs", args: "(input: \"hello\")")
+        }
+    }
+}

--- a/Dependencies/Swift Gen/codegen/lib/graphql_swift_gen/templates/directive.swift.erb
+++ b/Dependencies/Swift Gen/codegen/lib/graphql_swift_gen/templates/directive.swift.erb
@@ -1,5 +1,5 @@
 //
-//  <%= schema_name %>.swift
+//  <%= directive.name %>.swift
 //  Buy
 //
 //  Created by Shopify.
@@ -24,17 +24,32 @@
 //  THE SOFTWARE.
 //
 
-public class <%= schema_name %> {
-  <% [['Query', schema.query_root_name], ['Mutation', schema.mutation_root_name]].each do |operation_type, root_name| %>
-    <% directive_args = swift_root_directive_args(operation_type) %>
-    <% formatted_args = directive_args.empty? ? "_ " : directive_args.join(", ") + ", " %>
-   public static func build<%= operation_type %>(<%= formatted_args %>subfields: (<%= root_name %>Query) -> Void) -> <%= root_name %>Query {
-      let root = <%= root_name %>Query()
-      <% unless directive_args.empty? %>
-      root.directives = [<%= directives_for_kind(operation_type).map(&:name).join(", ") %>].compactMap({ $0 })
+import Foundation
+<% if import_graphql_support %>
+  import GraphQLSupport
+<% end %>
+
+extension <%= schema_name %> {
+  open class <%= directive.classify_name %>Directive: GraphQL.AbstractDirective {
+    <%= swift_doc(directive) %>
+    public init(<%= swift_directive_arg_defs(directive) %>) {
+      <% unless directive.args.empty? %>
+        var args: [String] = []
+        <% directive.required_args.each do |arg| %>
+          args.append("<%= arg.name %>:<%= generate_build_input_code(arg.name, arg.type.unwrap_non_null) %>")
+        <% end %>
+        <% directive.optional_args.each do |arg| %>
+          if let <%= escape_reserved_word(arg.name) %> = <%= escape_reserved_word(arg.name) %> {
+            args.append("<%= arg.name %>:<%= generate_build_input_code(arg.name, arg.type) %>")
+          }
+        <% end %>
+        <% if directive.optional_args.empty? %>
+          let argsString = "(\(args.joined(separator: ",")))"
+        <% else %>
+          let argsString: String? = args.isEmpty ? nil : "(\(args.joined(separator: ",")))"
+        <% end %>
       <% end %>
-      subfields(root)
-      return root
+      super.init(name: "<%= directive.name %>", args: argsString)
     }
-  <% end %>
+  }
 }

--- a/Dependencies/Swift Gen/codegen/lib/graphql_swift_gen/templates/type.swift.erb
+++ b/Dependencies/Swift Gen/codegen/lib/graphql_swift_gen/templates/type.swift.erb
@@ -50,9 +50,13 @@ extension <%= schema_name %> {
     open class <%= type.name %>Query: GraphQL.AbstractQuery, GraphQLQuery {
       public typealias Response = <%= type.name %>
 
-      <% if type.name == schema.mutation_root_name %>
+      <% if type.name == schema.query_root_name %>
         open override var description: String {
-          return "mutation" + super.description
+          return "query " + super.description
+        }
+      <% elsif type.name == schema.mutation_root_name %>
+        open override var description: String {
+          return "mutation " + super.description
         }
       <% end %>
       <% fields.each do |field| %>

--- a/Dependencies/Swift Gen/graphql_swift_gen.gemspec
+++ b/Dependencies/Swift Gen/graphql_swift_gen.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.1.0"
 
-  spec.add_dependency "graphql_schema", "~> 0.1.1"
+  spec.add_dependency "graphql_schema", "~> 0.1.8"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 12.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,12 @@ PATH
   remote: Dependencies/Swift Gen
   specs:
     graphql_swift_gen (0.1.0)
-      graphql_schema (~> 0.1.1)
+      graphql_schema (~> 0.1.8)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    graphql_schema (0.1.6)
+    graphql_schema (0.1.8)
 
 PLATFORMS
   ruby

--- a/Scripts/build
+++ b/Scripts/build
@@ -27,6 +27,9 @@ res = Net::HTTP.get_response(endpoint)
 if res.is_a?(Net::HTTPSuccess)
   puts "Using Storefront API version: #{storefront_api_version}"
 
+	FileUtils.rm_rf(generated_code_path)
+	FileUtils.mkdir_p(generated_code_path)
+
   template_path = File.join(scripts_path, 'version.swift.erb')
   output = ERB.new(File.read(template_path)).result()
   output_path = File.join(generated_code_path, 'Storefront.Schema.swift')


### PR DESCRIPTION
This PR modifies the `graphql_swift_gen` tool to add support for generating `QUERY` and `MUTATION` directives.

### Summary of Changes

- Adds `GraphQL.AbstractDirective` class.
- Modifies `GraphQL.AbstractQuery` to accept an array of directives which are formatted at request time.
- Modifies `ApiSchema.swift.erb` template to generate optional directive arguments for the `buildQuery` and `buildMutation` functions.
- Updates `build` script to nuke `/Generated` prior to updating the schema. This allows types removed upstream to be removed within the SDK.