### PR TITLE
adds preselected shipping to pay session

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Pay/PayAuthorization.swift
+++ b/Pay/PayAuthorization.swift
@@ -39,7 +39,7 @@ public struct PayAuthorization {
     public let billingAddress: PayAddress
 
     /// Shipping address that was selected by the user
-    public let shippingAddress: PayAddress
+    public let shippingAddress: PayAddress?
 
     /// Shipping rate that was selected by the user
     public let shippingRate: PayShippingRate?
@@ -47,7 +47,7 @@ public struct PayAuthorization {
     // ----------------------------------
     //  MARK: - Init -
     //
-    internal init(paymentData: Data, billingAddress: PayAddress, shippingAddress: PayAddress, shippingRate: PayShippingRate?) {
+    internal init(paymentData: Data, billingAddress: PayAddress, shippingAddress: PayAddress?, shippingRate: PayShippingRate?) {
         self.token           = String(data: paymentData, encoding: .utf8)!
         self.billingAddress  = billingAddress
         self.shippingAddress = shippingAddress

--- a/Pay/PayCheckout.swift
+++ b/Pay/PayCheckout.swift
@@ -25,7 +25,6 @@
 //
 
 import Foundation
-import PassKit
 
 /// Encapsulates all fields required for invoking the Apple Pay
 /// dialog. It also creates summary items for cart total,
@@ -43,16 +42,19 @@ public struct PayCheckout {
     public let lineItems:        [PayLineItem]
     public let shippingAddress:  PayAddress?
     public let shippingRate:     PayShippingRate?
-
+    public let availableShippingRates:     [PayShippingRate]?
+    
     public let currencyCode:     String
+    public let totalDuties:      Decimal?
     public let subtotalPrice:    Decimal
     public let totalTax:         Decimal
     public let paymentDue:       Decimal
+    public let total:            Decimal
 
     // ----------------------------------
     //  MARK: - Init -
     //
-    public init(id: String, lineItems: [PayLineItem], giftCards: [PayGiftCard]?, discount: PayDiscount?, shippingDiscount: PayDiscount?, shippingAddress: PayAddress?, shippingRate: PayShippingRate?, currencyCode: String, subtotalPrice: Decimal, needsShipping: Bool, totalTax: Decimal, paymentDue: Decimal) {
+    public init(id: String, lineItems: [PayLineItem], giftCards: [PayGiftCard]?, discount: PayDiscount?, shippingDiscount: PayDiscount?, shippingAddress: PayAddress?, shippingRate: PayShippingRate?, availableShippingRates: [PayShippingRate]?, currencyCode: String, totalDuties: Decimal?, subtotalPrice: Decimal, needsShipping: Bool, totalTax: Decimal, paymentDue: Decimal, total: Decimal) {
 
         self.id               = id
         self.lineItems        = lineItems
@@ -62,16 +64,23 @@ public struct PayCheckout {
         self.giftCards        = giftCards
         self.discount         = discount
         self.shippingDiscount = shippingDiscount
+        self.availableShippingRates = availableShippingRates
         
         self.currencyCode     = currencyCode
+        self.totalDuties      = totalDuties
         self.subtotalPrice    = subtotalPrice
         self.totalTax         = totalTax
         self.paymentDue       = paymentDue
 
         self.hasLineItems     = !lineItems.isEmpty
         self.needsShipping    = needsShipping
+        self.total            = total
     }
 }
+
+#if canImport(PassKit)
+
+import PassKit
 
 // ----------------------------------
 //  MARK: - PassKits -
@@ -111,6 +120,12 @@ internal extension PayCheckout {
             summaryItems.append(discount.amount.negative.summaryItemNamed(title))
         }
         
+        // Duties
+        
+        if let duties = self.totalDuties {
+            summaryItems.append(duties.summaryItemNamed("DUTIES"))
+        }
+        
         // Taxes
         
         if self.totalTax > 0.0 {
@@ -140,3 +155,5 @@ internal extension PayCheckout {
         return summaryItems
     }
 }
+
+#endif

--- a/PayTests/Models/Models.swift
+++ b/PayTests/Models/Models.swift
@@ -24,6 +24,8 @@
 //  THE SOFTWARE.
 //
 
+#if canImport(PassKit)
+
 import Foundation
 import PassKit
 import Pay
@@ -108,7 +110,7 @@ struct Models {
         return PayCurrency(currencyCode: "USD", countryCode: "US")
     }
     
-    static func createCheckout(requiresShipping: Bool = true, giftCards: [PayGiftCard]? = nil, discount: PayDiscount? = nil, shippingDiscount: PayDiscount? = nil, shippingAddress: PayAddress? = nil, shippingRate: PayShippingRate? = nil, empty: Bool = false, hasTax: Bool = true) -> PayCheckout {
+    static func createCheckout(requiresShipping: Bool = true, giftCards: [PayGiftCard]? = nil, discount: PayDiscount? = nil, shippingDiscount: PayDiscount? = nil, shippingAddress: PayAddress? = nil, shippingRate: PayShippingRate? = nil, emailAddress: String? = nil, duties: Decimal? = nil, empty: Bool = false, hasTax: Bool = true) -> PayCheckout {
         
         let lineItems = [
             self.createLineItem1(),
@@ -123,11 +125,14 @@ struct Models {
             shippingDiscount: shippingDiscount,
             shippingAddress:  shippingAddress,
             shippingRate:     shippingRate,
+            availableShippingRates: [shippingRate].compactMap { $0 },
             currencyCode:     "CAD",
+            totalDuties:      duties,
             subtotalPrice:    44.0,
             needsShipping:    requiresShipping,
             totalTax:         hasTax ? 6.0 : 0.0,
-            paymentDue:       50.0
+            paymentDue:       50.0,
+            total:            50
         )
     }
     
@@ -188,3 +193,5 @@ struct Models {
         return (order, PayShippingRate.DeliveryRange(from: from, to: to))
     }
 }
+
+#endif

--- a/PayTests/PayAuthorizationTests.swift
+++ b/PayTests/PayAuthorizationTests.swift
@@ -24,6 +24,8 @@
 //  THE SOFTWARE.
 //
 
+#if canImport(PassKit)
+
 import XCTest
 @testable import Pay
 
@@ -46,7 +48,9 @@ class PayAuthorizationTests: XCTestCase {
         
         XCTAssertEqual(authorization.token, "123")
         XCTAssertEqual(authorization.billingAddress.firstName,  address.firstName)
-        XCTAssertEqual(authorization.shippingAddress.firstName, address.firstName)
+        XCTAssertEqual(authorization.shippingAddress?.firstName, address.firstName)
         XCTAssertEqual(authorization.shippingRate!.handle,      rate.handle)
     }
 }
+
+#endif

--- a/PayTests/PaySessionTests.swift
+++ b/PayTests/PaySessionTests.swift
@@ -24,6 +24,8 @@
 //  THE SOFTWARE.
 //
 
+#if canImport(PassKit)
+
 import XCTest
 import PassKit
 @testable import Pay
@@ -81,8 +83,8 @@ class PaySessionTests: XCTestCase {
         XCTAssertEqual(digitalRequest.countryCode,                   currency.countryCode)
         XCTAssertEqual(digitalRequest.currencyCode,                  currency.currencyCode)
         XCTAssertEqual(digitalRequest.merchantIdentifier,            session.merchantID)
-        XCTAssertEqual(digitalRequest.requiredBillingAddressFields,  [.all])
-        XCTAssertEqual(digitalRequest.requiredShippingAddressFields, [.all])
+        XCTAssertEqual(digitalRequest.requiredBillingContactFields,  [.phoneNumber,.name, .postalAddress])
+        XCTAssertEqual(digitalRequest.requiredShippingContactFields, [])
         XCTAssertEqual(digitalRequest.supportedNetworks,             [.visa, .masterCard, .amex])
         XCTAssertEqual(digitalRequest.merchantCapabilities,          [.capability3DS])
         XCTAssertFalse(digitalRequest.paymentSummaryItems.isEmpty)
@@ -91,6 +93,20 @@ class PaySessionTests: XCTestCase {
         let shippingRequest  = session.paymentRequestUsing(shippingCheckout, currency: currency, merchantID: session.merchantID)
         
         XCTAssertEqual(shippingRequest.requiredShippingAddressFields, [.all])
+    }
+    
+    func testPaymentRequest_withShipping_fields() {
+        let checkout = Models.createCheckout()
+        let currency = Models.createCurrency()
+        let session  = Models.createSession(checkout: checkout, currency: currency)
+        
+        let digitalCheckout = Models.createCheckout(requiresShipping: true)
+        let digitalRequest  = session.paymentRequestUsing(digitalCheckout, currency: currency, merchantID: session.merchantID)
+        
+
+        XCTAssertEqual(digitalRequest.requiredBillingContactFields,  [.phoneNumber,.name, .postalAddress])
+        XCTAssertEqual(digitalRequest.requiredShippingContactFields, [.phoneNumber, .name, .postalAddress, .emailAddress])
+
     }
     
     // ----------------------------------
@@ -105,7 +121,7 @@ class PaySessionTests: XCTestCase {
         let token     = MockPaymentToken(paymentMethod: payMethod)
         let payment   = MockPayment(token: token, billingContact: contact, shippingContact: contact, shippingMethod: shippingRate.summaryItem)
         
-        let checkout  = Models.createCheckout(requiresShipping: true)
+        let checkout  = Models.createCheckout(requiresShipping: true, shippingRate: shippingRate)
         let delegate  = self.setupDelegateForMockSessionWith(checkout) { session in
             session.shippingRates = [
                 shippingRate
@@ -120,7 +136,7 @@ class PaySessionTests: XCTestCase {
             let tokenString = String(data: token.paymentData, encoding: .utf8)
             XCTAssertEqual(authorization.token, tokenString)
             XCTAssertEqual(authorization.billingAddress.city,  contact.postalAddress!.city)
-            XCTAssertEqual(authorization.shippingAddress.city, contact.postalAddress!.city)
+            XCTAssertEqual(authorization.shippingAddress?.city, contact.postalAddress!.city)
             
             XCTAssertNotNil(authorization.shippingRate)
             XCTAssertEqual(authorization.shippingRate!.handle, shippingRate.handle)
@@ -384,7 +400,7 @@ class PaySessionTests: XCTestCase {
         let shippingRate   = Models.createShippingRate()
         let shippingMethod = shippingRate.summaryItem
         
-        let checkout = Models.createCheckout(requiresShipping: true)
+        let checkout = Models.createCheckout(requiresShipping: true, shippingRate: shippingRate)
         let delegate = self.setupDelegateForMockSessionWith(checkout) { session in
             
             session.checkout      = checkout
@@ -411,28 +427,30 @@ class PaySessionTests: XCTestCase {
     
     func testSelectShippingMethod() {
         
-        let shippingRate   = Models.createShippingRate()
-        let shippingMethod = shippingRate.summaryItem
+        let preExistingShippingRate   = Models.createShippingRate()
+        let updatedShippingRate = Models.createShippingRates().last!
         
-        let checkout = Models.createCheckout(requiresShipping: true)
+        let shippingMethod = preExistingShippingRate.summaryItem
+        
+        let checkout = Models.createCheckout(requiresShipping: true, shippingRate: preExistingShippingRate)
         let delegate = self.setupDelegateForMockSessionWith(checkout) { session in
             
             session.checkout      = checkout
             session.shippingRates = [
-                shippingRate
+                preExistingShippingRate
             ]
         }
         
         let updatedCheckout = Models.createCheckout(
             requiresShipping: true,
-            shippingRate:     shippingRate
+            shippingRate:     updatedShippingRate
         )
         
         delegate.didSelectShippingRate = { session, selectedShippingRate, checkoutToUpdate, provide in
             provide(updatedCheckout)
         }
         
-        XCTAssertNil(checkout.shippingRate)
+        XCTAssertNotNil(checkout.shippingRate)
         
         let expectation = self.expectation(description: "")
         
@@ -588,3 +606,5 @@ class PaySessionTests: XCTestCase {
         return delegate
     }
 }
+
+#endif


### PR DESCRIPTION
What this does

- Importing some proposed changes from Gymshark's fork of Mobile BUY SDK.
- We needed ability to pre-provide a selected shippingContact
- We needed ability to pre-provide available shipping rates.
- We understand you won't have shipping methods set for Checkouts which require no shipping
- We replaced requiredBillingAddressFields deprecations in some areas with the newer alternative requiredBillingContactFields

- [x]  Tests have been updated to address this.