### PR TITLE
Switch to `application/json` request body

### DIFF
--- a/Buy/Client/Graph.Client.swift
+++ b/Buy/Client/Graph.Client.swift
@@ -181,15 +181,18 @@ extension Graph {
         }
 
         func graphRequestFor(query: GraphQL.AbstractQuery) -> URLRequest {
-            var request     = URLRequest(url: self.apiURL)
-            let requestData = String(describing: query).data(using: .utf8)!
+            var request = URLRequest(url: self.apiURL)
+
+            let requestData = try! JSONEncoder().encode([
+                "query": String(describing: query)
+            ])
 
             request.httpMethod              = "POST"
             request.httpBody                = requestData
             request.httpShouldHandleCookies = false
 
             request.setValue("application/json",       forHTTPHeaderField: Header.accept)
-            request.setValue("application/graphql",    forHTTPHeaderField: Header.contentType)
+            request.setValue("application/json",       forHTTPHeaderField: Header.contentType)
             request.setValue(SHA256.hash(requestData), forHTTPHeaderField: Header.queryTag)
 
             for (name, value) in self.headers {

--- a/BuyTests/Client/Graph.ClientTests.swift
+++ b/BuyTests/Client/Graph.ClientTests.swift
@@ -67,14 +67,25 @@ class Graph_ClientTests: XCTestCase {
     //  MARK: - Requests -
     //
     func testRequestGeneration() {
-        let client  = self.defaultClient()
-        let request = client.graphRequestFor(query: self.defaultQueryPayload().query)
+        let client = self.defaultClient()
+        let query = self.defaultQueryPayload().query
+        let request = client.graphRequestFor(query: query)
 
         XCTAssertEqual(request.httpMethod, "POST")
-        XCTAssertTrue(request.httpBody?.count ?? 0 > 0)
+
+        guard let bodyData = request.httpBody else {
+            return XCTFail("expected request to have a body")
+        }
+
+        let decodedBody = try! JSONDecoder().decode(
+            Dictionary<String, String>.self, from: bodyData
+        )
+
+        XCTAssertEqual(decodedBody["query"], query.description)
+
         XCTAssertFalse(request.httpShouldHandleCookies)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"),       "application/json")
-        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/graphql")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
         XCTAssertEqual(request.value(forHTTPHeaderField: "X-Query-Tag"),  SHA256.hash(request.httpBody!))
 
         // Ensure that the client inserts defaults headers


### PR DESCRIPTION
Switches to using `application/json` request body format to comply with the [GraphQL over HTTP spec](https://graphql.github.io/graphql-over-http).

This should be a completely transparent change to existing clients and users.